### PR TITLE
Updating AssertEqualityComparer so that it can natively handle an IDictionary

### DIFF
--- a/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
+++ b/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
@@ -133,6 +133,18 @@ namespace Xunit.Sdk
                     return true;
             }
 
+            foreach (var key in dictionaryY.Keys)
+            {
+                if (!dictionaryX.Contains(key))
+                    return true;
+
+                var valueX = dictionaryX[key];
+                var valueY = dictionaryY[key];
+
+                if (!equalityComparer.Equals(valueX, valueY))
+                    return true;
+            }
+
             @equals = true;
             return true;
         }

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -329,6 +329,54 @@ public class CollectionAssertsTests
             Assert.NotEqual(expected, actual);
             Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
         }
+
+        [Fact]
+        public void CaseSensitiveDictionaryUsesExpectedComparer()
+        {
+            var expected = new Dictionary<string, int>(StringComparer.CurrentCulture)
+            {
+                {"A", 1}, {"B", 2}, {"C", 3}
+            };
+            var actual = new Dictionary<string, int>(StringComparer.CurrentCultureIgnoreCase)
+            {
+                {"a", 1}, {"b", 2}, {"c", 3}
+            };
+
+            Assert.NotEqual(expected, actual);
+            Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
+        }
+
+        [Fact]
+        public void CaseInsensitiveDictionaryUsesExpectedComparer()
+        {
+            var expected = new Dictionary<string, int>(StringComparer.CurrentCultureIgnoreCase)
+            {
+                {"A", 1}, {"B", 2}, {"C", 3}
+            };
+            var actual = new Dictionary<string, int>(StringComparer.CurrentCulture)
+            {
+                {"a", 1}, {"b", 2}, {"c", 3}
+            };
+
+            Assert.NotEqual(expected, actual);
+            Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
+        }
+
+        [Fact]
+        public void DetectsDuplicateValueInActual()
+        {
+            var expected = new Dictionary<string, int>(StringComparer.CurrentCultureIgnoreCase)
+            {
+                {"A", 1}, {"B", 2}, {"C", 3}
+            };
+            var actual = new Dictionary<string, int>(StringComparer.CurrentCulture)
+            {
+                {"a", 1}, {"A", 1}, {"c", 3}
+            };
+
+            Assert.NotEqual(expected, actual);
+            Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
+        }
     }
 
     public class Equal_WithComparer


### PR DESCRIPTION
I first thought I would make an Assert.Equal override for IDictionary, but then after reviewing the code it looked like the comparer might make more sense so that there is consistent behavior.
