### PR TITLE
Fixes #322: Can't generate report in nunit format when using multiple assemblies in xunit.console

### DIFF
--- a/src/xunit.console/NUnitXml.xslt
+++ b/src/xunit.console/NUnitXml.xslt
@@ -6,42 +6,54 @@
     <xsl:apply-templates/>
   </xsl:template>
 
-  <xsl:template match="assembly">
-    <test-results>
-      <xsl:attribute name="name">
-        <xsl:value-of select="@name"/>
-      </xsl:attribute>
+  <xsl:template match="assemblies">
+    <test-results name="Test results">
       <xsl:attribute name="date">
-        <xsl:value-of select="@run-date"/>
+        <xsl:value-of select="assembly[1]/@run-date"/>
       </xsl:attribute>
       <xsl:attribute name="time">
-        <xsl:value-of select="@run-time"/>
+        <xsl:value-of select="assembly[1]/@run-time"/>
       </xsl:attribute>
       <xsl:attribute name="total">
-        <xsl:value-of select="@total"/>
+        <xsl:value-of select="sum(assembly/@total)"/>
       </xsl:attribute>
       <xsl:attribute name="failures">
-        <xsl:value-of select="@failed"/>
+        <xsl:value-of select="sum(assembly/@failed)"/>
       </xsl:attribute>
       <xsl:attribute name="not-run">
-        <xsl:value-of select="@skipped"/>
+        <xsl:value-of select="sum(assembly/@skipped)"/>
       </xsl:attribute>
-      <test-suite>
-        <xsl:attribute name="name">
-          <xsl:value-of select="@name"/>
-        </xsl:attribute>
+      <test-suite name="xUnit.net Tests">
         <xsl:attribute name="success">
-          <xsl:if test="@failed > 0">False</xsl:if>
-          <xsl:if test="@failed = 0">True</xsl:if>
+          <xsl:if test="sum(assembly/@failed) > 0">False</xsl:if>
+          <xsl:if test="sum(assembly/@failed) = 0">True</xsl:if>
         </xsl:attribute>
         <xsl:attribute name="time">
-          <xsl:value-of select="@time"/>
+          <xsl:value-of select="sum(assembly/@time)"/>
         </xsl:attribute>
         <results>
-          <xsl:apply-templates select="collection"/>
+          <xsl:apply-templates select="assembly"/>
         </results>
       </test-suite>
     </test-results>
+  </xsl:template>
+
+  <xsl:template match="assembly">
+    <test-suite>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="success">
+        <xsl:if test="@failed > 0">False</xsl:if>
+        <xsl:if test="@failed = 0">True</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <results>
+        <xsl:apply-templates select="collection"/>
+      </results>
+    </test-suite>
   </xsl:template>
 
   <xsl:template match="collection">


### PR DESCRIPTION
This change fixes the NUnit XML output when two or more assemblies are included in a test run. It's a bit more complicated than one would think at first due to the requirement of a single `<test-suite>` tag directly under `<test-results>`, requiring a bit more layering to ensure correct, valid output.