### PR TITLE
Change Assert.Contains<T> to include actual collection in assertion message

### DIFF
--- a/src/xunit.assert/Asserts/CollectionAsserts.cs
+++ b/src/xunit.assert/Asserts/CollectionAsserts.cs
@@ -99,7 +99,7 @@ namespace Xunit
                     if (comparer.Equals(expected, item))
                         return;
 
-            throw new ContainsException(expected);
+            throw new ContainsException(expected, collection);
         }
 
         /// <summary>

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/ContainsException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/ContainsException.cs
@@ -8,21 +8,14 @@ namespace Xunit.Sdk
     /// Exception thrown when a collection unexpectedly does not contain the expected value.
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
-    public class ContainsException : XunitException
+    public class ContainsException : AssertActualExpectedException
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="ContainsException"/> class.
-        /// </summary>
-        /// <param name="expected">The expected object value</param>
-        public ContainsException(object expected)
-            : base(String.Format(CultureInfo.CurrentCulture, "Assert.Contains() Failure: Not found: {0}", expected)) { }
-
         /// <summary>
         /// Creates a new instance of the <see cref="ContainsException"/> class.
         /// </summary>
         /// <param name="expected">The expected object value</param>
         /// <param name="actual">The actual value</param>
         public ContainsException(object expected, object actual)
-            : base(String.Format(CultureInfo.CurrentCulture, "Assert.Contains() Failure:{2}Not found: {0}{2}In value:  {1}", expected, actual, Environment.NewLine)) { }
+            : base(expected, actual, "Assert.Contains() Failure") { }
     }
 }

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -140,11 +140,14 @@ public class CollectionAssertsTests
         [Fact]
         public void ItemNotInContainer()
         {
-            List<int> list = new List<int>();
+            List<int> list = new List<int> { 41, 43 };
 
             ContainsException ex = Assert.Throws<ContainsException>(() => Assert.Contains(42, list));
 
-            Assert.Equal("Assert.Contains() Failure: Not found: 42", ex.Message);
+            Assert.Equal(
+                "Assert.Contains() Failure" + Environment.NewLine + 
+                "Expected: 42" + Environment.NewLine +
+                "Actual:   List<Int32> { 41, 43 }", ex.Message);
         }
 
         [Fact]

--- a/test/test.xunit.assert/Asserts/StringAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/StringAssertsTests.cs
@@ -19,9 +19,9 @@ public class StringAssertsTests
             var ex = Record.Exception(() => Assert.Contains("WORLD", "Hello, world!"));
 
             Assert.IsType<ContainsException>(ex);
-            Assert.Equal("Assert.Contains() Failure:" + Environment.NewLine +
-                         "Not found: WORLD" + Environment.NewLine +
-                         "In value:  Hello, world!", ex.Message);
+            Assert.Equal("Assert.Contains() Failure" + Environment.NewLine +
+                         "Expected: WORLD" + Environment.NewLine +
+                         "Actual:   Hello, world!", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
This helps to understand collection contains test failures better when items have subtle differences in text capitalization, property values, etc.
