### PR TITLE
xunit1 sends method start/finish messages

### DIFF
--- a/src/xunit.runner.utility/Frameworks/v1/TestClassCallbackHandler.cs
+++ b/src/xunit.runner.utility/Frameworks/v1/TestClassCallbackHandler.cs
@@ -128,12 +128,24 @@ namespace Xunit
             {
                 TestClassResults.Continue = messageSink.OnMessage(new TestCaseFinished(lastTestCase, testCaseResults.Time, testCaseResults.Total, testCaseResults.Failed, testCaseResults.Skipped)) && TestClassResults.Continue;
                 testCaseResults.Reset();
+
+                if (current == null || (lastTestCase.Class.Name == current.Class.Name && lastTestCase.Method.Name != current.Class.Name))
+                {
+                    TestClassResults.Continue = messageSink.OnMessage(new TestMethodFinished(lastTestCase.TestCollection, lastTestCase.Class.Name, lastTestCase.Method.Name)) && TestClassResults.Continue;
+                }
+            }
+
+            if (current != null)
+            {
+                if (lastTestCase == null || (lastTestCase.Class.Name == current.Class.Name && lastTestCase.Method.Name != current.Method.Name))
+                {
+                    TestClassResults.Continue = messageSink.OnMessage(new TestMethodStarting(current.TestCollection, current.Class.Name, current.Method.Name)) && TestClassResults.Continue;
+                }
+
+                TestClassResults.Continue = messageSink.OnMessage(new TestCaseStarting(current)) && TestClassResults.Continue;
             }
 
             lastTestCase = current;
-
-            if (current != null)
-                TestClassResults.Continue = messageSink.OnMessage(new TestCaseStarting(current)) && TestClassResults.Continue;
         }
     }
 }

--- a/test/test.xunit.runner.utility/Frameworks/v1/Xunit1Tests.cs
+++ b/test/test.xunit.runner.utility/Frameworks/v1/Xunit1Tests.cs
@@ -235,6 +235,12 @@ public class Xunit1Tests
                 },
                 message =>
                 {
+                    var testMethodStarting = Assert.IsAssignableFrom<ITestMethodStarting>(message);
+                    Assert.Equal("type1", testMethodStarting.ClassName);
+                    Assert.Equal("passing", testMethodStarting.MethodName);
+                },
+                message =>
+                {
                     var testCaseStarting = Assert.IsAssignableFrom<ITestCaseStarting>(message);
                     Assert.Equal("type1.passing", testCaseStarting.TestCase.DisplayName);
                 },
@@ -265,6 +271,18 @@ public class Xunit1Tests
                     Assert.Equal(0, testCaseFinished.TestsFailed);
                     Assert.Equal(1, testCaseFinished.TestsRun);
                     Assert.Equal(0, testCaseFinished.TestsSkipped);
+                },
+                message =>
+                {
+                    var testMethodFinished = Assert.IsAssignableFrom<ITestMethodFinished>(message);
+                    Assert.Equal("type1", testMethodFinished.ClassName);
+                    Assert.Equal("passing", testMethodFinished.MethodName);
+                },
+                message =>
+                {
+                    var testMethodStarting = Assert.IsAssignableFrom<ITestMethodStarting>(message);
+                    Assert.Equal("type1", testMethodStarting.ClassName);
+                    Assert.Equal("failing", testMethodStarting.MethodName);
                 },
                 message =>
                 {
@@ -304,6 +322,12 @@ public class Xunit1Tests
                 },
                 message =>
                 {
+                    var testMethodFinished = Assert.IsAssignableFrom<ITestMethodFinished>(message);
+                    Assert.Equal("type1", testMethodFinished.ClassName);
+                    Assert.Equal("failing", testMethodFinished.MethodName);
+                },
+                message =>
+                {
                     var testClassFinished = Assert.IsAssignableFrom<ITestClassFinished>(message);
                     Assert.Equal("type1", testClassFinished.ClassName);
                     Assert.Equal(1.234M, testClassFinished.ExecutionTime);
@@ -316,6 +340,12 @@ public class Xunit1Tests
                     var testClassStarting = Assert.IsAssignableFrom<ITestClassStarting>(message);
                     Assert.Equal("type2", testClassStarting.ClassName);
                     Assert.Same(testCollection, testClassStarting.TestCollection);
+                },
+                message =>
+                {
+                    var testMethodStarting = Assert.IsAssignableFrom<ITestMethodStarting>(message);
+                    Assert.Equal("type2", testMethodStarting.ClassName);
+                    Assert.Equal("skipping", testMethodStarting.MethodName);
                 },
                 message =>
                 {
@@ -350,6 +380,12 @@ public class Xunit1Tests
                     Assert.Equal(0, testCaseFinished.TestsFailed);
                     Assert.Equal(1, testCaseFinished.TestsRun);
                     Assert.Equal(1, testCaseFinished.TestsSkipped);
+                },
+                message =>
+                {
+                    var testMethodFinished = Assert.IsAssignableFrom<ITestMethodFinished>(message);
+                    Assert.Equal("type2", testMethodFinished.ClassName);
+                    Assert.Equal("skipping", testMethodFinished.MethodName);
                 },
                 message =>
                 {


### PR DESCRIPTION
Added code so that xunit1 will now send testMethodStarting/testMethodFinished messages, same as xunit2
