### PR TITLE
Added namespace filtering to console runner

### DIFF
--- a/src/xunit.console/CommandLine.cs
+++ b/src/xunit.console/CommandLine.cs
@@ -269,6 +269,13 @@ namespace Xunit.ConsoleClient
 
                     project.Filters.IncludedMethods.Add(option.Value);
                 }
+                else if (optionName == "namespace")
+                {
+                    if (option.Value == null)
+                        throw new ArgumentException("missing argument for -namespace");
+
+                    project.Filters.IncludedNameSpaces.Add(option.Value);
+                }
                 else
                 {
                     // Might be a reporter...

--- a/src/xunit.console/Program.cs
+++ b/src/xunit.console/Program.cs
@@ -189,6 +189,9 @@ namespace Xunit.ConsoleClient
             Console.WriteLine("  -class \"name\"          : run all methods in a given test class (should be fully");
             Console.WriteLine("                         : specified; i.e., 'MyNamespace.MyClass')");
             Console.WriteLine("                         : if specified more than once, acts as an OR operation");
+            Console.WriteLine("  -namespace \"name\"     : run all methods in a given namespace (");
+            Console.WriteLine("                         : i.e., 'MyNamespace.MySubNamespace')");
+            Console.WriteLine("                         : if specified more than once, acts as an OR operation");
             Console.WriteLine();
 
             var switchableReporters = reporters.Where(r => !string.IsNullOrWhiteSpace(r.RunnerSwitch)).ToList();

--- a/src/xunit.runner.utility/Project/XunitFilters.cs
+++ b/src/xunit.runner.utility/Project/XunitFilters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 
 namespace Xunit
@@ -18,6 +19,7 @@ namespace Xunit
             IncludedTraits = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
             IncludedClasses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             IncludedMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            IncludedNameSpaces = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -41,6 +43,11 @@ namespace Xunit
         public HashSet<string> IncludedMethods { get; }
 
         /// <summary>
+        /// Gets the set of assembly filters for tests to include.
+        /// </summary>
+        public HashSet<string> IncludedNameSpaces { get; }
+
+        /// <summary>
         /// Filters the given method using the defined filter values.
         /// </summary>
         /// <param name="testCase">The test case to filter.</param>
@@ -53,8 +60,21 @@ namespace Xunit
                 return false;
             if (!FilterExcludedTraits(testCase))
                 return false;
+            if (!FilterIncludedNameSpaces(testCase))
+                return false;
 
             return true;
+        }
+        bool FilterIncludedNameSpaces(ITestCase testCase)
+        {
+            // No assemblies in the filter == everything is okay
+            if (IncludedNameSpaces.Count == 0)
+                return true;
+
+            if (IncludedNameSpaces.Count != 0 && IncludedNameSpaces.Any(a => testCase.TestMethod.TestClass.Class.Name.Contains(a)))
+                return true;
+
+            return false;
         }
 
         bool FilterIncludedMethodsAndClasses(ITestCase testCase)

--- a/src/xunit.runner.utility/Project/XunitFilters.cs
+++ b/src/xunit.runner.utility/Project/XunitFilters.cs
@@ -71,7 +71,7 @@ namespace Xunit
             if (IncludedNameSpaces.Count == 0)
                 return true;
 
-            if (IncludedNameSpaces.Count != 0 && IncludedNameSpaces.Any(a => testCase.TestMethod.TestClass.Class.Name.Contains(a)))
+            if (IncludedNameSpaces.Count != 0 && IncludedNameSpaces.Any(a => testCase.TestMethod.TestClass.Class.Name.StartsWith($"{a}.", StringComparison.Ordinal)))
                 return true;
 
             return false;


### PR DESCRIPTION
I was hoping to have the ability to filter runnable scripts by namespace through the console runner.  This will provide an easy way of building a script hierarchy without the need to add multiple traits to scripts. Provides a similar functionality to the "File Path" filter that is available in the Visual Studio Test Explorer.