### PR TITLE
Added nuget config to include additional package source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="xUnit Dev Packages" value="http://www.myget.org/F/b4ff5f68eccf4f6bbfed74f055f88d8f/" />
+  </packageSources>
+  <disabledPackageSources />
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)"  />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
To get xUnit building locally, you need a secondary package source.

Rather than make everyone configure their VS accordingly, let's just tell nuget.exe about it.

Resolves #38
