### PR TITLE
Use current culture to fix culture-specific failing tests. Fixes #41

### DIFF
--- a/test/test.xunit.assert/Asserts/EqualityAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/EqualityAssertsTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+
 using Xunit;
 using Xunit.Sdk;
 
@@ -171,8 +173,8 @@ public class EqualityAssertsTests
         public void Failure()
         {
             var ex = Assert.Throws<EqualException>(() => Assert.Equal(0.11111M, 0.11444M, 3));
-            Assert.Equal("0.111 (rounded from 0.11111)", ex.Expected);
-            Assert.Equal("0.114 (rounded from 0.11444)", ex.Actual);
+            Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11111M, 3), 0.11111M), ex.Expected);
+            Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11444M, 3), 0.11444M), ex.Actual);
         }
     }
 
@@ -188,8 +190,8 @@ public class EqualityAssertsTests
         public void Failure()
         {
             var ex = Assert.Throws<EqualException>(() => Assert.Equal(0.11111, 0.11444, 3));
-            Assert.Equal("0.111 (rounded from 0.11111)", ex.Expected);
-            Assert.Equal("0.114 (rounded from 0.11444)", ex.Actual);
+            Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11111, 3), 0.11111), ex.Expected);
+            Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11444, 3), 0.11444), ex.Actual);
         }
     }
 

--- a/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -47,7 +48,7 @@ public class Xunit2TheoryAcceptanceTests
                 result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+GenericWithSerializableData.GenericTest<Int32, Object>(value1: 42, value2: null)", result.TestDisplayName),
                 // TODO: The parameter values here should eventually read: '[1, 2, 3]' and '["a", "b", "c"]'
                 result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+GenericWithSerializableData.GenericTest<Int32[], List<String>>(value1: System.Int32[], value2: System.Collections.Generic.List`1[System.String])", result.TestDisplayName),
-                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+GenericWithSerializableData.GenericTest<String, Double>(value1: ""Hello, world!"", value2: 21.12)", result.TestDisplayName)
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+GenericWithSerializableData.GenericTest<String, Double>(value1: ""Hello, world!"", value2: " + 21.12.ToString(CultureInfo.CurrentCulture) + ")", result.TestDisplayName)
             );
         }
 
@@ -105,7 +106,7 @@ public class Xunit2TheoryAcceptanceTests
                 if (passing == null)
                     return false;
 
-                Assert.Equal("Xunit2TheoryAcceptanceTests+InlineDataTests+ClassUnderTest.TestViaInlineData(x: 42, y: 21.12, z: \"Hello, world!\")", passing.TestDisplayName);
+                Assert.Equal("Xunit2TheoryAcceptanceTests+InlineDataTests+ClassUnderTest.TestViaInlineData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: \"Hello, world!\")", passing.TestDisplayName);
                 return true;
             });
             Assert.Single(testMessages, msg =>
@@ -219,7 +220,7 @@ public class Xunit2TheoryAcceptanceTests
                 if (passing == null)
                     return false;
 
-                Assert.Equal("Xunit2TheoryAcceptanceTests+FieldDataTests+ClassWithSelfFieldData.TestViaFieldData(x: 42, y: 21.12, z: \"Hello, world!\")", passing.TestDisplayName);
+                Assert.Equal("Xunit2TheoryAcceptanceTests+FieldDataTests+ClassWithSelfFieldData.TestViaFieldData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: \"Hello, world!\")", passing.TestDisplayName);
                 return true;
             });
             Assert.Single(testMessages, msg =>
@@ -338,7 +339,7 @@ public class Xunit2TheoryAcceptanceTests
                 if (passing == null)
                     return false;
 
-                Assert.Equal("Xunit2TheoryAcceptanceTests+MethodDataTests+ClassWithSelfMethodData.TestViaMethodData(x: 42, y: 21.12, z: \"Hello, world!\")", passing.TestDisplayName);
+                Assert.Equal("Xunit2TheoryAcceptanceTests+MethodDataTests+ClassWithSelfMethodData.TestViaMethodData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: \"Hello, world!\")", passing.TestDisplayName);
                 return true;
             });
             Assert.Single(testMessages, msg =>
@@ -460,7 +461,7 @@ public class Xunit2TheoryAcceptanceTests
                 if (passing == null)
                     return false;
 
-                Assert.Equal("Xunit2TheoryAcceptanceTests+MethodDataTests+ClassWithParameterizedMethodData.TestViaMethodData(x: 42, y: 21.12, z: \"Hello, world!\")", passing.TestDisplayName);
+                Assert.Equal("Xunit2TheoryAcceptanceTests+MethodDataTests+ClassWithParameterizedMethodData.TestViaMethodData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: \"Hello, world!\")", passing.TestDisplayName);
                 return true;
             });
             Assert.Single(testMessages, msg =>
@@ -508,7 +509,7 @@ public class Xunit2TheoryAcceptanceTests
                 if (passing == null)
                     return false;
 
-                Assert.Equal("Xunit2TheoryAcceptanceTests+PropertyDataTests+ClassWithSelfPropertyData.TestViaPropertyData(x: 42, y: 21.12, z: \"Hello, world!\")", passing.TestDisplayName);
+                Assert.Equal("Xunit2TheoryAcceptanceTests+PropertyDataTests+ClassWithSelfPropertyData.TestViaPropertyData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: \"Hello, world!\")", passing.TestDisplayName);
                 return true;
             });
             Assert.Single(testMessages, msg =>
@@ -625,7 +626,7 @@ public class Xunit2TheoryAcceptanceTests
         {
             var testMessages = Run<ITestFailed>(typeof(ClassUnderTest));
 
-            var equalFailure = Assert.Single(testMessages, msg => msg.TestDisplayName == "Xunit2TheoryAcceptanceTests+ErrorAggregation+ClassUnderTest.TestViaInlineData(x: 42, y: 21.12, z: Xunit2TheoryAcceptanceTests+ErrorAggregation+ClassUnderTest)");
+            var equalFailure = Assert.Single(testMessages, msg => msg.TestDisplayName == "Xunit2TheoryAcceptanceTests+ErrorAggregation+ClassUnderTest.TestViaInlineData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: Xunit2TheoryAcceptanceTests+ErrorAggregation+ClassUnderTest)");
             Assert.Contains("Assert.Equal() Failure", equalFailure.Messages.Single());
 
             var notNullFailure = Assert.Single(testMessages, msg => msg.TestDisplayName == "Xunit2TheoryAcceptanceTests+ErrorAggregation+ClassUnderTest.TestViaInlineData(x: 0, y: 0, z: null)");

--- a/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
+++ b/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -118,7 +119,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("2064", assemblyElement.Attribute("passed").Value);
             Assert.Equal("42", assemblyElement.Attribute("failed").Value);
             Assert.Equal("6", assemblyElement.Attribute("skipped").Value);
-            Assert.Equal("123.457", assemblyElement.Attribute("time").Value);
+            Assert.Equal(123.457M.ToString(CultureInfo.CurrentCulture), assemblyElement.Attribute("time").Value);
         }
 
         [Fact]
@@ -146,7 +147,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("2064", collectionElement.Attribute("passed").Value);
             Assert.Equal("42", collectionElement.Attribute("failed").Value);
             Assert.Equal("6", collectionElement.Attribute("skipped").Value);
-            Assert.Equal("123.457", collectionElement.Attribute("time").Value);
+            Assert.Equal(123.457M.ToString(CultureInfo.CurrentCulture), collectionElement.Attribute("time").Value);
         }
 
         [Fact]
@@ -171,7 +172,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Pass", testElement.Attribute("result").Value);
-            Assert.Equal("123.457", testElement.Attribute("time").Value);
+            Assert.Equal(123.457M.ToString(CultureInfo.CurrentCulture), testElement.Attribute("time").Value);
             Assert.Null(testElement.Attribute("source-file"));
             Assert.Null(testElement.Attribute("source-line"));
             Assert.Empty(testElement.Elements("traits"));
@@ -203,7 +204,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Fail", testElement.Attribute("result").Value);
-            Assert.Equal("123.457", testElement.Attribute("time").Value);
+            Assert.Equal(123.457M.ToString(CultureInfo.CurrentCulture), testElement.Attribute("time").Value);
             var failureElement = Assert.Single(testElement.Elements("failure"));
             Assert.Equal("Exception Type", failureElement.Attribute("exception-type").Value);
             Assert.Equal("Exception Type : Exception Message", failureElement.Elements("message").Single().Value);
@@ -256,7 +257,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Skip", testElement.Attribute("result").Value);
-            Assert.Equal("0.000", testElement.Attribute("time").Value);
+            Assert.Equal(0.0M.ToString("0.000", CultureInfo.CurrentCulture), testElement.Attribute("time").Value);
             var reasonElement = Assert.Single(testElement.Elements("reason"));
             Assert.Equal("Skip Reason", reasonElement.Value);
             Assert.Empty(testElement.Elements("failure"));

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -207,7 +208,7 @@ public class XunitTestCaseTests
 
             var testCase = new XunitTestCase(testCollection, assmInfo, type, method, fact, arguments);
 
-            Assert.Equal("MockType.MockMethod(p1: 42, ???: 21.12)", testCase.DisplayName);
+            Assert.Equal("MockType.MockMethod(p1: 42, ???: " + 21.12.ToString(CultureInfo.CurrentCulture) + ")", testCase.DisplayName);
         }
     }
 

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTheoryTestCaseTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTheoryTestCaseTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -24,7 +25,7 @@ public class XunitTheoryTestCaseTests
             var resultMessages = bus.Messages.OfType<ITestResultMessage>();
             Assert.Equal(2, resultMessages.Count());
             var passed = (ITestPassed)Assert.Single(resultMessages, msg => msg is ITestPassed);
-            Assert.Equal("XunitTheoryTestCaseTests+RunAsync+ClassUnderTest.TestWithData(x: 42, y: 21.12, z: \"Hello\")", passed.TestDisplayName);
+            Assert.Equal("XunitTheoryTestCaseTests+RunAsync+ClassUnderTest.TestWithData(x: 42, y: " + 21.12.ToString(CultureInfo.CurrentCulture) + ", z: \"Hello\")", passed.TestDisplayName);
             var failed = (ITestFailed)Assert.Single(resultMessages, msg => msg is ITestFailed);
             Assert.Equal("XunitTheoryTestCaseTests+RunAsync+ClassUnderTest.TestWithData(x: 0, y: 0, z: \"World!\")", failed.TestDisplayName);
         }

--- a/test/test.xunit.runner.utility/Frameworks/v2/Xunit2Tests.cs
+++ b/test/test.xunit.runner.utility/Frameworks/v2/Xunit2Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -152,7 +153,7 @@ public class Xunit2Tests
 
                 Assert.Contains("TestClass.TestMethod(x: ???)", testCaseNames);
                 Assert.Contains("TestClass.TestMethod(x: 42)", testCaseNames);
-                Assert.Contains("TestClass.TestMethod(x: 42, ???: 21.12)", testCaseNames);
+                Assert.Contains("TestClass.TestMethod(x: 42, ???: " + 21.12.ToString(CultureInfo.CurrentCulture) + ")", testCaseNames);
             }
         }
     }

--- a/test/test.xunit1/xunit/EqualTests.cs
+++ b/test/test.xunit1/xunit/EqualTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using Xunit;
 using Xunit.Sdk;
@@ -587,9 +588,9 @@ namespace Xunit1
             [Fact]
             public void AssertEqualWithDoubleWithPrecisionFailure()
             {
-                var ex = Assert.Throws<EqualException>(() => Assert.Equal(0.11111, 0.11444, 3));
-                Assert.Equal("0.111 (rounded from 0.11111)", ex.Expected);
-                Assert.Equal("0.114 (rounded from 0.11444)", ex.Actual);
+                var ex = Assert.Throws<EqualException>(() => Assert.Equal(0.11111M, 0.11444M, 3));
+                Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11111, 3), 0.11111), ex.Expected);
+                Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11444, 3), 0.11444), ex.Actual);
             }
 
             [Fact]
@@ -601,9 +602,9 @@ namespace Xunit1
             [Fact]
             public void AssertEqualWithDecimalWithPrecisionFailure()
             {
-                var ex = Assert.Throws<EqualException>(() => Assert.Equal(0.11111M, 0.11444M, 3));
-                Assert.Equal("0.111 (rounded from 0.11111)", ex.Expected);
-                Assert.Equal("0.114 (rounded from 0.11444)", ex.Actual);
+                var ex = Assert.Throws<EqualException>(() => Assert.Equal(0.11111, 0.11444, 3));
+                Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11111M, 3), 0.11111M), ex.Expected);
+                Assert.Equal(String.Format(CultureInfo.CurrentCulture, "{0} (rounded from {1})", Math.Round(0.11444M, 3), 0.11444M), ex.Actual);
             }
         }
     }

--- a/test/test.xunit1/xunit/Sdk/Exceptions/AssertActualExpectedExceptionTests.cs
+++ b/test/test.xunit1/xunit/Sdk/Exceptions/AssertActualExpectedExceptionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 using Xunit.Sdk;
 
@@ -72,7 +73,7 @@ namespace Xunit1
                 "Message" + Environment.NewLine +
                 "Position: First difference is at position 1" + Environment.NewLine +
                 "Expected: <MakeEnumeration>d__2 { 1, 42, \"Hello\" }" + Environment.NewLine +
-                "Actual:   <MakeEnumeration>d__2 { 1, 2.3, \"Goodbye\" }";
+                "Actual:   <MakeEnumeration>d__2 { 1, " + 2.3.ToString(CultureInfo.CurrentCulture) + ", \"Goodbye\" }";
 
             AssertActualExpectedException ex =
                 new AssertActualExpectedException(expectedValue, actualValue, "Message");


### PR DESCRIPTION
This pull-request replaces string constants such as `"123.457"` by their culture-specific versions (in this case using `123.457M.ToString(CultureInfo.CurrentCulture)`). This fixes a bug where running the tests would fail on systems where the culture does not use the dot character as the decimal separator.
