### PR TITLE
Added set comparison assertions. Closes #56

### DIFF
--- a/src/xunit.assert/Asserts/CollectionAsserts.cs
+++ b/src/xunit.assert/Asserts/CollectionAsserts.cs
@@ -297,5 +297,57 @@ namespace Xunit
 
             return result;
         }
+
+        /// <summary>
+        /// Verifies that a set is a subset of another set.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to be verified</typeparam>
+        /// <param name="expectedSuperset">The expected superset</param>
+        /// <param name="actual">The set expected to be a subset</param>
+        /// <exception cref="ContainsException">Thrown when the actual set is not a subset of the expected set</exception>
+        public static void Subset<T>(ISet<T> expectedSuperset, ISet<T> actual)
+        {
+            if (expectedSuperset == null || actual == null || !actual.IsSubsetOf(expectedSuperset))
+                throw new SubsetException();
+        }
+
+        /// <summary>
+        /// Verifies that a set is a proper subset of another set.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to be verified</typeparam>
+        /// <param name="expectedSuperset">The expected superset</param>
+        /// <param name="actual">The set expected to be a proper subset</param>
+        /// <exception cref="ContainsException">Thrown when the actual set is not a proper subset of the expected set</exception>
+        public static void ProperSubset<T>(ISet<T> expectedSuperset, ISet<T> actual)
+        {
+            if (expectedSuperset == null || actual == null || !actual.IsProperSubsetOf(expectedSuperset))
+                throw new ProperSubsetException();
+        }
+
+        /// <summary>
+        /// Verifies that a set is a superset of another set.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to be verified</typeparam>
+        /// <param name="expectedSubset">The expected subset</param>
+        /// <param name="actual">The set expected to be a superset</param>
+        /// <exception cref="ContainsException">Thrown when the actual set is not a superset of the expected set</exception>
+        public static void Superset<T>(ISet<T> expectedSubset, ISet<T> actual)
+        {
+            if (expectedSubset == null || actual == null || !actual.IsSupersetOf(expectedSubset))
+                throw new SupersetException();
+        }
+
+        /// <summary>
+        /// Verifies that a set is a proper superset of another set.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to be verified</typeparam>
+        /// <param name="expectedSubset">The expected subset</param>
+        /// <param name="actual">The set expected to be a proper superset</param>
+        /// <exception cref="ContainsException">Thrown when the actual set is not a proper superset of the expected set</exception>
+        public static void ProperSuperset<T>(ISet<T> expectedSubset, ISet<T> actual)
+        {
+            if (expectedSubset == null || actual == null || !actual.IsProperSupersetOf(expectedSubset))
+                throw new ProperSupersetException();
+        }
     }
 }

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/ProperSubsetException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/ProperSubsetException.cs
@@ -1,0 +1,17 @@
+namespace Xunit.Sdk
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Exception thrown when a set is not a proper subset of another set.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
+    public class ProperSubsetException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProperSubsetException"/> class.
+        /// </summary>
+        public ProperSubsetException()
+            : base("Assert.ProperSubset() Failure") { }
+    }
+}

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/ProperSupersetException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/ProperSupersetException.cs
@@ -1,0 +1,17 @@
+namespace Xunit.Sdk
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Exception thrown when a set is not a proper superset of another set.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
+    public class ProperSupersetException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProperSupersetException"/> class.
+        /// </summary>
+        public ProperSupersetException()
+            : base("Assert.ProperSuperset() Failure") { }
+    }
+}

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/SubsetException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/SubsetException.cs
@@ -1,0 +1,17 @@
+namespace Xunit.Sdk
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Exception thrown when a set is not a subset of another set.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
+    public class SubsetException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="SubsetException"/> class.
+        /// </summary>
+        public SubsetException()
+            : base("Assert.Subset() Failure") { }
+    }
+}

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/SupersetException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/SupersetException.cs
@@ -1,0 +1,17 @@
+namespace Xunit.Sdk
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Exception thrown when a set is not a superset of another set.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
+    public class SupersetException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="SupersetException"/> class.
+        /// </summary>
+        public SupersetException()
+            : base("Assert.Superset() Failure") { }
+    }
+}

--- a/src/xunit.assert/xunit.assert.csproj
+++ b/src/xunit.assert/xunit.assert.csproj
@@ -73,10 +73,14 @@
     <Compile Include="Asserts\Sdk\Exceptions\NotSameException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\NullException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\ParameterCountMismatchException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\ProperSubsetException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\ProperSupersetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\PropertyChangedException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SameException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SingleException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\StartsWithException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\SubsetException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\SupersetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\ThrowsException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\TimeoutException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\TrueException.cs" />

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -678,4 +678,124 @@ public class CollectionAssertsTests
             Assert.Equal("The collection contained 2 matching element(s) instead of 1.", ex.Message);
         }
     }
+    
+    public class Subset
+    {
+        [Fact]
+        public void IsSubset()
+        {
+            HashSet<int> expectedSuperset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.Subset(expectedSuperset, actual);
+        }
+
+        [Fact]
+        public void IsProperSubset()
+        {
+            HashSet<int> expectedSuperset = new HashSet<int> { 1, 2, 3, 4 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.Subset(expectedSuperset, actual);
+        }
+
+        [Fact]
+        public void IsNoSubset()
+        {
+            HashSet<int> expectedSuperset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 7 };
+
+            Assert.Throws<SubsetException>(() => Assert.Subset(expectedSuperset, actual));
+        }
+    }
+
+    public class ProperSubset
+    {
+        [Fact]
+        public void IsSubset()
+        {
+            HashSet<int> expectedSuperset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.Throws<ProperSubsetException>(() => Assert.ProperSubset(expectedSuperset, actual));
+        }
+
+        [Fact]
+        public void IsProperSubset()
+        {
+            HashSet<int> expectedSuperset = new HashSet<int> { 1, 2, 3, 4 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.ProperSubset(expectedSuperset, actual);
+        }
+
+        [Fact]
+        public void IsNoSubset()
+        {
+            HashSet<int> expectedSuperset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 7 };
+
+            Assert.Throws<ProperSubsetException>(() => Assert.ProperSubset(expectedSuperset, actual));
+        }
+    }
+
+    public class Superset
+    {
+        [Fact]
+        public void IsSuperset()
+        {
+            HashSet<int> expectedSubset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.Superset(expectedSubset, actual);
+        }
+
+        [Fact]
+        public void IsProperSuperset()
+        {
+            HashSet<int> expectedSubset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3, 4 };
+
+            Assert.Superset(expectedSubset, actual);
+        }
+
+        [Fact]
+        public void IsNoSuperset()
+        {
+            HashSet<int> expectedSubset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 7 };
+
+            Assert.Throws<SupersetException>(() => Assert.Superset(expectedSubset, actual));
+        }
+    }
+
+    public class ProperSuperset
+    {
+        [Fact]
+        public void IsSuperset()
+        {
+            HashSet<int> expectedSubset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.Throws<ProperSupersetException>(() => Assert.ProperSuperset(expectedSubset, actual));
+        }
+
+        [Fact]
+        public void IsProperSuperset()
+        {
+            HashSet<int> expectedSubset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 3, 4 };
+
+            Assert.ProperSuperset(expectedSubset, actual);
+        }
+
+        [Fact]
+        public void IsNoSuperset()
+        {
+            HashSet<int> expectedSubset = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> actual = new HashSet<int> { 1, 2, 7 };
+
+            Assert.Throws<ProperSupersetException>(() => Assert.ProperSuperset(expectedSubset, actual));
+        }
+    }
 }


### PR DESCRIPTION
This PR adds four new assertion methods that all work on `ISet<T>` values:
- `Assert.Subset()`
- `Assert.ProperSubset()`
- `Assert.Super()`
- `Assert.ProperSuperset()`

I am not quite sure what one would expect the parameters to represent. Would one expect the first parameter of a call to `Assert.Subset()` (usually called the expected value) to be the set against which the second (actual) parameter is checked to be a subset or vice versa? I opted for the first version, but let me know if this is correct in your opinion.
