### PR TITLE
Fixes issue #425

### DIFF
--- a/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
@@ -43,7 +43,10 @@ namespace Xunit.Sdk
                 else if (value != null && value.GetType() != argument.ArgumentType && argument.ArgumentType.GetTypeInfo().IsEnum)
                     value = Enum.Parse(argument.ArgumentType, value.ToString());
 
-                yield return value;
+				if (value != null && value.GetType() != argument.ArgumentType && argument.ArgumentType.GetTypeInfo().IsArray)
+					value = Reflector.ConvertArguments(new[] { value }, new[] { argument.ArgumentType })[0];
+				
+				yield return value;
             }
         }
 

--- a/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
@@ -138,7 +138,27 @@ public class Xunit2TheoryAcceptanceTests
             [InlineData(new[] { 42, 2112 }, new[] { "SELF", "PARENT1", "PARENT2", "PARENT3" }, null, 10.5, "Hello, world!")]
             public void TestMethod(int[] v1, string[] v2, float[] v3, double v4, string v5) { }
         }
-    }
+
+
+		[Fact]
+		public void ValueArraysWithObjectParameterInjectCorrectType()
+		{
+			var testMessages = Run<ITestResultMessage>(typeof(ClassUnderTestForValueArraysWithObjectParameter));
+
+			var passing = Assert.Single(testMessages.Cast<ITestPassed>());
+			Assert.Contains("Xunit2TheoryAcceptanceTests+InlineDataTests+ClassUnderTestForValueArraysWithObjectParameter.TestMethod", passing.Test.DisplayName);
+		}
+
+		class ClassUnderTestForValueArraysWithObjectParameter
+		{
+			[Theory]
+			[InlineData(new[] { 42, 2112 }, typeof(int[]))]
+			public void TestMethod(object value, Type expected)
+			{
+				Assert.IsType(expected, value);
+			}
+		}
+	}
 
     public class MissingDataTests : AcceptanceTestV2
     {


### PR DESCRIPTION
This pull request fixes issue #425.

The issue came from the values of the `InlineDataAttribute` not being converted to the right type if the destination type defined in the test method is object.