### PR TITLE
Allow AspNet assemblies to load correctly when treated as platform

### DIFF
--- a/src/common/SerializationHelper.cs
+++ b/src/common/SerializationHelper.cs
@@ -159,7 +159,7 @@ namespace Xunit.Sdk
             {
                 // Make sure we only use the short form for WPA81
                 var an = new AssemblyName(assemblyName);
-                assembly = Assembly.Load(new AssemblyName { Name = an.Name });
+                assembly = Assembly.Load(new AssemblyName { Name = an.Name, Version = new Version(0, 0) });
 
             }
             catch { }

--- a/src/xunit.execution/Sdk/Frameworks/TestAssembly.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestAssembly.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -56,7 +56,8 @@ namespace Xunit.Sdk
             var assemblyPath = info.GetValue<string>("AssemblyPath");
             var assembly = System.Reflection.Assembly.Load(new AssemblyName
             {
-                Name = Path.GetFileNameWithoutExtension(assemblyPath)
+                Name = Path.GetFileNameWithoutExtension(assemblyPath),
+                Version = new Version(0, 0)
             });
 
             ConfigFileName = info.GetValue<string>("ConfigFileName");

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -37,7 +37,7 @@ namespace Xunit.Sdk
                 Assembly = Assembly.Load(Path.GetFileNameWithoutExtension(assemblyFileName));
             }
 #elif WINDOWS_PHONE_APP || WINDOWS_PHONE || ASPNET50 || ASPNETCORE50
-            Assembly = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(assemblyFileName) });
+            Assembly = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(assemblyFileName), Version = new Version(0, 0) });
 #elif ANDROID
             Assembly = Assembly.Load(assemblyFileName);
 #else

--- a/src/xunit.runner.utility/Frameworks/v2/Xunit2.cs
+++ b/src/xunit.runner.utility/Frameworks/v2/Xunit2.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit.Abstractions;
@@ -37,7 +38,7 @@ namespace Xunit
             var assemblyName = assm.GetName();
 #elif WINDOWS_PHONE_APP || WINDOWS_PHONE || ASPNET50 || ASPNETCORE50
             var assm = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(assemblyFileName) });
-            var assemblyName = new AssemblyName { Name = assm.GetName().Name };
+            var assemblyName = new AssemblyName { Name = assm.GetName().Name, Version = new Version(0, 0) };
 #else
             var assemblyName = AssemblyName.GetAssemblyName(assemblyFileName);
 #endif

--- a/src/xunit.runner.utility/Frameworks/v2/Xunit2Discoverer.cs
+++ b/src/xunit.runner.utility/Frameworks/v2/Xunit2Discoverer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Reflection;
 using Xunit.Abstractions;
 
@@ -80,7 +81,7 @@ namespace Xunit
             var name = Assembly.Load(xunitExecutionAssemblyPath);
 #elif WINDOWS_PHONE_APP || WINDOWS_PHONE || ASPNET50 || ASPNETCORE50
             // WPA81 needs an AssemblyName that has the assembly short name (w/o extension)
-            var name = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(xunitExecutionAssemblyPath) }).GetName();
+            var name = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(xunitExecutionAssemblyPath), Version = new Version(0, 0) }).GetName();
 #else
             var name = AssemblyName.GetAssemblyName(xunitExecutionAssemblyPath);
 #endif


### PR DESCRIPTION
Previously, xunit assemblies were loaded by simple name, using
reflection with an AssemblyName without a version set.  This works
when the assembly is not treated as a trusted platform assembly.
When the assembly is treated as a trusted platform assembly, the bind
will fail with FUSION_E_REF_DEF_MISMATCH since binds to platform
assemblies must include a version.  By adding Version(0, 0) to the
AssemblyName, the bind will succeed because the assembly def version
will be greater than the assembly ref version.


See https://github.com/dotnet/coreclr/blob/master/src/binder/assemblybinder.cpp#L113 - prior to this change, this would succeed when fBeingBoundToPlatformAssembly was false, but fail when true.