### PR TITLE
Include execution lib for xamarin projects

### DIFF
--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -44,9 +44,12 @@
     <file src="xunit.execution.wpa81\bin\Release\xunit.execution.dll"                 target="build\wpa81\device\xunit.execution.dll" />
     <file src="xunit.execution.wpa81\bin\Release\xunit.execution.pri"                 target="build\wpa81\device\xunit.execution.pri" />
     
-    <!-- Prevent PCL build targets from copying execution into the Xamarin projects -->
-    <file src="xunit.core\build\xunit.core.empty.props" target="build\monotouch\xunit.core.props" />
-    <file src="xunit.core\build\xunit.core.empty.props" target="build\monoandroid\xunit.core.props" />
+  
+    <file src="xunit.core\build\xunit.core.props"                                     target="build\monotouch\xunit.core.props" />
+    <file src="xunit.execution.iOS\bin\iPhone\Release\xunit.execution.dll"            target="build\monotouch\xunit.execution.dll" />
+    
+    <file src="xunit.core\build\xunit.core.props"                                     target="build\monoandroid\xunit.core.props" />
+    <file src="xunit.execution.android\bin\Release\xunit.execution.dll"               target="build\monoandroid\xunit.execution.dll" />
     
     <!-- TD.NET -->
     <file src="xunit.core\bin\Release\xunit.core.dll.tdnet"                     target="lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll.tdnet" />

--- a/src/xunit.core/build/xunit.core.empty.props
+++ b/src/xunit.core/build/xunit.core.empty.props
@@ -1,2 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />


### PR DESCRIPTION
This PR updates the xunit.core.nuspec to include the Xamarin execution libs the same way core does for the other platforms.

Without this, Xamarin runner apps have a reference to the xunit.execution nuget, but that is more brittle as the execution lib and core need to be in sync.
