### PR TITLE
src/xunit.assert/Asserts/PropertyAsserts.cs (Assert.PropertyChanged):

### DIFF
--- a/src/xunit.assert/Asserts/Sdk/Exceptions/InaccessiblePropertyException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/InaccessiblePropertyException.cs
@@ -1,0 +1,19 @@
+﻿using System.Globalization;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when code raises a property changed event before the property actually changed.
+    /// </summary>
+    public class InaccessiblePropertyException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="PropertyChangedPrematurelyException"/>.
+        /// </summary>
+        /// <param name="propertyName"></param>
+        public InaccessiblePropertyException(string propertyName)
+            : base(string.Format(CultureInfo.CurrentCulture, "Assert.PropertyChanged failure: Property {0} does not have a public getter", propertyName))
+        {
+        }
+    }
+}

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/PropertyChangedPrematurelyException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/PropertyChangedPrematurelyException.cs
@@ -1,0 +1,19 @@
+﻿using System.Globalization;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when code raises a property changed event before the property actually changed.
+    /// </summary>
+    public class PropertyChangedPrematurelyException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="PropertyChangedPrematurelyException"/>.
+        /// </summary>
+        /// <param name="propertyName"></param>
+        public PropertyChangedPrematurelyException(string propertyName)
+            : base(string.Format(CultureInfo.CurrentCulture, "Assert.PropertyChanged failure: Property {0} was not set to a new value before PropertyChanged was raised", propertyName))
+        {
+        }
+    }
+}

--- a/src/xunit.assert/xunit.assert.csproj
+++ b/src/xunit.assert/xunit.assert.csproj
@@ -79,6 +79,8 @@
     <Compile Include="Asserts\Sdk\Exceptions\ProperSubsetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\ProperSupersetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\PropertyChangedException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\InaccessiblePropertyException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\PropertyChangedPrematurelyException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SameException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SingleException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\StartsWithException.cs" />


### PR DESCRIPTION
  - Now fails for properties that are not updated before PropertyChanged is raised.
  - Now fails for properties that do not have a public getter.