### PR TITLE
Return the queued tasks to the debugger to assist in debugging

### DIFF
--- a/src/xunit.execution/Sdk/MaxConcurrencyTaskScheduler.cs
+++ b/src/xunit.execution/Sdk/MaxConcurrencyTaskScheduler.cs
@@ -58,7 +58,8 @@ namespace Xunit.Sdk
         [SecurityCritical]
         protected override IEnumerable<Task> GetScheduledTasks()
         {
-            throw new NotImplementedException();
+            var tasks = workQueue.ToArray();
+            return tasks;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Low hanging fruit - return the task scheduler's queue of tasks to the debugger when requested by it. This populates the Tasks pane.
