### PR TITLE
Use full version number to prevent issues runing on Wpa81

### DIFF
--- a/src/common/SerializationHelper.cs
+++ b/src/common/SerializationHelper.cs
@@ -159,7 +159,7 @@ namespace Xunit.Sdk
             {
                 // Make sure we only use the short form for WPA81
                 var an = new AssemblyName(assemblyName);
-                assembly = Assembly.Load(new AssemblyName { Name = an.Name, Version = new Version(0, 0) });
+                assembly = Assembly.Load(new AssemblyName { Name = an.Name, Version = new Version(0, 0, 0, 0) });
 
             }
             catch { }

--- a/src/xunit.execution/Sdk/Frameworks/TestAssembly.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestAssembly.cs
@@ -57,7 +57,7 @@ namespace Xunit.Sdk
             var assembly = System.Reflection.Assembly.Load(new AssemblyName
             {
                 Name = Path.GetFileNameWithoutExtension(assemblyPath),
-                Version = new Version(0, 0)
+                Version = new Version(0, 0, 0, 0)
             });
 
             ConfigFileName = info.GetValue<string>("ConfigFileName");

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
@@ -37,7 +37,7 @@ namespace Xunit.Sdk
                 Assembly = Assembly.Load(Path.GetFileNameWithoutExtension(assemblyFileName));
             }
 #elif WINDOWS_PHONE_APP || WINDOWS_PHONE || DNX451 || DNXCORE50
-            Assembly = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(assemblyFileName), Version = new Version(0, 0) });
+            Assembly = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(assemblyFileName), Version = new Version(0, 0, 0, 0) });
 #elif ANDROID
             Assembly = Assembly.Load(assemblyFileName);
 #else

--- a/src/xunit.runner.utility/Frameworks/v2/Xunit2.cs
+++ b/src/xunit.runner.utility/Frameworks/v2/Xunit2.cs
@@ -38,7 +38,7 @@ namespace Xunit
             var assemblyName = assm.GetName();
 #elif WINDOWS_PHONE_APP || WINDOWS_PHONE || DNX451 || DNXCORE50
             var assm = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(assemblyFileName) });
-            var assemblyName = new AssemblyName { Name = assm.GetName().Name, Version = new Version(0, 0) };
+            var assemblyName = new AssemblyName { Name = assm.GetName().Name, Version = new Version(0, 0, 0, 0) };
 #else
             var assemblyName = AssemblyName.GetAssemblyName(assemblyFileName);
 #endif

--- a/src/xunit.runner.utility/Frameworks/v2/Xunit2Discoverer.cs
+++ b/src/xunit.runner.utility/Frameworks/v2/Xunit2Discoverer.cs
@@ -81,7 +81,7 @@ namespace Xunit
             var name = Assembly.Load(xunitExecutionAssemblyPath);
 #elif WINDOWS_PHONE_APP || WINDOWS_PHONE || DNX451 || DNXCORE50
             // WPA81 needs an AssemblyName that has the assembly short name (w/o extension)
-            var name = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(xunitExecutionAssemblyPath), Version = new Version(0, 0) }).GetName();
+            var name = Assembly.Load(new AssemblyName { Name = Path.GetFileNameWithoutExtension(xunitExecutionAssemblyPath), Version = new Version(0, 0, 0, 0) }).GetName();
 #else
             var name = AssemblyName.GetAssemblyName(xunitExecutionAssemblyPath);
 #endif


### PR DESCRIPTION
This has not been tested yet, but this should address the error we're seeing:

Could not load file or assembly 'v2_WPA81, Version=0.0.65535.65535, Culture=neutral, PublicKeyToken=null' 

The v2_WPA81.dll has a default version of 0.0.0.0 and the load is asking for a higher version.
