### PR TITLE
Don't use shadow copy in TestDriven runner...

### DIFF
--- a/src/xunit.runner.tdnet/TdNetRunnerHelper.cs
+++ b/src/xunit.runner.tdnet/TdNetRunnerHelper.cs
@@ -27,7 +27,7 @@ namespace Xunit.Runner.TdNet
             var assemblyFileName = assembly.GetLocalCodeBase();
             configuration = ConfigReader.Load(assemblyFileName);
             var diagnosticMessageVisitor = new DiagnosticMessageVisitor(testListener, Path.GetFileNameWithoutExtension(assemblyFileName), configuration.DiagnosticMessagesOrDefault);
-            xunit = new Xunit2(configuration.UseAppDomainOrDefault, new NullSourceInformationProvider(), assemblyFileName, diagnosticMessageSink: diagnosticMessageVisitor);
+            xunit = new Xunit2(configuration.UseAppDomainOrDefault, new NullSourceInformationProvider(), assemblyFileName, shadowCopy: false, diagnosticMessageSink: diagnosticMessageVisitor);
             toDispose.Push(xunit);
         }
 


### PR DESCRIPTION
It appears that with the switch to xunit2 (commit 5701328f), the shadow copy behavior for the TestDriven runner changed from ```false``` to default (```true```).

Unless this change was fixing another issue, I'd like to propose reverting to the old shadow copy behavior.  Right now, I'm having trouble moving to xunit 2.0, because the assemblies I need to test are delay signed, and the CLR doesn't allow delay signed assemblies to be shadow copied.  With the command line runner, I can pass /noshadow, but I don't seem to have a similar option when running tests from VS with TestDriven.

I tried this out, and I don't believe it will cause the files in the output directory to become locked (I could run tests and then rebuild without any issues).