### PR TITLE
Add strong name to xunit.execution.dotnet.dll

### DIFF
--- a/src/xunit.execution.dotnet/xunit.execution.dotnet.csproj
+++ b/src/xunit.execution.dotnet/xunit.execution.dotnet.csproj
@@ -13,6 +13,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\signing.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
As described in dotnet/coreclr#1477, there's a bug in CoreCLR where loading an unsigned assembly without specifying a version number can fail.  this PR works around this by adding a strong name to xunit.execution.dotnet.dll.