### PR TITLE
code cleanup: replace Object by object and String by string.

### DIFF
--- a/src/xunit.assert/Asserts/CollectionAsserts.cs
+++ b/src/xunit.assert/Asserts/CollectionAsserts.cs
@@ -271,7 +271,7 @@ namespace Xunit
         /// exactly one element.</exception>
         public static void Single(IEnumerable collection, object expected)
         {
-            Single(collection.Cast<object>(), item => Object.Equals(item, expected));
+            Single(collection.Cast<object>(), item => object.Equals(item, expected));
         }
 
         /// <summary>

--- a/src/xunit.assert/Asserts/Sdk/ArgumentFormatter.cs
+++ b/src/xunit.assert/Asserts/Sdk/ArgumentFormatter.cs
@@ -104,7 +104,7 @@ namespace Xunit.Sdk
             var toString = type.GetMethod("ToString", EmptyTypes);
 #endif
 
-            if (toString != null && toString.DeclaringType != typeof(Object))
+            if (toString != null && toString.DeclaringType != typeof(object))
                 return (string)toString.Invoke(value, EmptyObjects);
 
             return FormatComplexValue(value, depth, type);

--- a/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
+++ b/src/xunit.assert/Asserts/Sdk/AssertEqualityComparer.cs
@@ -40,10 +40,10 @@ namespace Xunit.Sdk
             // Null?
             if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().IsAssignableFrom(NullableTypeInfo)))
             {
-                if (Object.Equals(x, default(T)))
-                    return Object.Equals(y, default(T));
+                if (object.Equals(x, default(T)))
+                    return object.Equals(y, default(T));
 
-                if (Object.Equals(y, default(T)))
+                if (object.Equals(y, default(T)))
                     return false;
             }
 
@@ -76,8 +76,8 @@ namespace Xunit.Sdk
             if (enumerablesEqual.HasValue)
                 return enumerablesEqual.GetValueOrDefault();
 
-            // Last case, rely on Object.Equals
-            return Object.Equals(x, y);
+            // Last case, rely on object.Equals
+            return object.Equals(x, y);
         }
 
         bool? CheckIfEnumerablesAreEqual(T x, T y)

--- a/src/xunit.execution.desktop/Sdk/LongLivedMarshalByRefObject.cs
+++ b/src/xunit.execution.desktop/Sdk/LongLivedMarshalByRefObject.cs
@@ -22,7 +22,7 @@ namespace Xunit.Sdk
 
         /// <inheritdoc/>
         [SecurityCritical]
-        public override sealed Object InitializeLifetimeService()
+        public override sealed object InitializeLifetimeService()
         {
             return null;
         }

--- a/src/xunit.runner.utility.desktop/Utility/LongLivedMarshalByRefObject.cs
+++ b/src/xunit.runner.utility.desktop/Utility/LongLivedMarshalByRefObject.cs
@@ -10,7 +10,7 @@ namespace Xunit
     {
         /// <inheritdoc/>
         [SecurityCritical]
-        public override sealed Object InitializeLifetimeService()
+        public override sealed object InitializeLifetimeService()
         {
             return null;
         }

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -18,7 +18,7 @@ public class CollectionAssertsTests
         [Fact]
         public static void NullActionThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => Assert.All<object>(new Object[0], null));
+            Assert.Throws<ArgumentNullException>(() => Assert.All<object>(new object[0], null));
         }
 
         [Fact]

--- a/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
+++ b/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
@@ -361,7 +361,7 @@ public class XmlTestExecutionVisitorTests
         {
             var assemblyFinished = Substitute.For<ITestAssemblyFinished>();
             var testCase = Mocks.TestCase<ClassUnderTest>("TestMethod");
-            var test = Mocks.Test(testCase, new String(Enumerable.Range(0, 32).Select(x => (char)x).ToArray()));
+            var test = Mocks.Test(testCase, new string(Enumerable.Range(0, 32).Select(x => (char)x).ToArray()));
             var testSkipped = Substitute.For<ITestSkipped>();
             testSkipped.TestCase.Returns(testCase);
             testSkipped.Test.Returns(test);
@@ -425,7 +425,7 @@ public class XmlTestExecutionVisitorTests
                 yield return new object[] { methodCleanupFailure, "test-method-cleanup", "MyMethod" };
 
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "test-case-cleanup", "MyTestCase" };
 

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/TestCaseRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/TestCaseRunnerTests.cs
@@ -190,7 +190,7 @@ public class TestCaseRunnerTests
                 aggregator.Add(aggregatorSeedException);
 
             return new TestableTestCaseRunner(
-                testCase ?? Mocks.TestCase<Object>("ToString"),
+                testCase ?? Mocks.TestCase<object>("ToString"),
                 messageBus,
                 aggregator,
                 new CancellationTokenSource(),

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/TestRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/TestRunnerTests.cs
@@ -286,15 +286,15 @@ public class TestRunnerTests
             if (aggregatorSeedException != null)
                 aggregator.Add(aggregatorSeedException);
             if (testCase == null)
-                testCase = Mocks.TestCase<Object>("ToString");
+                testCase = Mocks.TestCase<object>("ToString");
             var test = Mocks.Test(testCase, displayName);
 
             return new TestableTestRunner(
                 test,
                 messageBus,
-                typeof(Object),
+                typeof(object),
                 new object[0],
-                typeof(Object).GetMethod("ToString"),
+                typeof(object).GetMethod("ToString"),
                 new object[0],
                 skipReason,
                 aggregator,

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunnerTests.cs
@@ -20,7 +20,7 @@ public class XunitTestCollectionRunnerTests
 
         Assert.Collection(runner.CollectionFixtureMappings.OrderBy(mapping => mapping.Key.Name),
             mapping => Assert.IsType<FixtureUnderTest>(mapping.Value),
-            mapping => Assert.IsType<Object>(mapping.Value)
+            mapping => Assert.IsType<object>(mapping.Value)
         );
     }
 

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscovererTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscovererTests.cs
@@ -127,7 +127,7 @@ public class XunitTestFrameworkDiscovererTests
         public static void GuardClauses()
         {
             var framework = TestableXunitTestFrameworkDiscoverer.Create();
-            var typeName = typeof(Object).FullName;
+            var typeName = typeof(object).FullName;
             var sink = Substitute.For<IMessageSink>();
             var options = TestFrameworkOptions.ForDiscovery();
 

--- a/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
@@ -52,7 +52,7 @@ public class TeamCityReporterMessageHandlerTests
 
                 // ITestCaseCleanupFailure
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "Test Case Cleanup Failure (MyTestCase)" };
 

--- a/test/test.xunit.runner.tdnet/Visitors/ResultVisitorTests.cs
+++ b/test/test.xunit.runner.tdnet/Visitors/ResultVisitorTests.cs
@@ -40,7 +40,7 @@ public class ResultVisitorTests
             var listener = Substitute.For<ITestListener>();
             var visitor = new ResultVisitor(listener, 42) { TestRunState = initialState };
 
-            visitor.OnMessage(Mocks.TestFailed(typeof(Object), "GetHashCode"));
+            visitor.OnMessage(Mocks.TestFailed(typeof(object), "GetHashCode"));
 
             Assert.Equal(TestRunState.Failure, visitor.TestRunState);
         }
@@ -135,7 +135,7 @@ public class ResultVisitorTests
                 yield return new object[] { methodCleanupFailure, "Test Method Cleanup Failure (MyMethod)" };
 
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "Test Case Cleanup Failure (MyTestCase)" };
 

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -56,7 +56,7 @@ public class DefaultRunnerReporterMessageHandlerTests
 
                 // ITestCaseCleanupFailure
                 var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
-                var testCase = Mocks.TestCase(typeof(Object), "ToString", displayName: "MyTestCase");
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
                 testCaseCleanupFailure.TestCase.Returns(testCase);
                 yield return new object[] { testCaseCleanupFailure, "Test Case Cleanup Failure (MyTestCase)" };
 


### PR DESCRIPTION
as discussed in https://github.com/xunit/xunit/issues/623 this PR replaces occurrences of String by string and Object by object where appropriate.
Does not change any functionality, nor does it change any other code style or something like that.