### PR TITLE
Fix for #605 - MSBuild Runner add an IgnoreFailures parameter.

### DIFF
--- a/src/xunit.runner.msbuild/xunit.cs
+++ b/src/xunit.runner.msbuild/xunit.cs
@@ -40,6 +40,12 @@ namespace Xunit.Runner.MSBuild
         [Output]
         public int ExitCode { get; protected set; }
 
+        /// <summary>
+        /// Sets whether test failures will be ignored and allow the build to proceed.
+        /// When set to <c>false</c>, test failures will cause the build to fail.
+        /// </summary>
+        public bool IgnoreFailures { get; protected set; }
+
         public bool FailSkips { get; protected set; }
 
         protected XunitFilters Filters
@@ -238,7 +244,8 @@ namespace Xunit.Runner.MSBuild
                     Transform("NUnitXml.xslt", assembliesElement, NUnit);
             }
 
-            return ExitCode == 0;
+            // ExitCode is set to 1 for test failures and -1 for Exceptions.
+            return ExitCode == 0 || (ExitCode == 1 && IgnoreFailures);
         }
 
         List<IRunnerReporter> GetAvailableRunnerReporters()


### PR DESCRIPTION
MSBuild runner modification - Added an IgnoreFailures parameter.  If IgnoreFailures is set true then the Execute function will return true if there are test failures.  This allows for better integration with TeamCity since it will allow you to use the Mute Test feature to Mute failing tests.