### PR TITLE
Change ITestFramework.GetExecutor() to take an AssemblyName instead of an assembly file name

### DIFF
--- a/src/xunit.abstractions/Frameworks/ITestFramework.cs
+++ b/src/xunit.abstractions/Frameworks/ITestFramework.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace Xunit.Abstractions
 {
@@ -23,8 +24,8 @@ namespace Xunit.Abstractions
         /// <summary>
         /// Get a test executor.
         /// </summary>
-        /// <param name="assemblyFileName">The file path of the assembly to run tests from.</param>
+        /// <param name="assemblyName">The name of the assembly to run tests from.</param>
         /// <returns>The test executor.</returns>
-        ITestFrameworkExecutor GetExecutor(string assemblyFileName);
+        ITestFrameworkExecutor GetExecutor(AssemblyName assemblyName);
     }
 }

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestFramework.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestFramework.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -45,9 +46,9 @@ namespace Xunit.Sdk
         }
 
         /// <inheritdoc/>
-        public ITestFrameworkExecutor GetExecutor(string assemblyFileName)
+        public ITestFrameworkExecutor GetExecutor(AssemblyName assemblyName)
         {
-            var executor = new XunitTestFrameworkExecutor(assemblyFileName, SourceInformationProvider);
+            var executor = new XunitTestFrameworkExecutor(assemblyName, SourceInformationProvider);
             toDispose.Add(executor);
             return executor;
         }

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkExecutor.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkExecutor.cs
@@ -24,15 +24,15 @@ namespace Xunit.Sdk
         /// <summary>
         /// Initializes a new instance of the <see cref="XunitTestFrameworkExecutor"/> class.
         /// </summary>
-        /// <param name="assemblyFileName">Path of the test assembly.</param>
+        /// <param name="assemblyName">Name of the test assembly.</param>
         /// <param name="sourceInformationProvider">The source line number information provider.</param>
-        public XunitTestFrameworkExecutor(string assemblyFileName, ISourceInformationProvider sourceInformationProvider)
+        public XunitTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider)
         {
-            this.assemblyFileName = assemblyFileName;
             this.sourceInformationProvider = sourceInformationProvider;
 
-            var assembly = Assembly.Load(AssemblyName.GetAssemblyName(assemblyFileName));
+            var assembly = Assembly.Load(assemblyName);
             assemblyInfo = Reflector.Wrap(assembly);
+            assemblyFileName = assemblyInfo.AssemblyPath;
         }
 
         static void CreateFixture(Type interfaceType, ExceptionAggregator aggregator, Dictionary<Type, object> mappings)

--- a/src/xunit.runner.utility/Frameworks/AppDomainTestFramework.cs
+++ b/src/xunit.runner.utility/Frameworks/AppDomainTestFramework.cs
@@ -77,9 +77,9 @@ namespace Xunit
         }
 
         /// <inheritdoc/>
-        public ITestFrameworkExecutor GetExecutor(string assemblyFileName)
+        public ITestFrameworkExecutor GetExecutor(AssemblyName assemblyName)
         {
-            return testFramework.GetExecutor(assemblyFileName);
+            return testFramework.GetExecutor(assemblyName);
         }
     }
 }

--- a/src/xunit.runner.utility/Frameworks/v2/Xunit2.cs
+++ b/src/xunit.runner.utility/Frameworks/v2/Xunit2.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 using Xunit.Abstractions;
 
 namespace Xunit
@@ -22,7 +23,8 @@ namespace Xunit
         public Xunit2(ISourceInformationProvider sourceInformationProvider, string assemblyFileName, string configFileName = null, bool shadowCopy = true)
             : base(sourceInformationProvider, assemblyFileName, configFileName, shadowCopy)
         {
-            executor = Framework.GetExecutor(assemblyFileName);
+            AssemblyName assemblyName = AssemblyName.GetAssemblyName(assemblyFileName);
+            executor = Framework.GetExecutor(assemblyName);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This will help make it possible for test frameworks to be implemented in portable libraries or on platforms that don't support loading assemblies by filename.
