### PR TITLE
Ensure TestCases in messages is serialisable

### DIFF
--- a/src/messages/BaseMessages/TestAssemblyMessage.cs
+++ b/src/messages/BaseMessages/TestAssemblyMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 
 #if XUNIT_CORE_DLL
@@ -18,7 +19,8 @@ namespace Xunit
         public TestAssemblyMessage(IEnumerable<ITestCase> testCases, ITestAssembly testAssembly)
         {
             TestAssembly = testAssembly;
-            TestCases = testCases;
+            // Ensure the enumerable is serialisable
+            TestCases = testCases.ToList();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Derived instances of `IExecutionMessage` are being created with code like `TestCases.Cast<ITestCase>()`, where the resulting `IEnumerable<>` isn't serialisable. This change ensures the passed in enumerable is converted into a serialisable list before it's assigned.
