### PR TITLE
Add support for Xamarin.iOS (Unified) profile

### DIFF
--- a/src/xunit.abstractions.nuspec
+++ b/src/xunit.abstractions.nuspec
@@ -18,7 +18,7 @@
   <files>
     <file src="xunit.abstractions.net35\bin\Release\xunit.abstractions.dll" target="lib\net35\xunit.abstractions.dll" />
     <file src="xunit.abstractions.net35\bin\Release\xunit.abstractions.xml" target="lib\net35\xunit.abstractions.xml" />
-    <file src="xunit.abstractions.pcl\bin\Release\xunit.abstractions.dll"   target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.abstractions.dll" />
-    <file src="xunit.abstractions.pcl\bin\Release\xunit.abstractions.xml"   target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.abstractions.xml" />
+    <file src="xunit.abstractions.pcl\bin\Release\xunit.abstractions.dll"   target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
+    <file src="xunit.abstractions.pcl\bin\Release\xunit.abstractions.xml"   target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.xml" />
   </files>
 </package>

--- a/src/xunit.assert.nuspec
+++ b/src/xunit.assert.nuspec
@@ -7,7 +7,7 @@
     <authors>James Newkirk, Brad Wilson</authors>
     <description>
       Includes the current assertion library from xUnit.net (xunit.assert.dll).
-      Supported platforms: Desktop .NET 4.5+, ASP.NET Core 5+, Modern Windows 8+, Windows Phone 8+ (Silverlight), Windows Phone 8.1+ (Universal), Portable Libraries (supporting Profile259).
+      Supported platforms: Desktop .NET 4.5+, ASP.NET Core 5+, Modern Windows 8+, Windows Phone 8+ (Silverlight), Windows Phone 8.1+ (Universal), Xamarin (iOS|Classic), Xamarin Android, Portable Libraries (supporting Profile259).
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/xunit/xunit</projectUrl>
@@ -16,8 +16,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
   <files>
-    <file src="xunit.assert\bin\Release\xunit.assert.dll" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10\xunit.assert.dll" />
-    <file src="xunit.assert\bin\Release\xunit.assert.pdb" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10\xunit.assert.pdb" />
-    <file src="xunit.assert\bin\Release\xunit.assert.xml" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10\xunit.assert.xml" />
+    <file src="xunit.assert\bin\Release\xunit.assert.dll" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch+Xamarin.iOS\xunit.assert.dll" />
+    <file src="xunit.assert\bin\Release\xunit.assert.pdb" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch+Xamarin.iOS\xunit.assert.pdb" />
+    <file src="xunit.assert\bin\Release\xunit.assert.xml" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch+Xamarin.iOS\xunit.assert.xml" />
   </files>
 </package>

--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -36,13 +36,13 @@
   </metadata>
   <files>
     <!-- Core -->
-    <file src="xunit.core\bin\Release\xunit.core.dll" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll" />
-    <file src="xunit.core\bin\Release\xunit.core.pdb" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.core.pdb" />
-    <file src="xunit.core\bin\Release\xunit.core.xml" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.core.xml" />
+    <file src="xunit.core\bin\Release\xunit.core.dll" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll" />
+    <file src="xunit.core\bin\Release\xunit.core.pdb" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.pdb" />
+    <file src="xunit.core\bin\Release\xunit.core.xml" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.xml" />
 
     <!-- Execution -->
-    <file src="xunit.core\build\xunit.core.props"                                     target="build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props" />
-    <file src="xunit.execution.net45\bin\Release\xunit.execution.dll"                 target="build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.execution.dll" />
+    <file src="xunit.core\build\xunit.core.props"                                     target="build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" />
+    <file src="xunit.execution.net45\bin\Release\xunit.execution.dll"                 target="build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.execution.dll" />
 
     <file src="xunit.core\build\xunit.core.props"                                     target="build\win8\xunit.core.props" />
     <file src="xunit.core\build\xunit.core.targets"                                   target="build\win8\xunit.core.targets" />
@@ -63,12 +63,15 @@
     <file src="xunit.core\build\xunit.core.props"                                     target="build\monotouch\xunit.core.props" />
     <file src="xunit.execution.iOS\bin\iPhone\Release\xunit.execution.dll"            target="build\monotouch\xunit.execution.dll" />
 
+    <file src="xunit.core\build\xunit.core.props"                                     target="build\Xamarin.iOS\xunit.core.props" />
+    <file src="xunit.execution.ios-universal\bin\iPhone\Release\xunit.execution.dll"  target="build\Xamarin.iOS\xunit.execution.dll" />
+
     <file src="xunit.core\build\xunit.core.props"                                     target="build\monoandroid\xunit.core.props" />
     <file src="xunit.execution.android\bin\Release\xunit.execution.dll"               target="build\monoandroid\xunit.execution.dll" />
 
     <!-- TD.NET -->
-    <file src="xunit.core\bin\Release\xunit.core.dll.tdnet"                     target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll.tdnet" />
-    <file src="xunit.runner.tdnet\bin\Release\xunit.runner.tdnet.dll"           target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.runner.tdnet.dll" />
-    <file src="xunit.runner.utility.net35\bin\Release\xunit.runner.utility.dll" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.runner.utility.dll" />
+    <file src="xunit.core\bin\Release\xunit.core.dll.tdnet"                     target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll.tdnet" />
+    <file src="xunit.runner.tdnet\bin\Release\xunit.runner.tdnet.dll"           target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.tdnet.dll" />
+    <file src="xunit.runner.utility.net35\bin\Release\xunit.runner.utility.dll" target="lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.utility.dll" />
   </files>
 </package>

--- a/src/xunit.execution.ios-universal/xunit.execution.ios-universal.csproj
+++ b/src/xunit.execution.ios-universal/xunit.execution.ios-universal.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{372BC460-0BBA-4AD5-9FC4-87950B220267}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xunit</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>xunit.execution</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;__UNIFIED__;__MOBILE__;__IOS__;XUNIT_CORE_DLL;XAMARIN;NO_APPDOMAIN</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;XUNIT_CORE_DLL;XAMARIN;NO_APPDOMAIN</DefineConstants>
+    <DocumentationFile>bin\iPhone\Release\xunit.execution.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\xunit.abstractions.pcl\xunit.abstractions.pcl.csproj">
+      <Project>{77743589-f177-4007-97b8-50b82a1c7044}</Project>
+      <Name>xunit.abstractions.pcl</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\xunit.core\xunit.core.csproj">
+      <Project>{1b843c0f-8e08-4ba9-8c85-eeaf779a0774}</Project>
+      <Name>xunit.core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\common\AssemblyExtensions.cs">
+      <Link>Common\AssemblyExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\DictionaryExtensions.cs">
+      <Link>Common\DictionaryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ExceptionExtensions.cs">
+      <Link>Common\ExceptionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ExceptionUtility.cs">
+      <Link>Common\ExceptionUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\common\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\common\Guard.cs">
+      <Link>Common\Guard.cs</Link>
+    </Compile>
+    <Compile Include="..\common\LongLivedMarshalByRefObject_Execution_NoAppDomain.cs">
+      <Link>Common\LongLivedMarshalByRefObject_Execution_NoAppDomain.cs</Link>
+    </Compile>
+    <Compile Include="..\common\SerializationHelper_BinarySerializer.cs">
+      <Link>Common\SerializationHelper_BinarySerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\common\SerializationInfoExtensions.cs">
+      <Link>Common\SerializationInfoExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\SourceInformation.cs">
+      <Link>Common\SourceInformation.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestDiscoveryVisitor.cs">
+      <Link>Common\TestDiscoveryVisitor.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestMessageVisitor.cs">
+      <Link>Common\TestMessageVisitor.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestOptionsNames.cs">
+      <Link>Common\TestOptionsNames.cs</Link>
+    </Compile>
+    <Compile Include="..\common\XunitWorkerThread_Thread.cs">
+      <Link>Common\XunitWorkerThread_Thread.cs</Link>
+    </Compile>
+    <Compile Include="..\xunit.assert\Asserts\Sdk\ArgumentFormatter.cs">
+      <Link>Common\ArgumentFormatter.cs</Link>
+    </Compile>
+    <Compile Include="..\xunit.assert\Asserts\Sdk\AssertEqualityComparer.cs">
+      <Link>Sdk\AssertEqualityComparer.cs</Link>
+    </Compile>
+    <Compile Include="..\xunit.assert\Asserts\Sdk\AssertEqualityComparerAdapter.cs">
+      <Link>Sdk\AssertEqualityComparerAdapter.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\xunit.execution\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\messages\**\*.cs">
+      <Link>Messages\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/src/xunit.execution.nuspec
+++ b/src/xunit.execution.nuspec
@@ -7,7 +7,7 @@
     <authors>James Newkirk, Brad Wilson</authors>
     <description>
       Includes the execution framework for xUnit.net (xunit.execution.dll).
-      Supported platforms: Desktop .NET 4.5+, Modern Windows 8+, Windows Phone 8.1+ (Universal), MonoTouch, MonoAndroid, Portable Libraries (supporting Profile259), ASP.NET vNext.
+      Supported platforms: Desktop .NET 4.5+, Modern Windows 8+, Windows Phone 8.1+ (Universal), MonoTouch, MonoAndroid, Xamarin.iOS, Portable Libraries (supporting Profile259), ASP.NET vNext.
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/xunit/xunit</projectUrl>
@@ -28,6 +28,9 @@
     <file src="xunit.execution.iOS\bin\iPhone\Release\xunit.execution.dll"   target="lib\monotouch\xunit.execution.dll" />
     <file src="xunit.execution.iOS\bin\iPhone\Release\xunit.execution.pdb"   target="lib\monotouch\xunit.execution.pdb" />
     <file src="xunit.execution.iOS\bin\iPhone\Release\xunit.execution.xml"   target="lib\monotouch\xunit.execution.xml" />
+    <file src="xunit.execution.ios-universal\bin\iPhone\Release\xunit.execution.dll"   target="lib\Xamarin.iOS\xunit.execution.dll" />
+    <file src="xunit.execution.ios-universal\bin\iPhone\Release\xunit.execution.pdb"   target="lib\Xamarin.iOS\xunit.execution.pdb" />
+    <file src="xunit.execution.ios-universal\bin\iPhone\Release\xunit.execution.xml"   target="lib\Xamarin.iOS\xunit.execution.xml" />
     <file src="xunit.execution.android\bin\Release\xunit.execution.dll"      target="lib\monoandroid\xunit.execution.dll" />
     <file src="xunit.execution.android\bin\Release\xunit.execution.pdb"      target="lib\monoandroid\xunit.execution.pdb" />
     <file src="xunit.execution.android\bin\Release\xunit.execution.xml"      target="lib\monoandroid\xunit.execution.xml" />

--- a/src/xunit.execution/Properties/AssemblyInfo.cs
+++ b/src/xunit.execution/Properties/AssemblyInfo.cs
@@ -3,8 +3,10 @@ using System.Reflection;
 
 #if ANDROID
 [assembly: AssemblyTitle("xUnit.net (MonoAndroid)")]
-#elif __IOS__
+#elif __IOS__ && ! __UNIFIED__
 [assembly: AssemblyTitle("xUnit.net (MonoTouch)")]
+#elif __IOS__
+[assembly: AssemblyTitle("xUnit.net (Xamarin.iOS)")]
 #elif WINDOWS_PHONE_APP
 [assembly: AssemblyTitle("xUnit.net (WPA81 + WIN81)")]
 #elif WINDOWS_PHONE

--- a/src/xunit.runner.utility.ios-universal/xunit.runner.utility.ios-universal.csproj
+++ b/src/xunit.runner.utility.ios-universal/xunit.runner.utility.ios-universal.csproj
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DB7068BF-3B26-49AB-83B3-F6B8431E37E9}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xunit</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>xunit.runner.utility</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;__UNIFIED__;__MOBILE__;__IOS__;XAMARIN;NO_APPDOMAIN</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;XAMARIN;NO_APPDOMAIN</DefineConstants>
+    <DocumentationFile>bin\iPhone\Release\xunit.runner.utility.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+   <ItemGroup>
+    <Compile Include="..\common\AssemblyExtensions.cs">
+      <Link>Common\AssemblyExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\AssemblyHelper.cs">
+      <Link>Common\AssemblyHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\common\DictionaryExtensions.cs">
+      <Link>Common\DictionaryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\DisposableExtensions.cs">
+      <Link>Common\DisposableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ExceptionExtensions.cs">
+      <Link>Common\ExceptionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\ExceptionUtility.cs">
+      <Link>Common\ExceptionUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\common\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\common\Guard.cs">
+      <Link>Common\Guard.cs</Link>
+    </Compile>
+    <Compile Include="..\common\LongLivedMarshalByRefObject_Runner_NoAppDomain.cs">
+      <Link>Common\LongLivedMarshalByRefObject_Runner_NoAppDomain.cs</Link>
+    </Compile>
+    <Compile Include="..\common\RemoteAppDomainManager_NoAppDomain.cs">
+      <Link>Common\RemoteAppDomainManager_NoAppDomain.cs</Link>
+    </Compile>
+    <Compile Include="..\common\SerializationInfoExtensions.cs">
+      <Link>Common\SerializationInfoExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\common\SourceInformation.cs">
+      <Link>Common\SourceInformation.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestDiscoveryVisitor.cs">
+      <Link>Common\TestDiscoveryVisitor.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestMessageVisitor.cs">
+      <Link>Common\TestMessageVisitor.cs</Link>
+    </Compile>
+    <Compile Include="..\common\TestOptionsNames.cs">
+      <Link>Common\TestOptionsNames.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\xunit.runner.utility\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\messages\**\*.cs">
+      <Link>Messages\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\xunit.abstractions.pcl\xunit.abstractions.pcl.csproj">
+      <Project>{77743589-f177-4007-97b8-50b82a1c7044}</Project>
+      <Name>xunit.abstractions.pcl</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/src/xunit.runner.utility.nuspec
+++ b/src/xunit.runner.utility.nuspec
@@ -7,7 +7,7 @@
     <authors>James Newkirk, Brad Wilson</authors>
     <description>
       Includes the version-independent runner for xUnit.net to run both v1 and v2 tests (xunit.runner.utility.dll).
-      Supported platforms: Desktop .NET 3.5+, Windows 8.1+ (Universal), Windows Phone 8.1+ (Universal), MonoTouch, MonoAndroid, Portable Libraries (supporting Profile259), ASP.NET vNext.
+      Supported platforms: Desktop .NET 3.5+, Windows 8.1+ (Universal), Windows Phone 8.1+ (Universal), MonoTouch, MonoAndroid, Xamarin.iOS, Portable Libraries (supporting Profile259), ASP.NET vNext.
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/xunit/xunit</projectUrl>
@@ -28,6 +28,9 @@
     <file src="xunit.runner.utility.iOS\bin\iPhone\Release\xunit.runner.utility.dll"   target="lib\monotouch\xunit.runner.utility.dll" />
     <file src="xunit.runner.utility.iOS\bin\iPhone\Release\xunit.runner.utility.pdb"   target="lib\monotouch\xunit.runner.utility.pdb" />
     <file src="xunit.runner.utility.iOS\bin\iPhone\Release\xunit.runner.utility.xml"   target="lib\monotouch\xunit.runner.utility.xml" />
+    <file src="xunit.runner.utility.ios-universal\bin\iPhone\Release\xunit.runner.utility.dll"   target="lib\Xamarin.iOS\xunit.runner.utility.dll" />
+    <file src="xunit.runner.utility.ios-universal\bin\iPhone\Release\xunit.runner.utility.pdb"   target="lib\Xamarin.iOS\xunit.runner.utility.pdb" />
+    <file src="xunit.runner.utility.ios-universal\bin\iPhone\Release\xunit.runner.utility.xml"   target="lib\Xamarin.iOS\xunit.runner.utility.xml" />
     <file src="xunit.runner.utility.android\bin\Release\xunit.runner.utility.dll"      target="lib\monoandroid\xunit.runner.utility.dll" />
     <file src="xunit.runner.utility.android\bin\Release\xunit.runner.utility.pdb"      target="lib\monoandroid\xunit.runner.utility.pdb" />
     <file src="xunit.runner.utility.android\bin\Release\xunit.runner.utility.xml"      target="lib\monoandroid\xunit.runner.utility.xml" />

--- a/src/xunit.runner.utility/Properties/AssemblyInfo.cs
+++ b/src/xunit.runner.utility/Properties/AssemblyInfo.cs
@@ -3,8 +3,10 @@ using System.Reflection;
 
 #if ANDROID
 [assembly: AssemblyTitle("xUnit.net Runner Utility (MonoAndroid)")]
-#elif __IOS__
+#elif __IOS__ && !__UNIFIED__
 [assembly: AssemblyTitle("xUnit.net Runner Utility (MonoTouch)")]
+#elif __IOS__ 
+[assembly: AssemblyTitle("xUnit.net Runner Utility (Xamarin.iOS)")]
 #elif WINDOWS_PHONE_APP
 [assembly: AssemblyTitle("xUnit.net Runner Utility (WPA81 + WIN81)")]
 #elif WINDOWS_PHONE

--- a/xunit.sln
+++ b/xunit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DAED8494-AC8A-4C67-A8F1-616D95ECC302}"
 	ProjectSection(SolutionItems) = preProject
@@ -119,6 +119,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.execution.wp8", "src\xunit.execution.wp8\xunit.execution.wp8.csproj", "{AA80CCD7-6DD1-4122-9A85-B8F9FD9F113E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.utility.wp8", "src\xunit.runner.utility.wp8\xunit.runner.utility.wp8.csproj", "{F9692B98-F6E5-48DA-B9EF-28E86F6DAEFD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.execution.ios-universal", "src\xunit.execution.ios-universal\xunit.execution.ios-universal.csproj", "{372BC460-0BBA-4AD5-9FC4-87950B220267}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.utility.ios-universal", "src\xunit.runner.utility.ios-universal\xunit.runner.utility.ios-universal.csproj", "{DB7068BF-3B26-49AB-83B3-F6B8431E37E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -242,6 +246,14 @@ Global
 		{F9692B98-F6E5-48DA-B9EF-28E86F6DAEFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9692B98-F6E5-48DA-B9EF-28E86F6DAEFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9692B98-F6E5-48DA-B9EF-28E86F6DAEFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{372BC460-0BBA-4AD5-9FC4-87950B220267}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{372BC460-0BBA-4AD5-9FC4-87950B220267}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{372BC460-0BBA-4AD5-9FC4-87950B220267}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{372BC460-0BBA-4AD5-9FC4-87950B220267}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB7068BF-3B26-49AB-83B3-F6B8431E37E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB7068BF-3B26-49AB-83B3-F6B8431E37E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB7068BF-3B26-49AB-83B3-F6B8431E37E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB7068BF-3B26-49AB-83B3-F6B8431E37E9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -287,5 +299,7 @@ Global
 		{B70F7D22-1455-4118-A827-DC60CE6363A8} = {C50B1A3D-B2F9-468F-8280-526B0D712107}
 		{AA80CCD7-6DD1-4122-9A85-B8F9FD9F113E} = {72690AF2-D51A-4FD2-BD59-17FADACC29A1}
 		{F9692B98-F6E5-48DA-B9EF-28E86F6DAEFD} = {A36A630E-A604-47E6-894E-732946960182}
+		{372BC460-0BBA-4AD5-9FC4-87950B220267} = {72690AF2-D51A-4FD2-BD59-17FADACC29A1}
+		{DB7068BF-3B26-49AB-83B3-F6B8431E37E9} = {A36A630E-A604-47E6-894E-732946960182}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds support for the Xamarin.iOS Unified profile (different than MonoTouch), that includes iOS 64-bit support.
