### PR TITLE
Dispose Enumerators if possible

### DIFF
--- a/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
+++ b/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
@@ -87,20 +87,33 @@ namespace Xunit.Sdk
             if (enumerableX == null || enumerableY == null)
                 return null;
 
-            var enumeratorX = enumerableX.GetEnumerator();
-            var enumeratorY = enumerableY.GetEnumerator();
-            var equalityComparer = innerComparerFactory();
-
-            while (true)
+            IEnumerator enumeratorX = null, enumeratorY = null;
+            try
             {
-                var hasNextX = enumeratorX.MoveNext();
-                var hasNextY = enumeratorY.MoveNext();
+                enumeratorX = enumerableX.GetEnumerator();
+                enumeratorY = enumerableY.GetEnumerator();
+                var equalityComparer = innerComparerFactory();
 
-                if (!hasNextX || !hasNextY)
-                    return hasNextX == hasNextY;
+                while (true)
+                {
+                    var hasNextX = enumeratorX.MoveNext();
+                    var hasNextY = enumeratorY.MoveNext();
 
-                if (!equalityComparer.Equals(enumeratorX.Current, enumeratorY.Current))
-                    return false;
+                    if (!hasNextX || !hasNextY)
+                        return hasNextX == hasNextY;
+
+                    if (!equalityComparer.Equals(enumeratorX.Current, enumeratorY.Current))
+                        return false;
+                }
+            }
+            finally
+            {
+                var asDisposable = enumeratorX as IDisposable;
+                if (asDisposable != null)
+                    asDisposable.Dispose();
+                asDisposable = enumeratorY as IDisposable;
+                if (asDisposable != null)
+                    asDisposable.Dispose();
             }
         }
 


### PR DESCRIPTION
In some cases it is illegal to have multiple enumerators open on the same enumerable at the same time. This is the case with EntityFramework results which come from a database that doesn't support concurrent DbDataReaders (e.g. PostgreSQL).

When comparing enumerables, added a check if the enumerators are disposable, and if so, dispose them.