### PR TITLE
Xunit1 start message for skipped test

### DIFF
--- a/src/xunit.runner.utility/Frameworks/v1/TestClassCallbackHandler.cs
+++ b/src/xunit.runner.utility/Frameworks/v1/TestClassCallbackHandler.cs
@@ -101,6 +101,11 @@ namespace Xunit
 
                 case "Skip":
                     testCaseResults.Skipped++;
+                    if (testCase != lastTestCase)
+                    {
+                        SendTestCaseMessagesWhenAppropriate(testCase);
+                        @continue = messageSink.OnMessage(new TestStarting(testCase, displayName)) && @continue;
+                    }
                     resultMessage = new TestSkipped(testCase, displayName, xml.SelectSingleNode("reason/message").InnerText);
                     break;
             }


### PR DESCRIPTION
The xunit1 API doesn't notify test start for skipped tests (unless you use a custom Fact). This means you don't get the right notifications through to the xunit2 API. This change ensures you get proper notifications for skipped tests - the previous test case is finished, a new test case is started, and a new test is started.

Note that this change is built on top of #72, since the tests are shared, and it means that the test method is also correctly started and finished, if appropriate.
