### PR TITLE
Update the core to put empty props files for iOS and Android

### DIFF
--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -24,8 +24,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="build\MonoAndroid\_._" target="build\MonoAndroid\_._" />
-    <file src="build\MonoTouch\_._" target="build\MonoTouch\_._" />
+    <file src="xunit.core\build\xunit.core.empty.props" target="build\MonoAndroid\xunit.core.props" />
+    <file src="xunit.core\build\xunit.core.empty.props" target="build\MonoTouch\xunit.core.props" />    
     <file src="xunit.core\build\xunit.core.props" target="build\portable-net45+win+wpa81+wp80\xunit.core.props" />
     <file src="xunit.core\bin\Release\xunit.core.dll" target="lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll" />
     <file src="xunit.core\bin\Release\xunit.core.dll.tdnet" target="lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll.tdnet" />

--- a/src/xunit.core/build/xunit.core.empty.props
+++ b/src/xunit.core/build/xunit.core.empty.props
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />


### PR DESCRIPTION
This should fix the core nuget. For iOS/Android platforms that pull in the package, it'll use a different, empty, props file instead.
