### PR TITLE
Ignore Roslyn Intellisense directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ AppPackages
 *.user
 *.[Cc]ache
 *[Rr]esharper*
+*.ide
 *.zip
 *.suo
 *.user


### PR DESCRIPTION
Visual Studio "Dev14" where Roslyn replaces the C# language service adds a *.ide directory to the solution that should not be added to SCC. The .gitignore template file on github has already been updated to include this.
