### PR TITLE
Workaround Xamarin linker issues

### DIFF
--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -27,6 +27,17 @@
         <dependency id="xunit.extensibility.core" version="[99.99.99-dev]" />
         <dependency id="xunit.extensibility.execution" version="[99.99.99-dev]" />
       </group>
+      
+      <!-- For Xamarin.iOS and Xamarin.Android, the linker will not honor unused assemblies in the output dir; we must ref them -->
+      <group targetFramework="Xamarin.iOS">
+        <dependency id="xunit.extensibility.execution" version="[99.99.99-dev]" />
+      </group>
+      <group targetFramework="MonoTouch">
+        <dependency id="xunit.extensibility.execution" version="[99.99.99-dev]" />
+      </group>      
+      <group targetFramework="MonoAndroid">
+        <dependency id="xunit.extensibility.execution" version="[99.99.99-dev]" />
+      </group>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This PR ensures that the correct/matching execution libs are pulled into Xamarin.iOS & Android projects.

The runner app template itself (not the runner dll/nuget) has the following code `AddExecutionAssembly(typeof(ExtensibilityPointFactory).Assembly);` whose sole purpose is to ensure the Xamarin linker/packager includes the execution library.

Right now as a workaround the devices nuspec pulls in the `xunit.extensibility.execution` package for ios/android but that is incorrect as the version may not correctly match the version of xunit.core.