### PR TITLE
Added *nix support to AssemblyExtensions::GetLocalCodeBase

### DIFF
--- a/src/common/AssemblyExtensions.cs
+++ b/src/common/AssemblyExtensions.cs
@@ -12,6 +12,12 @@ internal static class AssemblyExtensions
         if (!codeBase.StartsWith("file:///"))
             throw new ArgumentException(String.Format("Code base {0} in wrong format; must start with file:///", codeBase), "assembly");
 
-        return codeBase.Substring(8).Replace('/', '\\');
+        codeBase = codeBase.Substring(8);
+        if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
+            return "/" + codeBase;
+
+
+        return codeBase.Replace('/', '\\');
     }
 }
+


### PR DESCRIPTION
Factoring out using the Uri class broke getting local assembly path names on unix based systems, here's a patch for that.
