### PR TITLE
Issue #31 - Adding in support for Assert.All

### DIFF
--- a/src/xunit.assert/Asserts/CollectionAsserts.cs
+++ b/src/xunit.assert/Asserts/CollectionAsserts.cs
@@ -185,6 +185,37 @@ namespace Xunit
         }
 
         /// <summary>
+        /// Verifies that all items in the collection pass when executed against
+        /// action.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="action">The action to test each item against.</param>
+        /// <exception cref="CompositeException">Thrown when the collection contains at least one none matching element.</exception>
+        public static void All<T>(IEnumerable<T> collection, Action<T> action)
+        {
+            Assert.GuardArgumentNotNull("collection", collection);
+            Assert.GuardArgumentNotNull("action", action);
+
+            var errors = new Stack<Tuple<int, Exception>>();
+            int position = 0;
+            foreach (var item in collection)
+            {
+                try
+                {
+                    action(item);
+                }
+                catch (Exception ex)
+                {
+                    errors.Push(new Tuple<int, Exception>(position, ex));
+                }
+                position++;
+            }
+            if (errors.Count > 0)
+                throw new CompositeException(position, errors.ToArray());
+        }
+
+        /// <summary>
         /// Verifies that a collection is not empty.
         /// </summary>
         /// <param name="collection">The collection to be inspected</param>

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/CompositeException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/CompositeException.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when an All assertion has one or more items fail an assertion.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
+    public class CompositeException : XunitException
+    {
+        private readonly IReadOnlyList<Tuple<int, Exception>> errors;
+        private readonly int totalItems;
+ 
+        /// <summary>
+        /// Creates a new instance of the <see cref="CompositeException"/> class.
+        /// </summary>
+        /// <param name="totalItems">The total number of items that were in the collection.</param>
+        /// <param name="errors">The list of errors that occured during the test pass.</param>
+        public CompositeException(int totalItems, Tuple<int, Exception>[] errors)
+            : base("Assert.All() Failure")
+        {
+            this.errors = errors;
+            this.totalItems = totalItems;
+        }
+
+        /// <summary>
+        /// The errors that occured during execution of the test.
+        /// </summary>
+        public IReadOnlyList<Exception> Failures { get { return errors.Select(t => t.Item2).ToList(); } }
+
+        /// <inheritdoc/>
+        public override string Message
+        {
+            get
+            {
+                var result = new StringBuilder();
+                result.AppendLine(String.Format(
+                    CultureInfo.CurrentCulture, 
+                    "{0} out of {1} items in the collection did not pass.{2}", 
+                    errors.Count, 
+                    totalItems,
+                    Environment.NewLine));
+
+                var first = true;
+                foreach (var error in errors)
+                {
+                    if (!first)
+                        result.AppendLine("=================================================================");
+                    first = false;
+
+                    result.AppendLine(String.Format(CultureInfo.CurrentCulture,
+                                         "{0}{3}Error during validation of item at index {1}{3}Inner exception: {2}",
+                                         base.Message,
+                                         error.Item1,
+                                         error.Item2,
+                                         Environment.NewLine));
+                }
+
+                return result.ToString();
+            }
+        }
+    }
+}

--- a/src/xunit.assert/xunit.assert.csproj
+++ b/src/xunit.assert/xunit.assert.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Asserts\Sdk\Exceptions\AssertActualExpectedException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\AssertCollectionCountException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\CollectionException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\CompositeException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\ContainsException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\DoesNotContainException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\DoesNotMatchException.cs" />

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -400,6 +400,51 @@ public class CollectionAssertsTests
         }
     }
 
+    public class All
+    {
+        [Fact]
+        public void NullCollectionThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => Assert.All<object>(null, _ => { }));
+        }
+
+        [Fact]
+        public void NullActionThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => Assert.All<object>(new Object[0], null));
+        }
+
+        [Fact]
+        public void ActionWhereSomeFail()
+        {
+            var items = new[] {1, 1, 2, 2, 1, 1};
+
+            var ex = Assert.Throws<CompositeException>(() => Assert.All(items, _ => Assert.Equal(1, _)));
+
+            Assert.Equal(2, ex.Failures.Count);
+            Assert.All(ex.Failures, _ => Assert.IsType<EqualException>(_));
+        }
+
+        [Fact]
+        public void ActionWhereNoneFail()
+        {
+            var items = new[] { 1, 1, 1, 1, 1, 1 };
+
+            Assert.All(items, _ => Assert.Equal(1, _));
+        }
+
+        [Fact]
+        public void ActionWhereAllFail()
+        {
+            var items = new[] { 1, 1, 2, 2, 1, 1 };
+
+            var ex = Assert.Throws<CompositeException>(() => Assert.All(items, _ => Assert.Equal(0, _)));
+
+            Assert.Equal(6, ex.Failures.Count);
+            Assert.All(ex.Failures, _ => Assert.IsType<EqualException>(_));
+        }
+    }
+
     public class NotEmpty
     {
         [Fact]

--- a/test/test.xunit.assert/Asserts/Sdk/Exceptions/CompositeExceptionTests.cs
+++ b/test/test.xunit.assert/Asserts/Sdk/Exceptions/CompositeExceptionTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+public class CompositeExceptionTests
+{
+    [Fact]
+    public void ReturnsAMessageForEachFailure()
+    {
+        var errors = new[]
+        {
+            new Tuple<int, Exception>(1, new Exception("Error 1")),
+            new Tuple<int, Exception>(3, new Exception("Error 2")),
+            new Tuple<int, Exception>(5, new Exception("Error 3")),
+        };
+
+        var ex = new CompositeException(5, errors);
+
+        var expectedMessage = "3 out of 5 items in the collection did not pass." + Environment.NewLine +
+                              Environment.NewLine +
+                              "Assert.All() Failure" + Environment.NewLine +
+                              "Error during validation of item at index 1" + Environment.NewLine +
+                              "Inner exception: System.Exception: Error 1" + Environment.NewLine +
+                              "=================================================================" + Environment.NewLine +
+                              "Assert.All() Failure" + Environment.NewLine +
+                              "Error during validation of item at index 3" + Environment.NewLine +
+                              "Inner exception: System.Exception: Error 2" + Environment.NewLine +
+                              "=================================================================" + Environment.NewLine +
+                              "Assert.All() Failure" + Environment.NewLine +
+                              "Error during validation of item at index 5" + Environment.NewLine +
+                              "Inner exception: System.Exception: Error 3" + Environment.NewLine;
+        Assert.Equal(expectedMessage, ex.Message);
+    }
+}

--- a/test/test.xunit.assert/test.xunit.assert.csproj
+++ b/test/test.xunit.assert/test.xunit.assert.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Asserts\RangeAssertsTests.cs" />
     <Compile Include="Asserts\RecordTests.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\AssertActualExpectedExceptionTests.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\CompositeExceptionTests.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\EndsWithExceptionTests.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\EqualExceptionTests.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\StartsWithExceptionTests.cs" />

--- a/test/test.xunit.runner.msbuild/xunitTests.cs
+++ b/test/test.xunit.runner.msbuild/xunitTests.cs
@@ -41,6 +41,7 @@ public class xunitTests
         public void ChangesCurrentDirectoryWhenWorkingFolderIsNotNull()
         {
             var tempFolder = Environment.GetEnvironmentVariable("TEMP");
+            tempFolder = Path.GetFullPath(tempFolder); // Ensure that the 8.3 path is not used
             var xunit = new Testable_xunit { WorkingFolder = tempFolder };
 
             xunit.Execute();


### PR DESCRIPTION
I added Assert.All so that it takes a collection and an action.

I also fixed a test in xunittests.cs that was using the temp directory as the working directory. On my laptop it was using the old MS DOS 8.3 formatting and causing the test to fail. 
