### PR TITLE
Restore NUnit XML output

### DIFF
--- a/src/xunit.console/App.config
+++ b/src/xunit.console/App.config
@@ -7,6 +7,7 @@
   <xunit>
     <transforms>
       <add commandline="xmlv1" xslfile="xUnit1.xslt" description="output results to xUnit.net v1 style XML file"/>
+      <add commandline="nunit" xslfile="NUnitXml.xslt" description="output results to NUnit-style XML file"/>
       <add commandline="html" xslfile="HTML.xslt" description="output results to HTML file"/>
     </transforms>
   </xunit>

--- a/src/xunit.console/NUnitXml.xslt
+++ b/src/xunit.console/NUnitXml.xslt
@@ -38,13 +38,13 @@
           <xsl:value-of select="@time"/>
         </xsl:attribute>
         <results>
-          <xsl:apply-templates select="class"/>
+          <xsl:apply-templates select="collection"/>
         </results>
       </test-suite>
     </test-results>
   </xsl:template>
 
-  <xsl:template match="class">
+  <xsl:template match="collection">
     <test-suite>
       <xsl:attribute name="name">
         <xsl:value-of select="@name"/>

--- a/src/xunit.console/NUnitXml.xslt
+++ b/src/xunit.console/NUnitXml.xslt
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output cdata-section-elements="message stack-trace"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="assembly">
+    <test-results>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="date">
+        <xsl:value-of select="@run-date"/>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@run-time"/>
+      </xsl:attribute>
+      <xsl:attribute name="total">
+        <xsl:value-of select="@total"/>
+      </xsl:attribute>
+      <xsl:attribute name="failures">
+        <xsl:value-of select="@failed"/>
+      </xsl:attribute>
+      <xsl:attribute name="not-run">
+        <xsl:value-of select="@skipped"/>
+      </xsl:attribute>
+      <test-suite>
+        <xsl:attribute name="name">
+          <xsl:value-of select="@name"/>
+        </xsl:attribute>
+        <xsl:attribute name="success">
+          <xsl:if test="@failed > 0">False</xsl:if>
+          <xsl:if test="@failed = 0">True</xsl:if>
+        </xsl:attribute>
+        <xsl:attribute name="time">
+          <xsl:value-of select="@time"/>
+        </xsl:attribute>
+        <results>
+          <xsl:apply-templates select="class"/>
+        </results>
+      </test-suite>
+    </test-results>
+  </xsl:template>
+
+  <xsl:template match="class">
+    <test-suite>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="success">
+        <xsl:if test="@failed > 0">False</xsl:if>
+        <xsl:if test="@failed = 0">True</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <xsl:if test="failure">
+        <xsl:copy-of select="failure"/>
+      </xsl:if>
+      <xsl:if test="reason">
+        <reason>
+          <xsl:apply-templates select="reason"/>
+        </reason>
+      </xsl:if>
+      <results>
+        <xsl:apply-templates select="test"/>
+      </results>
+    </test-suite>
+  </xsl:template>
+
+  <xsl:template match="test">
+    <test-case>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="executed">
+        <xsl:if test="@result='Skip'">False</xsl:if>
+        <xsl:if test="@result!='Skip'">True</xsl:if>
+      </xsl:attribute>
+      <xsl:if test="@result!='Skip'">
+        <xsl:attribute name="success">
+          <xsl:if test="@result='Fail'">False</xsl:if>
+          <xsl:if test="@result='Pass'">True</xsl:if>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@time">
+        <xsl:attribute name="time">
+          <xsl:value-of select="@time"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="reason">
+        <reason>
+          <message>
+            <xsl:apply-templates select="reason"/>
+          </message>
+        </reason>
+      </xsl:if>
+      <xsl:apply-templates select="traits"/>
+      <xsl:apply-templates select="failure"/>
+    </test-case>
+  </xsl:template>
+
+  <xsl:template match="traits">
+    <properties>
+      <xsl:apply-templates select="trait"/>
+    </properties>
+  </xsl:template>
+
+  <xsl:template match="trait">
+    <property>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="value">
+        <xsl:value-of select="@value"/>
+      </xsl:attribute>
+    </property>
+  </xsl:template>
+
+  <xsl:template match="failure">
+    <failure>
+      <xsl:copy-of select="node()"/>
+    </failure>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
There are some of us out here who still are stuck with CI platforms that expect/require NUnit or JUnit output for parsing test results. The original NUnit XSL transform was removed in the 1.9->2.0 transition, but these changes restore the ability to get NUnit style XML results including a minor update to the transform to work with the xUnit.net 2.0 XML.