### PR TITLE
fix for attribute array parameter types and enums.

### DIFF
--- a/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
@@ -111,9 +111,27 @@ namespace Xunit.Sdk
             var ati = attribute.GetType();
 
             foreach (var namedArg in attributeData.NamedArguments)
-                (ati.GetRuntimeProperty(namedArg.MemberName)).SetValue(attribute, namedArg.TypedValue.Value, index: null);
+                (ati.GetRuntimeProperty(namedArg.MemberName)).SetValue(attribute, GetTypedValue(namedArg.TypedValue), index: null);
 
             return attribute;
+        }
+
+        object GetTypedValue(CustomAttributeTypedArgument arg)
+        {
+            var collect = arg.Value as IReadOnlyCollection<CustomAttributeTypedArgument>;
+
+            if (collect == null)
+                return arg.Value;
+
+            var argType = arg.ArgumentType.GetElementType();
+            Array destinationArray = Array.CreateInstance(argType, collect.Count);
+
+            if (argType.IsEnum())
+                Array.Copy(collect.Select(x => Enum.ToObject(argType, x.Value)).ToArray(), destinationArray, collect.Count);
+            else
+                Array.Copy(collect.Select(x => x.Value).ToArray(), destinationArray, collect.Count);
+
+            return destinationArray;
         }
 
         /// <inheritdoc/>

--- a/test/test.xunit.execution/Sdk/Reflection/ReflectorTests.cs
+++ b/test/test.xunit.execution/Sdk/Reflection/ReflectorTests.cs
@@ -1029,4 +1029,64 @@ public class ReflectorTests
             Assert.Single(results);
         }
     }
+
+    public class ArrayTypesFromAttribute
+    {
+        enum FactState
+        {
+            Pause = 0,
+            Start,
+            Stop
+        }
+
+        class SuperFact : Attribute
+        {
+            public int[] Numbers { get; set; }
+            public Type[] Types { get; set; }
+            public FactState[] States { get; set; }
+            public System.Collections.Generic.List<Type> ListTypes { get; set; }
+        }
+
+        [Fact]
+        [SuperFact(Numbers = new[] { 1, 2, 3 })]
+        public void ValueTypeArray()
+        {
+            var expected = new[] { 1, 2, 3 };
+            var result = typeof(ArrayTypesFromAttribute).GetMethods().Single(m => m.Name == "ValueTypeArray")
+                .CustomAttributes.Where(x => x.AttributeType.Equals(typeof(SuperFact)))
+                .Select(Reflector.Wrap)
+                .Single();
+
+            Assert.True(expected.SequenceEqual((result.Attribute as SuperFact).Numbers));
+            Assert.True(expected.SequenceEqual(result.GetNamedArgument<int[]>("Numbers")));
+        }
+
+        [Fact]
+        [SuperFact(Types = new[] { typeof(string), typeof(FactAttribute) })]
+        public void ReferenceTypeArray()
+        {
+            var expected = new[] { typeof(string), typeof(FactAttribute) };
+            var result = typeof(ArrayTypesFromAttribute).GetMethods().Single(m => m.Name == "ReferenceTypeArray")
+                .CustomAttributes.Where(x => x.AttributeType.Equals(typeof(SuperFact)))
+                .Select(Reflector.Wrap)
+                .Single();
+
+            Assert.True(expected.SequenceEqual((result.Attribute as SuperFact).Types));
+            Assert.True(expected.SequenceEqual(result.GetNamedArgument<Type[]>("Types")));
+        }
+
+        [Fact]
+        [SuperFact(States = new[] { FactState.Pause, FactState.Start, FactState.Stop })]
+        public void EnumTypeArray()
+        {
+            var expected = new[] { FactState.Pause, FactState.Start, FactState.Stop };
+            var result = typeof(ArrayTypesFromAttribute).GetMethods().Single(m => m.Name == "EnumTypeArray")
+                .CustomAttributes.Where(x => x.AttributeType.Equals(typeof(SuperFact)))
+                .Select(Reflector.Wrap)
+                .Single();
+
+            Assert.True(expected.SequenceEqual((result.Attribute as SuperFact).States));
+            Assert.True(expected.SequenceEqual(result.GetNamedArgument<FactState[]>("States")));
+        }
+    }
 }


### PR DESCRIPTION
FsCheck uses Type[] parameter on the PropertyAttribute. This PR handles this case and will help the project upgrade to XUnit2.