### PR TITLE
Since the class isn't sealed, it can be inherited, so make serialization virtual

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/TestCollection.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestCollection.cs
@@ -47,7 +47,7 @@ namespace Xunit.Sdk
         public Guid UniqueID { get; set; }
 
         /// <inheritdoc/>
-        public void Serialize(IXunitSerializationInfo info)
+        public virtual void Serialize(IXunitSerializationInfo info)
         {
             info.AddValue("DisplayName", DisplayName);
             info.AddValue("TestAssembly", TestAssembly);
@@ -66,7 +66,7 @@ namespace Xunit.Sdk
         }
 
         /// <inheritdoc/>
-        public void Deserialize(IXunitSerializationInfo info)
+        public virtual void Deserialize(IXunitSerializationInfo info)
         {
             DisplayName = info.GetValue<string>("DisplayName");
             TestAssembly = info.GetValue<ITestAssembly>("TestAssembly");


### PR DESCRIPTION
Custom frameworks, runners, etc. may want to create custom collections for their own parallelism (or whatever) purposes, and may need to participate in the serialization too. 

In particular, I would use this for my own VSSDK extension that runs in parallel VSX integration tests across all installed versions of VS by creating a custom test collection for each IDE (which is custom-run).