### PR TITLE
Trying to improve the precision of execution timing. Helps with #69

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
@@ -445,7 +445,7 @@ namespace Xunit.Sdk
                 else
                 {
                     var beforeAttributesRun = new Stack<BeforeAfterTestAttribute>();
-                    var stopwatch = Stopwatch.StartNew();
+                    Stopwatch stopwatch = null;
 
                     if (!aggregator.HasExceptions)
                         await aggregator.RunAsync(async () =>
@@ -508,6 +508,7 @@ namespace Xunit.Sdk
 
                                             await aggregator.RunAsync(async () =>
                                             {
+                                                stopwatch = Stopwatch.StartNew();
                                                 var result = methodUnderTest.Invoke(testClass, Reflector.ConvertArguments(testMethodArguments, parameterTypes));
                                                 var task = result as Task;
                                                 if (task != null)
@@ -518,6 +519,8 @@ namespace Xunit.Sdk
                                                     if (ex != null)
                                                         aggregator.Add(ex);
                                                 }
+
+                                                stopwatch.Stop();
                                             });
                                         }
                                         finally
@@ -560,8 +563,6 @@ namespace Xunit.Sdk
                                 }
                             });
                         });
-
-                    stopwatch.Stop();
 
                     if (!cancellationTokenSource.IsCancellationRequested)
                     {


### PR DESCRIPTION
This is just an idea, but a few tests showed me that the wait time is
not included. Even if it doesn't work all the time, then it sill offers
more precise meassurment. Helps with https://github.com/xunit/xunit/issues/69
