### PR TITLE
Improve xunit perf, in particular for Theory test case discovery

### DIFF
--- a/src/common/SerializationHelper.cs
+++ b/src/common/SerializationHelper.cs
@@ -64,6 +64,14 @@ namespace Xunit.Sdk
             return string.Format("{0}:{1}", GetTypeNameForSerialization(value.GetType()), serializationInfo.ToSerializedString());
         }
 
+        /// <summary>Gets whether the specified <paramref name="value"/> is serializable with <see cref="Serialize"/>.</summary>
+        /// <param name="value">The object to test for serializability.</param>
+        /// <returns>true if the object can be serialized; otherwise, false.</returns>
+        internal static bool IsSerializable(object value)
+        {
+            return XunitSerializationInfo.CanSerializeObject(value);
+        }
+
         /// <summary>
         /// Converts an assembly qualified type name into a <see cref="Type"/> object.
         /// </summary>

--- a/src/common/SerializationHelper.cs
+++ b/src/common/SerializationHelper.cs
@@ -107,8 +107,8 @@ namespace Xunit.Sdk
                             return null;
 
                         var genericArgument = assemblyQualifiedTypeName.Substring(firstOpenSquare + 1, lastOpenSquare - firstOpenSquare - 2);  // Strip surrounding [ and ]
-                        var innerTypeNames = SplitAtOuterCommas(genericArgument).Select(x => x.Substring(1, x.Length - 2)).ToArray();  // Strip surrounding [ and ] from each type name
-                        var innerTypes = innerTypeNames.Select(GetType).ToArray();
+                        var innerTypeNames = SplitAtOuterCommas(genericArgument).Select(x => x.Substring(1, x.Length - 2));  // Strip surrounding [ and ] from each type name
+                        var innerTypes = innerTypeNames.Select(s => GetType(s)).ToArray();
                         if (innerTypes.Any(t => t == null))
                             return null;
 
@@ -140,14 +140,11 @@ namespace Xunit.Sdk
                 }
             }
 
-            var parts = SplitAtOuterCommas(assemblyQualifiedTypeName).Select(x => x.Trim()).ToList();
-            if (parts.Count == 0)
-                return null;
-
-            if (parts.Count == 1)
-                return Type.GetType(parts[0]);
-
-            return GetType(parts[1], parts[0]);
+            IList<string> parts = SplitAtOuterCommas(assemblyQualifiedTypeName, trimWhitespace: true);
+            return 
+                parts.Count == 0 ? null :
+                parts.Count == 1 ? Type.GetType(parts[0]) :
+                GetType(parts[1], parts[0]);
         }
 
         /// <summary>
@@ -234,9 +231,32 @@ namespace Xunit.Sdk
             return string.Format("{0}, {1}", typeName, assemblyName);
         }
 
-        private static IList<string> SplitAtOuterCommas(string value)
+        /// <summary>
+        /// Retrieves a substring from the string, with whitespace trimmed on both ends.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <param name="startIndex">The starting index.</param>
+        /// <param name="length">The length.</param>
+        /// <returns>
+        /// A substring starting no earlier than startIndex and ending no later
+        /// than startIndex + length.
+        /// </returns>
+        private static string SubstringTrim(string str, int startIndex, int length)
         {
-            var results = new List<string>();
+            int endIndex = startIndex + length;
+
+            while (startIndex < endIndex && char.IsWhiteSpace(str[startIndex]))
+                startIndex++;
+
+            while (endIndex > startIndex && char.IsWhiteSpace(str[endIndex - 1]))
+                endIndex--;
+
+            return str.Substring(startIndex, endIndex - startIndex);
+        }
+
+        private static IList<string> SplitAtOuterCommas(string value, bool trimWhitespace = false)
+        {
+            List<string> results = new List<string>();
 
             var startIndex = 0;
             var endIndex = 0;
@@ -251,7 +271,9 @@ namespace Xunit.Sdk
                     case ',':
                         if (depth == 0)
                         {
-                            results.Add(value.Substring(startIndex, endIndex - startIndex));
+                            results.Add(trimWhitespace ?
+                                SubstringTrim(value, startIndex, endIndex - startIndex) :
+                                value.Substring(startIndex, endIndex - startIndex));
                             startIndex = endIndex + 1;
                         }
                         break;
@@ -259,9 +281,16 @@ namespace Xunit.Sdk
             }
 
             if (depth != 0 || startIndex >= endIndex)
-                return new List<string>();
+            {
+                results.Clear();
+            }
+            else
+            {
+                results.Add(trimWhitespace ?
+                    SubstringTrim(value, startIndex, endIndex - startIndex) :
+                    value.Substring(startIndex, endIndex - startIndex));
+            }
 
-            results.Add(value.Substring(startIndex, endIndex - startIndex));
             return results;
         }
     }

--- a/src/common/TestMessageVisitor.cs
+++ b/src/common/TestMessageVisitor.cs
@@ -31,44 +31,62 @@ namespace Xunit
             return true;
         }
 
+        /// <summary>
+        /// Dispatches the message to the given callback, if it's of the correct type.
+        /// The callback is provided with both the message and this instance of the visitor.
+        /// </summary>
+        /// <typeparam name="TMessage">The message type</typeparam>
+        /// <param name="message">The message</param>
+        /// <param name="callback">The callback</param>
+        /// <returns>The result of the callback, if called; <c>true</c>, otherwise</returns>
+        private bool DoVisit<TMessage>(IMessageSinkMessage message, Func<TestMessageVisitor, TMessage, bool> callback)
+            where TMessage : class, IMessageSinkMessage
+        {
+            var castMessage = message as TMessage;
+            if (castMessage != null)
+                return callback(this, castMessage);
+
+            return true;
+        }
+
         /// <inheritdoc/>
         public virtual bool OnMessage(IMessageSinkMessage message)
         {
             return
-                DoVisit<IAfterTestFinished>(message, Visit) &&
-                DoVisit<IAfterTestStarting>(message, Visit) &&
-                DoVisit<IBeforeTestFinished>(message, Visit) &&
-                DoVisit<IBeforeTestStarting>(message, Visit) &&
-                DoVisit<IDiagnosticMessage>(message, Visit) &&
-                DoVisit<IDiscoveryCompleteMessage>(message, Visit) &&
-                DoVisit<IErrorMessage>(message, Visit) &&
-                DoVisit<ITestAssemblyCleanupFailure>(message, Visit) &&
-                DoVisit<ITestAssemblyFinished>(message, Visit) &&
-                DoVisit<ITestAssemblyStarting>(message, Visit) &&
-                DoVisit<ITestCaseCleanupFailure>(message, Visit) &&
-                DoVisit<ITestCaseDiscoveryMessage>(message, Visit) &&
-                DoVisit<ITestCaseFinished>(message, Visit) &&
-                DoVisit<ITestOutput>(message, Visit) &&
-                DoVisit<ITestCaseStarting>(message, Visit) &&
-                DoVisit<ITestClassCleanupFailure>(message, Visit) &&
-                DoVisit<ITestClassConstructionFinished>(message, Visit) &&
-                DoVisit<ITestClassConstructionStarting>(message, Visit) &&
-                DoVisit<ITestClassDisposeFinished>(message, Visit) &&
-                DoVisit<ITestClassDisposeStarting>(message, Visit) &&
-                DoVisit<ITestClassFinished>(message, Visit) &&
-                DoVisit<ITestClassStarting>(message, Visit) &&
-                DoVisit<ITestCleanupFailure>(message, Visit) &&
-                DoVisit<ITestCollectionCleanupFailure>(message, Visit) &&
-                DoVisit<ITestCollectionFinished>(message, Visit) &&
-                DoVisit<ITestCollectionStarting>(message, Visit) &&
-                DoVisit<ITestFailed>(message, Visit) &&
-                DoVisit<ITestFinished>(message, Visit) &&
-                DoVisit<ITestMethodCleanupFailure>(message, Visit) &&
-                DoVisit<ITestMethodFinished>(message, Visit) &&
-                DoVisit<ITestMethodStarting>(message, Visit) &&
-                DoVisit<ITestPassed>(message, Visit) &&
-                DoVisit<ITestSkipped>(message, Visit) &&
-                DoVisit<ITestStarting>(message, Visit);
+                DoVisit<IAfterTestFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<IAfterTestStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<IBeforeTestFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<IBeforeTestStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<IDiagnosticMessage>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<IDiscoveryCompleteMessage>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<IErrorMessage>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestAssemblyCleanupFailure>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestAssemblyFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestAssemblyStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCaseCleanupFailure>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCaseDiscoveryMessage>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCaseFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestOutput>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCaseStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassCleanupFailure>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassConstructionFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassConstructionStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassDisposeFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassDisposeStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestClassStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCleanupFailure>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCollectionCleanupFailure>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCollectionFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestCollectionStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestFailed>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestMethodCleanupFailure>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestMethodFinished>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestMethodStarting>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestPassed>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestSkipped>(message, (t, m) => t.Visit(m)) &&
+                DoVisit<ITestStarting>(message, (t, m) => t.Visit(m));
         }
 
         /// <summary>

--- a/src/common/XunitWorkerThread_Thread.cs
+++ b/src/common/XunitWorkerThread_Thread.cs
@@ -9,8 +9,8 @@ namespace Xunit.Sdk
 
         public XunitWorkerThread(Action threadProc)
         {
-            thread = new Thread(() => threadProc()) { IsBackground = true };
-            thread.Start();
+            thread = new Thread(s => ((Action)s)()) { IsBackground = true };
+            thread.Start(threadProc);
         }
 
         public void Join()
@@ -21,7 +21,7 @@ namespace Xunit.Sdk
 
         public static void QueueUserWorkItem(Action backgroundTask)
         {
-            ThreadPool.QueueUserWorkItem(_ => backgroundTask());
+            ThreadPool.QueueUserWorkItem(s => ((Action)s)(), backgroundTask);
         }
     }
 }

--- a/src/messages/BaseMessages/TestAssemblyMessage.cs
+++ b/src/messages/BaseMessages/TestAssemblyMessage.cs
@@ -22,6 +22,15 @@ namespace Xunit
             TestCases = testCases.ToList();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestAssemblyMessage"/> class.
+        /// </summary>
+        internal TestAssemblyMessage(ITestCase testCase, ITestAssembly testAssembly)
+        {
+            TestAssembly = testAssembly;
+            TestCases = new ITestCase[] { testCase };
+        }
+
         /// <inheritdoc/>
         public ITestAssembly TestAssembly { get; set; }
 

--- a/src/messages/BaseMessages/TestCaseMessage.cs
+++ b/src/messages/BaseMessages/TestCaseMessage.cs
@@ -16,7 +16,7 @@ namespace Xunit
         /// Initializes a new instance of the <see cref="TestCaseMessage"/> class.
         /// </summary>
         public TestCaseMessage(ITestCase testCase)
-            : base(new[] { testCase }, testCase.TestMethod) { }
+            : base(testCase, testCase.TestMethod) { }
 
         /// <inheritdoc/>
         public ITestCase TestCase { get { return TestCases.FirstOrDefault(); } }

--- a/src/messages/BaseMessages/TestClassMessage.cs
+++ b/src/messages/BaseMessages/TestClassMessage.cs
@@ -21,6 +21,15 @@ namespace Xunit
             TestClass = testClass;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestClassMessage"/> class.
+        /// </summary>
+        internal TestClassMessage(ITestCase testCase, ITestClass testClass)
+            : base(testCase, testClass.TestCollection)
+        {
+            TestClass = testClass;
+        }
+
         /// <inheritdoc/>
         public ITestClass TestClass { get; set; }
     }

--- a/src/messages/BaseMessages/TestCollectionMessage.cs
+++ b/src/messages/BaseMessages/TestCollectionMessage.cs
@@ -21,6 +21,15 @@ namespace Xunit
             TestCollection = testCollection;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestCollectionMessage"/> class.
+        /// </summary>
+        internal TestCollectionMessage(ITestCase testCase, ITestCollection testCollection)
+            : base(testCase, testCollection.TestAssembly)
+        {
+            TestCollection = testCollection;
+        }
+
         /// <inheritdoc/>
         public ITestCollection TestCollection { get; private set; }
     }

--- a/src/messages/BaseMessages/TestMethodMessage.cs
+++ b/src/messages/BaseMessages/TestMethodMessage.cs
@@ -21,6 +21,15 @@ namespace Xunit
             TestMethod = testMethod;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestMethodMessage"/> class.
+        /// </summary>
+        internal TestMethodMessage(ITestCase testCase, ITestMethod testMethod)
+            : base(testCase, testMethod.TestClass)
+        {
+            TestMethod = testMethod;
+        }
+
         /// <inheritdoc/>
         public ITestMethod TestMethod { get; set; }
     }

--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestAssemblyRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestAssemblyRunner.cs
@@ -118,7 +118,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task AfterTestAssemblyStartingAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task BeforeTestAssemblyFinishedAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestCaseRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestCaseRunner.cs
@@ -56,7 +56,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task AfterTestCaseStartingAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task BeforeTestCaseFinishedAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestClassRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestClassRunner.cs
@@ -140,7 +140,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task AfterTestClassStartingAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task BeforeTestClassFinishedAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestCollectionRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestCollectionRunner.cs
@@ -75,7 +75,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task AfterTestCollectionStartingAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task BeforeTestCollectionFinishedAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestInvoker.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestInvoker.cs
@@ -131,7 +131,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task AfterTestMethodInvokedAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Xunit.Sdk
         /// </summary>
         protected virtual Task BeforeTestMethodInvokedAsync()
         {
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <summary>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs
@@ -150,14 +150,14 @@ namespace Xunit.Sdk
         protected override Task AfterTestAssemblyStartingAsync()
         {
             Initialize();
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>
         protected override Task BeforeTestAssemblyFinishedAsync()
         {
             SetSynchronizationContext(originalSyncContext);
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCaseRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCaseRunner.cs
@@ -42,7 +42,11 @@ namespace Xunit.Sdk
             TestClass = TestCase.TestMethod.TestClass.Class.ToRuntimeType();
             TestMethod = TestCase.Method.ToRuntimeMethod();
 
-            var parameterTypes = TestMethod.GetParameters().Select(p => p.ParameterType).ToArray();
+            ParameterInfo[] parameters = TestMethod.GetParameters();
+            Type[] parameterTypes = new Type[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+                parameterTypes[i] = parameters[i].ParameterType;
+
             TestMethodArguments = Reflector.ConvertArguments(testMethodArguments, parameterTypes);
 
             beforeAfterAttributes =

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestClassRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestClassRunner.cs
@@ -100,7 +100,7 @@ namespace Xunit.Sdk
                     CreateFixture(interfaceType);
             }
 
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>
@@ -109,7 +109,7 @@ namespace Xunit.Sdk
             foreach (var fixture in ClassFixtureMappings.Values.OfType<IDisposable>())
                 Aggregator.Run(fixture.Dispose);
 
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunner.cs
@@ -82,7 +82,7 @@ namespace Xunit.Sdk
                 }
             }
 
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>
@@ -91,7 +91,7 @@ namespace Xunit.Sdk
             foreach (var fixture in CollectionFixtureMappings.Values.OfType<IDisposable>())
                 Aggregator.Run(fixture.Dispose);
 
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestInvoker.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestInvoker.cs
@@ -80,7 +80,7 @@ namespace Xunit.Sdk
                     break;
             }
 
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
 
         /// <inheritdoc/>
@@ -98,7 +98,7 @@ namespace Xunit.Sdk
                     CancellationTokenSource.Cancel();
             }
 
-            return Task.FromResult(0);
+            return CommonTasks.Completed;
         }
     }
 }

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestRunner.cs
@@ -55,7 +55,15 @@ namespace Xunit.Sdk
         protected override async Task<Tuple<decimal, string>> InvokeTestAsync(ExceptionAggregator aggregator)
         {
             var output = string.Empty;
-            var testOutputHelper = ConstructorArguments.OfType<TestOutputHelper>().FirstOrDefault();
+
+            TestOutputHelper testOutputHelper = null;
+            foreach (object obj in ConstructorArguments)
+            {
+                testOutputHelper = obj as TestOutputHelper;
+                if (testOutputHelper != null)
+                    break;
+            }
+
             if (testOutputHelper != null)
                 testOutputHelper.Initialize(MessageBus, Test);
 
@@ -75,9 +83,9 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="aggregator">The exception aggregator used to run code and collect exceptions.</param>
         /// <returns>Returns the execution time (in seconds) spent running the test method.</returns>
-        protected virtual async Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
+        protected virtual Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
         {
-            return await new XunitTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource).RunAsync();
+            return new XunitTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource).RunAsync();
         }
     }
 }

--- a/src/xunit.execution/Sdk/Frameworks/TheoryDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TheoryDiscoverer.cs
@@ -51,12 +51,12 @@ namespace Xunit.Sdk
                         // down below so that we get the composite test case.
                         foreach (var dataRow in discoverer.GetData(dataAttribute, testMethod.Method))
                         {
-                            // Attempt to serialize the test case, since we need a way to uniquely identify a test
-                            // and serialization is the best way to do that. If it's not serializable, this will
-                            // throw and we will fall back to a single theory test case that gets its data
-                            // at runtime.
+                            // Determine whether we can serialize the test case, since we need a way to uniquely 
+                            // identify a test and serialization is the best way to do that. If it's not serializable, 
+                            // this will throw and we will fall back to a single theory test case that gets its data at runtime.
                             var testCase = new XunitTestCase(diagnosticMessageSink, defaultMethodDisplay, testMethod, dataRow);
-                            SerializationHelper.Serialize(testCase);
+                            if (!SerializationHelper.IsSerializable(dataRow))
+                                return new XunitTestCase[] { new XunitTheoryTestCase(diagnosticMessageSink, defaultMethodDisplay, testMethod) };
                             results.Add(testCase);
                         }
                     }
@@ -67,7 +67,7 @@ namespace Xunit.Sdk
 
                     return results;
                 }
-                catch { }  // If there are serialization issues with the theory data, fall through to return just the XunitTestCase
+                catch { }  // If something goes wrong, fall through to return just the XunitTestCase
             }
 
             return new XunitTestCase[] { new XunitTheoryTestCase(diagnosticMessageSink, defaultMethodDisplay, testMethod) };

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscoverer.cs
@@ -70,7 +70,7 @@ namespace Xunit.Sdk
         /// <returns>Return <c>true</c> to continue test discovery, <c>false</c>, otherwise.</returns>
         protected virtual bool FindTestsForMethod(ITestMethod testMethod, bool includeSourceInformation, IMessageBus messageBus, ITestFrameworkDiscoveryOptions discoveryOptions)
         {
-            var factAttributes = testMethod.Method.GetCustomAttributes(typeof(FactAttribute)).ToList();
+            var factAttributes = testMethod.Method.GetCustomAttributes(typeof(FactAttribute)).CastOrToList();
             if (factAttributes.Count > 1)
             {
                 var message = string.Format("Test method '{0}.{1}' has multiple [Fact]-derived attributes", testMethod.TestClass.Class.Name, testMethod.Method.Name);

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
@@ -73,7 +73,7 @@ namespace Xunit.Sdk
             return Assembly.CustomAttributes
                            .Where(attr => attributeType.GetTypeInfo().IsAssignableFrom(attr.AttributeType.GetTypeInfo()))
                            .OrderBy(attr => attr.AttributeType.Name)
-                           .Select(Reflector.Wrap)
+                           .Select(a => Reflector.Wrap(a))
                            .Cast<IAttributeInfo>()
                            .ToList();
         }
@@ -92,11 +92,11 @@ namespace Xunit.Sdk
 
             try
             {
-                return selector.Select(Reflector.Wrap).Cast<ITypeInfo>();
+                return selector.Select(t => Reflector.Wrap(t)).Cast<ITypeInfo>();
             }
             catch (ReflectionTypeLoadException ex)
             {
-                return ex.Types.Select(Reflector.Wrap).Cast<ITypeInfo>();
+                return ex.Types.Select(t => Reflector.Wrap(t)).Cast<ITypeInfo>();
             }
         }
 

--- a/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
@@ -130,13 +130,32 @@ namespace Xunit.Sdk
             if (baseType == null)
                 return null;
 
-            var methodParameters = method.GetParameters().Select(p => p.ParameterType).ToArray();
+            var methodParameters = method.GetParameters();
             var methodGenericArgCount = method.GetGenericArguments().Length;
 
-            return baseType.GetMatchingMethods(method)
-                           .FirstOrDefault(m => m.Name == method.Name
-                                             && m.GetGenericArguments().Length == methodGenericArgCount
-                                             && TypeListComparer.Equals(m.GetParameters().Select(p => p.ParameterType).ToArray(), methodParameters));
+            foreach (MethodInfo m in baseType.GetMatchingMethods(method))
+            {
+                if (m.Name == method.Name &&
+                    m.GetGenericArguments().Length == methodGenericArgCount &&
+                    ParametersHaveSameTypes(methodParameters, m.GetParameters()))
+                    return m;
+            }
+
+            return null;
+        }
+
+        private static bool ParametersHaveSameTypes(ParameterInfo[] left, ParameterInfo[] right)
+        {
+            if (left.Length != right.Length)
+                return false;
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (!TypeComparer.Equals(left[i].ParameterType, right[i].ParameterType))
+                    return false;
+            }
+
+            return true;
         }
 
         /// <inheritdoc/>

--- a/src/xunit.execution/Sdk/Reflection/ReflectionTypeInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionTypeInfo.cs
@@ -35,7 +35,7 @@ namespace Xunit.Sdk
         /// <inheritdoc/>
         public IEnumerable<ITypeInfo> Interfaces
         {
-            get { return Type.GetTypeInfo().ImplementedInterfaces.Select(Reflector.Wrap).Cast<ITypeInfo>().ToList(); }
+            get { return Type.GetTypeInfo().ImplementedInterfaces.Select(i => Reflector.Wrap(i)).ToList(); }
         }
 
         /// <inheritdoc/>
@@ -80,14 +80,14 @@ namespace Xunit.Sdk
         /// <inheritdoc/>
         public IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName)
         {
-            return ReflectionAttributeInfo.GetCustomAttributes(Type, assemblyQualifiedAttributeTypeName).ToList();
+            return ReflectionAttributeInfo.GetCustomAttributes(Type, assemblyQualifiedAttributeTypeName).CastOrToList();
         }
 
         /// <inheritdoc/>
         public IEnumerable<ITypeInfo> GetGenericArguments()
         {
             return Type.GetTypeInfo().GenericTypeArguments
-                       .Select(Reflector.Wrap)
+                       .Select(t => Reflector.Wrap(t))
                        .ToList();
         }
 
@@ -105,10 +105,12 @@ namespace Xunit.Sdk
         /// <inheritdoc/>
         public IEnumerable<IMethodInfo> GetMethods(bool includePrivateMethods)
         {
-            return Type.GetRuntimeMethods().Where(m => includePrivateMethods || m.IsPublic)
-                       .Select(Reflector.Wrap)
-                       .Cast<IMethodInfo>()
-                       .ToList();
+            var methodInfos = Type.GetRuntimeMethods();
+            if (!includePrivateMethods)
+            {
+                methodInfos = methodInfos.Where(m => m.IsPublic);
+            }
+            return methodInfos.Select(m => Reflector.Wrap(m)).ToList();
         }
 
         /// <inheritdoc/>

--- a/src/xunit.execution/Sdk/Reflection/Reflector.cs
+++ b/src/xunit.execution/Sdk/Reflection/Reflector.cs
@@ -11,7 +11,7 @@ namespace Xunit.Sdk
     /// </summary>
     public static class Reflector
     {
-        readonly static object[] EmptyArgs = new object[0];
+        internal readonly static object[] EmptyArgs = new object[0];
         readonly static Type[] EmptyTypes = new Type[0];
         readonly static MethodInfo EnumerableCast = typeof(Enumerable).GetRuntimeMethods().First(m => m.Name == "Cast");
         readonly static MethodInfo EnumerableToArray = typeof(Enumerable).GetRuntimeMethods().First(m => m.Name == "ToArray");

--- a/src/xunit.execution/Sdk/Reflection/Reflector.cs
+++ b/src/xunit.execution/Sdk/Reflection/Reflector.cs
@@ -12,7 +12,8 @@ namespace Xunit.Sdk
     public static class Reflector
     {
         internal readonly static object[] EmptyArgs = new object[0];
-        readonly static Type[] EmptyTypes = new Type[0];
+        internal readonly static Type[] EmptyTypes = new Type[0];
+
         readonly static MethodInfo EnumerableCast = typeof(Enumerable).GetRuntimeMethods().First(m => m.Name == "Cast");
         readonly static MethodInfo EnumerableToArray = typeof(Enumerable).GetRuntimeMethods().First(m => m.Name == "ToArray");
 
@@ -31,31 +32,38 @@ namespace Xunit.Sdk
                 types = EmptyTypes;
 
             if (args.Length == types.Length)
+            {
                 for (var idx = 0; idx < args.Length; idx++)
                 {
-                    try
-                    {
-                        var type = types[idx];
-                        var arg = args[idx];
-
-                        if (arg == null || arg.GetType() == type)
-                            continue;
-
-                        if (type.IsArray)
-                        {
-                            var elementType = type.GetElementType();
-                            var enumerable = (IEnumerable<object>)arg;
-                            var castMethod = EnumerableCast.MakeGenericMethod(elementType);
-                            var toArrayMethod = EnumerableToArray.MakeGenericMethod(elementType);
-                            args[idx] = toArrayMethod.Invoke(null, new object[] { castMethod.Invoke(null, new object[] { enumerable }) });
-                        }
-                        else
-                            args[idx] = Convert.ChangeType(arg, type);
-                    }
-                    catch { }  // Eat conversion-related exceptions; they'll get re-surfaced during execution
+                    args[idx] = ConvertArgument(args[idx], types[idx]);
                 }
+            }
 
             return args;
+        }
+
+        internal static object ConvertArgument(object arg, Type type)
+        {
+            if (arg != null && arg.GetType() != type)
+            {
+                try
+                {
+                    if (type.IsArray)
+                    {
+                        var elementType = type.GetElementType();
+                        var enumerable = (IEnumerable<object>)arg;
+                        var castMethod = EnumerableCast.MakeGenericMethod(elementType);
+                        var toArrayMethod = EnumerableToArray.MakeGenericMethod(elementType);
+                        return toArrayMethod.Invoke(null, new object[] { castMethod.Invoke(null, new object[] { enumerable }) });
+                    }
+                    else
+                    {
+                        return Convert.ChangeType(arg, type);
+                    }
+                }
+                catch { } // Eat conversion-related exceptions; they'll get re-surfaced during execution
+            }
+            return arg;
         }
 
         /// <summary>

--- a/src/xunit.execution/Sdk/TypeUtility.cs
+++ b/src/xunit.execution/Sdk/TypeUtility.cs
@@ -53,7 +53,7 @@ namespace Xunit.Sdk
             if (arguments == null)
                 return baseDisplayName;
 
-            var parameterInfos = method.GetParameters().ToArray();
+            var parameterInfos = method.GetParameters().CastOrToArray();
             var displayValues = new string[Math.Max(arguments.Length, parameterInfos.Length)];
             int idx;
 
@@ -139,7 +139,7 @@ namespace Xunit.Sdk
         {
             var genericTypes = method.GetGenericArguments().ToArray();
             var resolvedTypes = new ITypeInfo[genericTypes.Length];
-            var parameterInfos = method.GetParameters().ToArray();
+            var parameterInfos = method.GetParameters().CastOrToArray();
 
             for (var idx = 0; idx < genericTypes.Length; ++idx)
                 resolvedTypes[idx] = ResolveGenericType(genericTypes[idx], parameters, parameterInfos);

--- a/src/xunit.execution/Sdk/Utility/CollectionExtensions.cs
+++ b/src/xunit.execution/Sdk/Utility/CollectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+
+namespace Xunit.Sdk
+{
+    internal static class CollectionExtensions
+    {
+        public static List<T> CastOrToList<T>(this IEnumerable<T> source)
+        {
+            return source as List<T> ?? source.ToList();
+        }
+
+        public static T[] CastOrToArray<T>(this IEnumerable<T> source)
+        {
+            return source as T[] ?? source.ToArray();
+        }
+    }
+}

--- a/src/xunit.execution/Sdk/Utility/CommonTasks.cs
+++ b/src/xunit.execution/Sdk/Utility/CommonTasks.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Xunit.Sdk
+{
+    internal static class CommonTasks
+    {
+        internal static readonly Task Completed = Task.FromResult(0);
+    }
+}


### PR DESCRIPTION
Over at https://github.com/dotnet/corefx, we're starting to use [Theory]ies more aggressively, and we're contemplating some usage that could result in tens of thousands of entries for a given test suite.  Today, this results in some significant performance penalties.

For example, given this test with 40,000 entries:
```C#
public static IEnumerable<object[]> LotsOfData
{
    get
    {
        for (int i = 0; i < 40000; i++)
            yield return new object[] { i, "This is a some data.", "And this is some more data." };
    }
}

[Theory]
[MemberData("LotsOfData")]
public static void TheoryTestWithLotsOfData(int i, string data, string moreData)
{
}
```
on my machine it takes xunit ~30 seconds to discover and run the tests, spending ~21 seconds on discovery and then ~9 seconds on test execution.

I spent some time iteratively profiling for both CPU usage and memory allocations and eliminating the top offenders, mostly low-hanging fruit.  With the commits in this PR, the above example on my machine has discovery time drop from ~21 seconds to ~0.25 seconds, and test execution time drop from ~9 seconds to ~8 seconds, for a total reduction from ~30 seconds to ~8 seconds.

The individual commits have more detail on the exact changes made.

This PR makes a sizeable dent in allocations, but there's still lots of work that can be done to improve things further.  Just as an example, here's a table showing the top-allocated objects, and how many times per test they're being allocated for my earlier example (so multiply each number by 40,000 to get the appx number of allocations for all of the tests together).  I've only shown types of objects allocated 15 or more times per test:

| Type | Number Before | Number After |
| --- | --- | --- |
| String |  278  | 51 |
| Func`2 | 220 | 0  |
| RuntimeMethodInfoStub | 68 | 8  |
| IntPtr | 61 |  1 |
| String[] | 54 |  8 |
| Char[] | 43 | 0  |
| List`1 |  39  | 22 |
| Object[] |  39 | 15 |
| Int[] | 36 | 2  |
| Stack`1 | 23 | 1 |
| CustomAttributeRecord[] | 20  | 14 |
| XunitSerializationTriple | 20 |  0 |
| Attribute[] | 19  |  9 |
| Byte[] | 18 |  0 |
| StringBuilder | 16 | 0  |
| SZGenericArrayEnumerator | 15 |  5 |

There's a very long tail of object types that get allocated twice or once per test as well, but the list was too long to type out here :smile:.