### PR TITLE
Added support for synchronous test discovery message reporting.

### DIFF
--- a/src/common/TestOptionsNames.cs
+++ b/src/common/TestOptionsNames.cs
@@ -13,6 +13,7 @@ internal static class TestOptionsNames
     {
         public static readonly string DiagnosticMessages = "xunit.discovery.DiagnosticMessages";
         public static readonly string MethodDisplay = "xunit.discovery.MethodDisplay";
+        public static readonly string SynchronousMessageReporting = "xunit.SynchronousMessageReporting";
     }
 
     internal static class Execution

--- a/src/xunit.execution/Sdk/Frameworks/TestFrameworkDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestFrameworkDiscoverer.cs
@@ -92,7 +92,7 @@ namespace Xunit.Sdk
 
             Task.Run(() =>
             {
-                using (var messageBus = new MessageBus(messageSink))
+                using (var messageBus = CreateMessageBus(messageSink, discoveryOptions))
                 using (new PreserveWorkingFolder(AssemblyInfo))
                 {
                     foreach (var type in AssemblyInfo.GetTypes(includePrivateTypes: false).Where(IsValidTestClass))
@@ -108,6 +108,16 @@ namespace Xunit.Sdk
             });
         }
 
+        private IMessageBus CreateMessageBus(IMessageSink messageSink, ITestFrameworkOptions options)
+        {
+            if (options.GetValue(TestOptionsNames.Discovery.SynchronousMessageReporting, false))
+            {
+                return new SynchronousMessageBus(messageSink);
+            }
+
+            return new MessageBus(messageSink);
+        }
+
         /// <inheritdoc/>
         public void Find(string typeName, bool includeSourceInformation, IMessageSink messageSink, ITestFrameworkOptions discoveryOptions)
         {
@@ -117,7 +127,7 @@ namespace Xunit.Sdk
 
             Task.Run(() =>
             {
-                using (var messageBus = new MessageBus(messageSink))
+                using (var messageBus = CreateMessageBus(messageSink, discoveryOptions))
                 using (new PreserveWorkingFolder(AssemblyInfo))
                 {
                     var typeInfo = AssemblyInfo.GetType(typeName);


### PR DESCRIPTION
This commit adds support for the use of a synchronous message bus when reporting discovered tests to a test runner tool.  NCrunch unfortunately requires test discovery to be a synchronous process as it is underpinned by a number of mechanisms (such a metadata discovery) that don't handle multithreading particularly well.