### PR TITLE
Add platform names to dll's to support troubleshooting

### DIFF
--- a/src/xunit.abstractions.pcl/xunit.abstractions.pcl.csproj
+++ b/src/xunit.abstractions.pcl/xunit.abstractions.pcl.csproj
@@ -26,14 +26,14 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PCL</DefineConstants>
     <DocumentationFile>bin\Debug\xunit.abstractions.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;PCL</DefineConstants>
     <DocumentationFile>bin\Release\xunit.abstractions.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/xunit.abstractions/Properties/AssemblyInfo.cs
+++ b/src/xunit.abstractions/Properties/AssemblyInfo.cs
@@ -5,7 +5,11 @@ using System.Reflection;
 // This file does not use GlobalAssemblyInfo.cs because its version should not change over time.
 // Once 2.0 ships, this assembly will be considered to be frozen.
 
-[assembly: AssemblyTitle("xUnit.net Abstractions")]
+#if PCL
+[assembly: AssemblyTitle("xUnit.net Abstractions (PCL)")]
+#else
+[assembly: AssemblyTitle("xUnit.net Abstractions (net35)")]
+#endif
 [assembly: AssemblyCompany("Outercurve Foundation")]
 [assembly: AssemblyProduct("xUnit.net Testing Framework")]
 [assembly: AssemblyCopyright("Copyright (C) Outercurve Foundation")]

--- a/src/xunit.execution/Properties/AssemblyInfo.cs
+++ b/src/xunit.execution/Properties/AssemblyInfo.cs
@@ -1,5 +1,17 @@
 using System;
 using System.Reflection;
 
-[assembly: AssemblyTitle("xUnit.net")]
+#if ANDROID
+[assembly: AssemblyTitle("xUnit.net (MonoAndroid)")]
+#elif __IOS__
+[assembly: AssemblyTitle("xUnit.net (MonoTouch)")]
+#elif NO_APPDOMAIN
+[assembly: AssemblyTitle("xUnit.net (Net45-NoAppdomain)")]
+#elif NO_SERIALIZATION
+[assembly: AssemblyTitle("xUnit.net (Net45-StringSerialization)")]
+#elif WINDOWS_PHONE_APP
+[assembly: AssemblyTitle("xUnit.net (Wpa81+Win81)")]
+#else
+[assembly: AssemblyTitle("xUnit.net (Net45)")]
+#endif
 [assembly: CLSCompliant(true)]

--- a/src/xunit.runner.utility/Properties/AssemblyInfo.cs
+++ b/src/xunit.runner.utility/Properties/AssemblyInfo.cs
@@ -1,5 +1,15 @@
 ﻿using System;
 using System.Reflection;
 
-[assembly: AssemblyTitle("xUnit.net Runner Utility")]
+#if ANDROID
+[assembly: AssemblyTitle("xUnit.net Runner Utility (MonoAndroid)")]
+#elif __IOS__
+[assembly: AssemblyTitle("xUnit.net Runner Utility (MonoTouch)")]
+#elif NO_APPDOMAIN
+[assembly: AssemblyTitle("xUnit.net Runner Utility (Net45-NoAppdomain)")]
+#elif WINDOWS_PHONE_APP
+[assembly: AssemblyTitle("xUnit.net Runner Utility (Wpa81+Win81)")]
+#else
+[assembly: AssemblyTitle("xUnit.net Runner Utility (Net35)")]
+#endif
 [assembly: CLSCompliant(true)]


### PR DESCRIPTION
Thought this might help disambiguate multiple versions of the same dll without loading them into reflector. Could be useful for troubleshooting to see which file is which for the ones where we build for multiple platforms.
