### PR TITLE
make AsyncTestSyncContext public

### DIFF
--- a/src/xunit.execution/Sdk/AsyncTestSyncContext.cs
+++ b/src/xunit.execution/Sdk/AsyncTestSyncContext.cs
@@ -9,7 +9,7 @@ using Windows.System.Threading;
 
 namespace Xunit.Sdk
 {
-    internal class AsyncTestSyncContext : SynchronizationContext
+    public class AsyncTestSyncContext : SynchronizationContext
     {
         readonly AsyncManualResetEvent @event = new AsyncManualResetEvent(true);
         Exception exception;


### PR DESCRIPTION
I need it for xBehave.net :smiley:

Currently have it copied in as a shim https://github.com/xbehave/xbehave.net/blob/dev/src/Xbehave.2.Execution/Shims/AsyncTestSyncContext.cs
