### PR TITLE
build: Enables FreeBSD support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! [ -x "$(command -v mono)" ]; then
   echo >&2 "Could not find 'mono' on the path."


### PR DESCRIPTION
Changed hardcoded bash shebang to env to support multiple directory
structures (required to build on FreeBSD).