### PR TITLE
solving #254

### DIFF
--- a/src/xunit.assert/Asserts/CollectionAsserts.cs
+++ b/src/xunit.assert/Asserts/CollectionAsserts.cs
@@ -271,7 +271,7 @@ namespace Xunit
         /// exactly one element.</exception>
         public static void Single(IEnumerable collection, object expected)
         {
-            Single(collection.Cast<object>(), item => Object.Equals(item, expected));
+            Single(collection.Cast<object>(), item => object.Equals(item, expected));
         }
 
         /// <summary>

--- a/src/xunit.assert/Asserts/CollectionAsserts.cs
+++ b/src/xunit.assert/Asserts/CollectionAsserts.cs
@@ -55,7 +55,7 @@ namespace Xunit
             int actualCount = elements.Length;
 
             if (expectedCount != actualCount)
-                throw new CollectionException(expectedCount, actualCount);
+                throw new CollectionException(expectedCount, actualCount, -1, null, collection);
 
             for (int idx = 0; idx < actualCount; idx++)
             {
@@ -65,7 +65,7 @@ namespace Xunit
                 }
                 catch (Exception ex)
                 {
-                    throw new CollectionException(expectedCount, actualCount, idx, ex);
+                    throw new CollectionException(expectedCount, actualCount, idx, ex, collection);
                 }
             }
         }

--- a/src/xunit.assert/Asserts/Sdk/ArgumentFormatter.cs
+++ b/src/xunit.assert/Asserts/Sdk/ArgumentFormatter.cs
@@ -104,7 +104,7 @@ namespace Xunit.Sdk
             var toString = type.GetMethod("ToString", EmptyTypes);
 #endif
 
-            if (toString != null && toString.DeclaringType != typeof(Object))
+            if (toString != null && toString.DeclaringType != typeof(object))
                 return (string)toString.Invoke(value, EmptyObjects);
 
             return FormatComplexValue(value, depth, type);

--- a/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
+++ b/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
@@ -40,10 +40,10 @@ namespace Xunit.Sdk
             // Null?
             if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().IsAssignableFrom(NullableTypeInfo)))
             {
-                if (Object.Equals(x, default(T)))
-                    return Object.Equals(y, default(T));
+                if (object.Equals(x, default(T)))
+                    return object.Equals(y, default(T));
 
-                if (Object.Equals(y, default(T)))
+                if (object.Equals(y, default(T)))
                     return false;
             }
 
@@ -76,8 +76,8 @@ namespace Xunit.Sdk
             if (enumerablesEqual.HasValue)
                 return enumerablesEqual.GetValueOrDefault();
 
-            // Last case, rely on Object.Equals
-            return Object.Equals(x, y);
+            // Last case, rely on object.Equals
+            return object.Equals(x, y);
         }
 
         bool? CheckIfEnumerablesAreEqual(T x, T y)

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/CollectionException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/CollectionException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Globalization;
 using System.Linq;
 
@@ -12,6 +13,8 @@ namespace Xunit.Sdk
         readonly string innerException;
         readonly string innerStackTrace;
 
+        readonly IEnumerable actualElements;
+
         /// <summary>
         /// Creates a new instance of the <see cref="CollectionException"/> class.
         /// </summary>
@@ -19,7 +22,8 @@ namespace Xunit.Sdk
         /// <param name="actualCount">The actual number of items in the collection.</param>
         /// <param name="indexFailurePoint">The index of the position where the first comparison failure occurred.</param>
         /// <param name="innerException">The exception that was thrown during the comparison failure.</param>
-        public CollectionException(int expectedCount, int actualCount, int indexFailurePoint = -1, Exception innerException = null)
+        /// <param name="actualElements">The elements of the collection</param>
+        public CollectionException(int expectedCount, int actualCount, int indexFailurePoint = -1, Exception innerException = null, IEnumerable actualElements = null)
             : base("Assert.Collection() Failure")
         {
             ExpectedCount = expectedCount;
@@ -27,12 +31,22 @@ namespace Xunit.Sdk
             IndexFailurePoint = indexFailurePoint;
             this.innerException = FormatInnerException(innerException);
             innerStackTrace = innerException == null ? null : innerException.StackTrace;
+
+            this.actualElements = actualElements;
         }
 
         /// <summary>
         /// The actual number of items in the collection.
         /// </summary>
         public int ActualCount { get; set; }
+
+        /// <summary>
+        /// The list of actual Elements, optional and null by default
+        /// </summary>
+        public IEnumerable ActualElements
+        {
+            get { return this.actualElements; }
+        }
 
         /// <summary>
         /// The expected number of items in the collection.

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/CollectionException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/CollectionException.cs
@@ -66,18 +66,20 @@ namespace Xunit.Sdk
             {
                 if (IndexFailurePoint >= 0)
                     return string.Format(CultureInfo.CurrentCulture,
-                                         "{0}{3}Error during comparison of item at index {1}{3}Inner exception: {2}",
+                                         "{0}{3}Error during comparison of item at index {1}{3}Inner exception: {2}{3}Actual items: {4}",
                                          base.Message,
                                          IndexFailurePoint,
                                          innerException,
-                                         Environment.NewLine);
+                                         Environment.NewLine,
+                                         ArgumentFormatter.Format(this.ActualElements));
 
                 return string.Format(CultureInfo.CurrentCulture,
-                                     "{0}{3}Expected item count: {1}{3}Actual item count:   {2}",
+                                     "{0}{3}Expected item count: {1}{3}Actual item count:   {2}{3}Actual items: {4}",
                                      base.Message,
                                      ExpectedCount,
                                      ActualCount,
-                                     Environment.NewLine);
+                                     Environment.NewLine,
+                                     ArgumentFormatter.Format(this.ActualElements));
             }
         }
 

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/CollectionException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/CollectionException.cs
@@ -74,7 +74,7 @@ namespace Xunit.Sdk
                                          ArgumentFormatter.Format(this.ActualElements));
 
                 return string.Format(CultureInfo.CurrentCulture,
-                                     "{0}{3}Expected item count: {1}{3}Actual item count:   {2}{3}Actual items: {4}",
+                                     "{0}{3}Expected item count: {1}{3}Actual item count: {2}{3}Actual items: {4}",
                                      base.Message,
                                      ExpectedCount,
                                      ActualCount,

--- a/src/xunit.execution.desktop/Sdk/LongLivedMarshalByRefObject.cs
+++ b/src/xunit.execution.desktop/Sdk/LongLivedMarshalByRefObject.cs
@@ -22,7 +22,7 @@ namespace Xunit.Sdk
 
         /// <inheritdoc/>
         [SecurityCritical]
-        public override sealed Object InitializeLifetimeService()
+        public override sealed object InitializeLifetimeService()
         {
             return null;
         }

--- a/src/xunit.runner.utility.desktop/Utility/LongLivedMarshalByRefObject.cs
+++ b/src/xunit.runner.utility.desktop/Utility/LongLivedMarshalByRefObject.cs
@@ -10,7 +10,7 @@ namespace Xunit
     {
         /// <inheritdoc/>
         [SecurityCritical]
-        public override sealed Object InitializeLifetimeService()
+        public override sealed object InitializeLifetimeService()
         {
             return null;
         }

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -18,7 +18,7 @@ public class CollectionAssertsTests
         [Fact]
         public static void NullActionThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => Assert.All<object>(new Object[0], null));
+            Assert.Throws<ArgumentNullException>(() => Assert.All<object>(new object[0], null));
         }
 
         [Fact]

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -76,9 +76,15 @@ public class CollectionAssertsTests
             var collEx = Assert.IsType<CollectionException>(ex);
             Assert.Equal(1, collEx.ExpectedCount);
             Assert.Equal(0, collEx.ActualCount);
-            Assert.Equal("Assert.Collection() Failure" + Environment.NewLine +
-                         "Expected item count: 1" + Environment.NewLine +
-                         "Actual item count:   0", collEx.Message);
+
+            var msg = collEx.Message;
+
+            Assert.True(collEx.Message.StartsWith(string.Format("Assert.Collection() Failure{0}" +
+                                       "Expected item count: 1{0}" +
+                                       "Actual item count: 0{0}" +
+                                       "Actual items: ",
+                                       Environment.NewLine)));
+
             Assert.Null(collEx.InnerException);
         }
 
@@ -107,11 +113,13 @@ public class CollectionAssertsTests
 
             var collEx = Assert.IsType<CollectionException>(ex);
             Assert.Equal(1, collEx.IndexFailurePoint);
-            Assert.Equal("Assert.Collection() Failure" + Environment.NewLine +
-                         "Error during comparison of item at index 1" + Environment.NewLine +
-                         "Inner exception: Assert.Equal() Failure" + Environment.NewLine +
-                         "        Expected: 2113" + Environment.NewLine +
-                         "        Actual:   2112", ex.Message);
+            Assert.True(ex.Message.StartsWith(string.Format("Assert.Collection() Failure{0}" +
+                                       "Error during comparison of item at index 1{0}" +
+                                       "Inner exception: Assert.Equal() Failure{0}" +
+                                       "        Expected: 2113{0}" +
+                                       "        Actual:   2112{0}" +
+                                       "Actual items: ", 
+                                       Environment.NewLine)));
         }
 
         [Fact]

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -113,6 +113,33 @@ public class CollectionAssertsTests
                          "        Expected: 2113" + Environment.NewLine +
                          "        Actual:   2112", ex.Message);
         }
+
+        [Fact]
+        public static void MismatchedElementWithElementList()
+        {
+            var list = new List<int> {42, 2112};
+            var ex = Record.Exception(() => 
+                Assert.Collection(list, 
+                    item => Assert.Equal(42, item),
+                    item => Assert.Equal(2113, item)
+                )
+            );
+            var collEx = Assert.IsType<CollectionException>(ex);
+            Assert.Equal(collEx.ActualElements, list);
+        }
+
+        [Fact]
+        public static void MismatchedElementCountWithElementList()
+        {
+            var list = new List<int> { 42, 2112 };
+            var ex = Record.Exception(() =>
+                Assert.Collection(list,
+                    item => Assert.Equal(42, item)
+                )
+            );
+            var collEx = Assert.IsType<CollectionException>(ex);
+            Assert.Equal(collEx.ActualElements, list);
+        }
     }
 
     public class Contains

--- a/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
+++ b/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
@@ -361,7 +361,7 @@ public class XmlTestExecutionVisitorTests
         {
             var assemblyFinished = Substitute.For<ITestAssemblyFinished>();
             var testCase = Mocks.TestCase<ClassUnderTest>("TestMethod");
-            var test = Mocks.Test(testCase, new String(Enumerable.Range(0, 32).Select(x => (char)x).ToArray()));
+            var test = Mocks.Test(testCase, new string(Enumerable.Range(0, 32).Select(x => (char)x).ToArray()));
             var testSkipped = Substitute.For<ITestSkipped>();
             testSkipped.TestCase.Returns(testCase);
             testSkipped.Test.Returns(test);
@@ -425,7 +425,7 @@ public class XmlTestExecutionVisitorTests
                 yield return new object[] { methodCleanupFailure, "test-method-cleanup", "MyMethod" };
 
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "test-case-cleanup", "MyTestCase" };
 

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/TestCaseRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/TestCaseRunnerTests.cs
@@ -190,7 +190,7 @@ public class TestCaseRunnerTests
                 aggregator.Add(aggregatorSeedException);
 
             return new TestableTestCaseRunner(
-                testCase ?? Mocks.TestCase<Object>("ToString"),
+                testCase ?? Mocks.TestCase<object>("ToString"),
                 messageBus,
                 aggregator,
                 new CancellationTokenSource(),

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/TestRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/TestRunnerTests.cs
@@ -286,15 +286,15 @@ public class TestRunnerTests
             if (aggregatorSeedException != null)
                 aggregator.Add(aggregatorSeedException);
             if (testCase == null)
-                testCase = Mocks.TestCase<Object>("ToString");
+                testCase = Mocks.TestCase<object>("ToString");
             var test = Mocks.Test(testCase, displayName);
 
             return new TestableTestRunner(
                 test,
                 messageBus,
-                typeof(Object),
+                typeof(object),
                 new object[0],
-                typeof(Object).GetMethod("ToString"),
+                typeof(object).GetMethod("ToString"),
                 new object[0],
                 skipReason,
                 aggregator,

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunnerTests.cs
@@ -20,7 +20,7 @@ public class XunitTestCollectionRunnerTests
 
         Assert.Collection(runner.CollectionFixtureMappings.OrderBy(mapping => mapping.Key.Name),
             mapping => Assert.IsType<FixtureUnderTest>(mapping.Value),
-            mapping => Assert.IsType<Object>(mapping.Value)
+            mapping => Assert.IsType<object>(mapping.Value)
         );
     }
 

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscovererTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscovererTests.cs
@@ -127,7 +127,7 @@ public class XunitTestFrameworkDiscovererTests
         public static void GuardClauses()
         {
             var framework = TestableXunitTestFrameworkDiscoverer.Create();
-            var typeName = typeof(Object).FullName;
+            var typeName = typeof(object).FullName;
             var sink = Substitute.For<IMessageSink>();
             var options = TestFrameworkOptions.ForDiscovery();
 

--- a/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
@@ -52,7 +52,7 @@ public class TeamCityReporterMessageHandlerTests
 
                 // ITestCaseCleanupFailure
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "Test Case Cleanup Failure (MyTestCase)" };
 

--- a/test/test.xunit.runner.tdnet/Visitors/ResultVisitorTests.cs
+++ b/test/test.xunit.runner.tdnet/Visitors/ResultVisitorTests.cs
@@ -40,7 +40,7 @@ public class ResultVisitorTests
             var listener = Substitute.For<ITestListener>();
             var visitor = new ResultVisitor(listener, 42) { TestRunState = initialState };
 
-            visitor.OnMessage(Mocks.TestFailed(typeof(Object), "GetHashCode"));
+            visitor.OnMessage(Mocks.TestFailed(typeof(object), "GetHashCode"));
 
             Assert.Equal(TestRunState.Failure, visitor.TestRunState);
         }
@@ -135,7 +135,7 @@ public class ResultVisitorTests
                 yield return new object[] { methodCleanupFailure, "Test Method Cleanup Failure (MyMethod)" };
 
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "Test Case Cleanup Failure (MyTestCase)" };
 

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -56,7 +56,7 @@ public class DefaultRunnerReporterMessageHandlerTests
 
                 // ITestCaseCleanupFailure
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "Test Case Cleanup Failure (MyTestCase)" };
 


### PR DESCRIPTION
## How I solved the issue
added an additional property to CollectionException that holds the actual elements. add that as an optional constructor parameter
add the actual values to the CollectionException where thrown.

## Tests:
- MismatchedElementsWithElementList is similar to MismatchedElements, but compares the ActualElements list instead of count for assertion,
- MismatchedElementCountWithElementList is similar to MismatchElementCount, but compares the ActualElements list instead of count for assertion.

### Not implemented: Actual Elements as part of the exception message
Adding the actual elements to the exception message would have been dangerous as collections can be quite long and IMHO the message itself is not the right way to print that. Thus I  used a property instead. 
Developers can use the ActualElements-Property of the CollectionException by code inspection while debugging or when handling the exception in code instead.