### PR TITLE
Added precision overloads to Assert.NotEqual. Closes #20

### DIFF
--- a/src/xunit.assert/Asserts/EqualityAsserts.cs
+++ b/src/xunit.assert/Asserts/EqualityAsserts.cs
@@ -102,5 +102,39 @@ namespace Xunit
             if (comparer.Equals(expected, actual))
                 throw new NotEqualException();
         }
+
+        /// <summary>
+        /// Verifies that two <see cref="double"/> values are not equal, within the number of decimal
+        /// places given by <paramref name="precision"/>.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+        /// <exception cref="EqualException">Thrown when the values are equal</exception>
+        public static void NotEqual(double expected, double actual, int precision)
+        {
+            var expectedRounded = Math.Round(expected, precision);
+            var actualRounded = Math.Round(actual, precision);
+
+            if (GetEqualityComparer<double>().Equals(expectedRounded, actualRounded))
+                throw new NotEqualException();
+        }
+
+        /// <summary>
+        /// Verifies that two <see cref="decimal"/> values are not equal, within the number of decimal
+        /// places given by <paramref name="precision"/>.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+        /// <exception cref="EqualException">Thrown when the values are equal</exception>
+        public static void NotEqual(decimal expected, decimal actual, int precision)
+        {
+            var expectedRounded = Math.Round(expected, precision);
+            var actualRounded = Math.Round(actual, precision);
+
+            if (GetEqualityComparer<decimal>().Equals(expectedRounded, actualRounded))
+                throw new NotEqualException();
+        }
     }
 }

--- a/test/test.xunit.assert/Asserts/EqualityAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/EqualityAssertsTests.cs
@@ -229,4 +229,36 @@ public class EqualityAssertsTests
             Assert.Equal("Assert.NotEqual() Failure", ex.Message);
         }
     }
+
+    public class NotEqual_Decimal
+    {
+        [Fact]
+        public void Success()
+        {
+            Assert.NotEqual(0.11111M, 0.11444M, 3);
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var ex = Assert.Throws<NotEqualException>(() => Assert.NotEqual(0.11111M, 0.11444M, 2));
+            Assert.Equal("Assert.NotEqual() Failure", ex.Message);
+        }
+    }
+
+    public class NotEqual_Double
+    {
+        [Fact]
+        public void Success()
+        {
+            Assert.NotEqual(0.11111, 0.11444, 3);
+        }
+
+        [Fact]
+        public void Failure()
+        {
+            var ex = Assert.Throws<NotEqualException>(() => Assert.NotEqual(0.11111, 0.11444, 2));
+            Assert.Equal("Assert.NotEqual() Failure", ex.Message);
+        }
+    }
 }


### PR DESCRIPTION
Overloads to the `Assert.NotEqual` method have been added, one that takes doubles and one that takes decimals.
