### PR TITLE
Group by method name not IMethodInfo (closes #78)

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestClassRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestClassRunner.cs
@@ -165,7 +165,7 @@ namespace Xunit.Sdk
             var orderedTestCases = TestCaseOrderer.OrderTestCases(TestCases);
             var constructorArguments = CreateTestClassConstructorArguments();
 
-            foreach (var method in orderedTestCases.GroupBy(tc => tc.Method))
+            foreach (var method in orderedTestCases.GroupBy(tc => tc.Method, MethodInfoNameEqualityComparer.Instance))
             {
                 summary.Aggregate(await RunTestMethodAsync((IReflectionMethodInfo)method.Key, method, constructorArguments));
                 if (CancellationTokenSource.IsCancellationRequested)
@@ -211,6 +211,21 @@ namespace Xunit.Sdk
         {
             argumentValue = null;
             return false;
+        }
+
+        private class MethodInfoNameEqualityComparer : IEqualityComparer<IMethodInfo>
+        {
+            public static readonly MethodInfoNameEqualityComparer Instance = new MethodInfoNameEqualityComparer();
+
+            public bool Equals(IMethodInfo x, IMethodInfo y)
+            {
+                return x.Name == y.Name;
+            }
+
+            public int GetHashCode(IMethodInfo obj)
+            {
+                return obj.Name.GetHashCode();
+            }
         }
     }
 }

--- a/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
@@ -652,4 +652,50 @@ public class Xunit2TheoryAcceptanceTests
             }
         }
     }
+
+    public class OverloadedMethodTests : AcceptanceTest
+    {
+        [Fact]
+        public void TestMethodMessagesOnlySentOnce()
+        {
+            var testMessages = Run<IMessageSinkMessage>(typeof(ClassUnderTest));
+
+            Assert.Single(testMessages, msg =>
+            {
+                var methodStarting = msg as ITestMethodStarting;
+                if (methodStarting == null)
+                    return false;
+
+                Assert.Equal("Xunit2TheoryAcceptanceTests+OverloadedMethodTests+ClassUnderTest", methodStarting.ClassName);
+                Assert.Equal("Theory", methodStarting.MethodName);
+                return true;
+            });
+
+            Assert.Single(testMessages, msg =>
+            {
+                var methodFinished = msg as ITestMethodFinished;
+                if (methodFinished == null)
+                    return false;
+
+                Assert.Equal("Xunit2TheoryAcceptanceTests+OverloadedMethodTests+ClassUnderTest", methodFinished.ClassName);
+                Assert.Equal("Theory", methodFinished.MethodName);
+                return true;
+            });
+        }
+
+        class ClassUnderTest
+        {
+            [Theory]
+            [InlineData(42)]
+            public void Theory(int value)
+            {
+            }
+
+            [Theory]
+            [InlineData("42")]
+            public void Theory(string value)
+            {
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #78, so method start/finish messages are only sent once when running overloaded methods as theories.
