### PR TITLE
Vs runner fix

### DIFF
--- a/src/xunit.runner.visualstudio.testadapter/VsTestRunner.cs
+++ b/src/xunit.runner.visualstudio.testadapter/VsTestRunner.cs
@@ -22,7 +22,6 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
     {
         public static TestProperty SerializedTestCaseProperty = GetTestProperty();
 
-
         bool cancelled;
 
         public void Cancel()
@@ -176,23 +175,25 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             string self = Path.GetFileNameWithoutExtension(Assembly.GetExecutingAssembly().GetLocalCodeBase());
             if (Path.GetFileNameWithoutExtension(assemblyFileName).Equals(self, StringComparison.OrdinalIgnoreCase))
                 return false;
+            
+            // skip xunit.dll and xunit.execution.dll as they won't have any tests
+            if ("xunit".Equals(Path.GetFileNameWithoutExtension(assemblyFileName), StringComparison.OrdinalIgnoreCase) ||
+                "xunit.execution".Equals(Path.GetFileNameWithoutExtension(assemblyFileName), StringComparison.OrdinalIgnoreCase))
+                return false;
 
             string xunitPath = Path.Combine(Path.GetDirectoryName(assemblyFileName), "xunit.dll");
             string xunitExecutionPath = Path.Combine(Path.GetDirectoryName(assemblyFileName), "xunit.execution.dll");
             if (!File.Exists(xunitPath) && !File.Exists(xunitExecutionPath))
                 return false;
-
-
-            // skip xunit.dll and xunit.execution.dll as they won't have any tests
-            if ("xunit.dll".Equals(assemblyFileName, StringComparison.OrdinalIgnoreCase) ||
-                "xunit.execution.dll".Equals(assemblyFileName, StringComparison.OrdinalIgnoreCase))
-                return false;
+           
 
             var assm = Assembly.ReflectionOnlyLoadFrom(assemblyFileName);
 
             // As we're in a reflection-only context, we can't use GetCustomAttributes
             // Also, GetCustomAttributeData will trigger resolving of references,
             // and we don't want to deal with binding policy 
+            // 
+            // Instead, we check the references
 
             var refs = assm.GetReferencedAssemblies();
 


### PR DESCRIPTION
This is a partial fix for detecting Xamarin assemblies in the VS Runner.

This only works if the Xamarin lib actually uses a type from either MonoTouch or Mono.Android (Like NSView, Activity, etc). If it doesn't, then the compiler will exclude the metadata reference.

It would be better to check the TargetFrameworkAttribute for the FrameworkName, but I was not able to get that to work yet. Using assembly.GetCustomAttributeData(), I was getting stuck on correctly dealing with ReflectionOnlyAssemblyResolve. Seems like getting the assembly-level attributes is triggering more assemblies to load.

The main issue is that Assembly.ReflectionOnlyAssemblyLoad() does not use system binding policy. So, in the case of a WinStore app that uses System.Runtime 4.0.10.0, it needs to be correctly resolved. There could be other issues too.

TL;DR, it would be best to read the attribute, but I wasn't able to get that to work correctly. Instead, what's there now will still load the assm in the Reflection Context and check its references for the Xamarin ones.
