### PR TITLE
Changing System.XML to System.Xml so that it works xplat

### DIFF
--- a/src/xunit.console/xunit.console.csproj
+++ b/src/xunit.console/xunit.console.csproj
@@ -55,7 +55,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>

--- a/test/test.xunit.console/test.xunit.console.csproj
+++ b/test/test.xunit.console/test.xunit.console.csproj
@@ -61,7 +61,7 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="TestDriven.Framework, Version=2.0.0.0, Culture=neutral, PublicKeyToken=50ecb853f8c6b8d2">
       <SpecificVersion>False</SpecificVersion>

--- a/test/test.xunit.execution/test.xunit.execution.csproj
+++ b/test/test.xunit.execution/test.xunit.execution.csproj
@@ -38,7 +38,7 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="TestDriven.Framework, Version=2.0.0.0, Culture=neutral, PublicKeyToken=50ecb853f8c6b8d2">
       <SpecificVersion>False</SpecificVersion>

--- a/test/test.xunit.runner.msbuild/test.xunit.runner.msbuild.csproj
+++ b/test/test.xunit.runner.msbuild/test.xunit.runner.msbuild.csproj
@@ -37,7 +37,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="TestDriven.Framework">
       <HintPath>..\..\tools\TestDriven.Framework.dll</HintPath>

--- a/test/test.xunit.runner.utility/test.xunit.runner.utility.csproj
+++ b/test/test.xunit.runner.utility/test.xunit.runner.utility.csproj
@@ -36,7 +36,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="TestDriven.Framework">
       <HintPath>..\..\tools\TestDriven.Framework.dll</HintPath>


### PR DESCRIPTION
On OSX we are running into errors like ```Unable to resolve dependency framework/System.XML```. I think this is because the casing is not correct. The change here just update the .csproj files which had ```System.XML``` to ```System.Xml```. I'm not sure if there are other issues but wanted to get this PR to you for review.