### PR TITLE
Add InvariantCulture to xml output formatting.

### DIFF
--- a/src/common/XmlTestExecutionVisitor.cs
+++ b/src/common/XmlTestExecutionVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 using Xunit.Abstractions;
@@ -40,7 +41,7 @@ namespace Xunit
                     new XAttribute("name", XmlEscape(testResult.Test.DisplayName)),
                     new XAttribute("type", testResult.TestCase.TestMethod.TestClass.Class.Name),
                     new XAttribute("method", testResult.TestCase.TestMethod.Method.Name),
-                    new XAttribute("time", testResult.ExecutionTime.ToString()),
+                    new XAttribute("time", testResult.ExecutionTime.ToString(CultureInfo.InvariantCulture)),
                     new XAttribute("result", resultText)
                 );
 
@@ -106,7 +107,7 @@ namespace Xunit
                     new XAttribute("passed", Total - Failed - Skipped),
                     new XAttribute("failed", Failed),
                     new XAttribute("skipped", Skipped),
-                    new XAttribute("time", Time.ToString("0.000")),
+                    new XAttribute("time", Time.ToString("0.000", CultureInfo.InvariantCulture)),
                     new XAttribute("errors", Errors)
                 );
 
@@ -125,8 +126,8 @@ namespace Xunit
                     new XAttribute("name", assemblyStarting.TestAssembly.Assembly.AssemblyPath),
                     new XAttribute("environment", assemblyStarting.TestEnvironment),
                     new XAttribute("test-framework", assemblyStarting.TestFrameworkDisplayName),
-                    new XAttribute("run-date", assemblyStarting.StartTime.ToString("yyyy-MM-dd")),
-                    new XAttribute("run-time", assemblyStarting.StartTime.ToString("HH:mm:ss"))
+                    new XAttribute("run-date", assemblyStarting.StartTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+                    new XAttribute("run-time", assemblyStarting.StartTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture))
                 );
 
                 if (assemblyStarting.TestAssembly.ConfigFileName != null)
@@ -147,7 +148,7 @@ namespace Xunit
                     new XAttribute("failed", testCollectionFinished.TestsFailed),
                     new XAttribute("skipped", testCollectionFinished.TestsSkipped),
                     new XAttribute("name", XmlEscape(testCollectionFinished.TestCollection.DisplayName)),
-                    new XAttribute("time", testCollectionFinished.ExecutionTime.ToString("0.000"))
+                    new XAttribute("time", testCollectionFinished.ExecutionTime.ToString("0.000", CultureInfo.InvariantCulture))
                 );
             }
 

--- a/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
+++ b/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -123,7 +124,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("2064", assemblyElement.Attribute("passed").Value);
             Assert.Equal("42", assemblyElement.Attribute("failed").Value);
             Assert.Equal("6", assemblyElement.Attribute("skipped").Value);
-            Assert.Equal(123.457M.ToString(), assemblyElement.Attribute("time").Value);
+            Assert.Equal(123.457M.ToString(CultureInfo.InvariantCulture), assemblyElement.Attribute("time").Value);
             Assert.Equal("1", assemblyElement.Attribute("errors").Value);
         }
 
@@ -152,7 +153,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("2064", collectionElement.Attribute("passed").Value);
             Assert.Equal("42", collectionElement.Attribute("failed").Value);
             Assert.Equal("6", collectionElement.Attribute("skipped").Value);
-            Assert.Equal(123.457M.ToString(), collectionElement.Attribute("time").Value);
+            Assert.Equal(123.457M.ToString(CultureInfo.InvariantCulture), collectionElement.Attribute("time").Value);
         }
 
         [CulturedFact]
@@ -179,7 +180,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Pass", testElement.Attribute("result").Value);
-            Assert.Equal(123.4567809M.ToString(), testElement.Attribute("time").Value);
+            Assert.Equal(123.4567809M.ToString(CultureInfo.InvariantCulture), testElement.Attribute("time").Value);
             Assert.Equal("test output", testElement.Element("output").Value);
             Assert.Null(testElement.Attribute("source-file"));
             Assert.Null(testElement.Attribute("source-line"));
@@ -212,7 +213,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Pass", testElement.Attribute("result").Value);
-            Assert.Equal(123.4567809M.ToString(), testElement.Attribute("time").Value);
+            Assert.Equal(123.4567809M.ToString(CultureInfo.InvariantCulture), testElement.Attribute("time").Value);
             Assert.Null(testElement.Attribute("output"));
             Assert.Null(testElement.Attribute("source-file"));
             Assert.Null(testElement.Attribute("source-line"));
@@ -247,7 +248,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Fail", testElement.Attribute("result").Value);
-            Assert.Equal(123.4567809M.ToString(), testElement.Attribute("time").Value);
+            Assert.Equal(123.4567809M.ToString(CultureInfo.InvariantCulture), testElement.Attribute("time").Value);
             Assert.Equal("test output", testElement.Element("output").Value);
             var failureElement = Assert.Single(testElement.Elements("failure"));
             Assert.Equal("Exception Type", failureElement.Attribute("exception-type").Value);
@@ -302,7 +303,7 @@ public class XmlTestExecutionVisitorTests
             Assert.Equal("XmlTestExecutionVisitorTests+Xml+ClassUnderTest", testElement.Attribute("type").Value);
             Assert.Equal("TestMethod", testElement.Attribute("method").Value);
             Assert.Equal("Skip", testElement.Attribute("result").Value);
-            Assert.Equal(0.0M.ToString(), testElement.Attribute("time").Value);
+            Assert.Equal(0.0M.ToString(CultureInfo.InvariantCulture), testElement.Attribute("time").Value);
             var reasonElement = Assert.Single(testElement.Elements("reason"));
             Assert.Equal("Skip Reason", reasonElement.Value);
             Assert.Empty(testElement.Elements("failure"));


### PR DESCRIPTION
When tests are running asynchronously and some of them change the thread culture during the test this results in number format issues in the xml document. Some of the numbers are formatted with periods as the decimal point and others have commas.
The fix is to add CultureInfo.InvariantCulture to all the ToString calls.