### PR TITLE
change TestInvoker.InvokeTestMethodAsync from public to protected

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestInvoker.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestInvoker.cs
@@ -178,7 +178,7 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="testClassInstance">The test class instance</param>
         /// <returns>Returns the time taken to invoke the test method</returns>
-        public virtual async Task<decimal> InvokeTestMethodAsync(object testClassInstance)
+        protected virtual async Task<decimal> InvokeTestMethodAsync(object testClassInstance)
         {
             var oldSyncContext = SynchronizationContext.Current;
 

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestInvokerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestInvokerTests.cs
@@ -295,7 +295,7 @@ public class XunitTestInvokerTests
             );
         }
 
-        public override Task<decimal> InvokeTestMethodAsync(object testClassInstance)
+        protected override Task<decimal> InvokeTestMethodAsync(object testClassInstance)
         {
             if (lambda == null)
                 return base.InvokeTestMethodAsync(testClassInstance);


### PR DESCRIPTION
As discussed (https://github.com/xunit/xunit/commit/d376e851f724fc70a86634fa36522696443b9087#commitcomment-10286397).

I think this is probably a typo.

I'm not sure if you have any appetite to change this now since strictly speaking it's a breaking change to the API. On other hand, chances are low anyone's using it yet. After recent changes, I'm no longer using it in xbehave.

Anyway, here it is, FWIW.