### PR TITLE
Fix of tests failing depending on current culture

### DIFF
--- a/src/common/ExecutionHelper.cs
+++ b/src/common/ExecutionHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -55,5 +56,26 @@ namespace Xunit
         /// a generalized reference to the platform-specific assembly.
         /// </summary>
         public static readonly string SubstitutionToken = ".{Platform}";
+
+        /// <summary>
+        /// Executes given <paramref name="action"/> with given <paramref name="culture"/>
+        /// </summary>
+        /// <param name="culture">Culture of thread to execute the <paramref name="action"/></param>
+        /// <param name="action">Action to execute with <paramref name="culture"/></param>
+        public static void ExecuteWithCulture(CultureInfo culture, Action action)
+        {
+            var currentCulture = CultureInfo.DefaultThreadCurrentCulture;
+
+            try
+            {
+                CultureInfo.DefaultThreadCurrentCulture = culture;
+
+                action();
+            }
+            finally
+            {
+                CultureInfo.DefaultThreadCurrentCulture = currentCulture;
+            }
+        }
     }
 }

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
@@ -162,43 +163,50 @@ public class DefaultRunnerReporterMessageHandlerTests
         [Fact]
         public void SingleAssembly()
         {
-            var clockTime = TimeSpan.FromSeconds(12.3456);
-            var assembly = new ExecutionSummary { Total = 2112, Errors = 6, Failed = 42, Skipped = 8, Time = 1.2345M };
-            var message = new TestExecutionSummary(clockTime, new List<KeyValuePair<string, ExecutionSummary>> { new KeyValuePair<string, ExecutionSummary>("assembly", assembly) });
-            var handler = TestableDefaultRunnerReporterMessageHandler.Create();
+            ExecutionHelper.ExecuteWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var clockTime = TimeSpan.FromSeconds(12.3456);
+                var assembly = new ExecutionSummary { Total = 2112, Errors = 6, Failed = 42, Skipped = 8, Time = 1.2345M };
+                var message = new TestExecutionSummary(clockTime, new List<KeyValuePair<string, ExecutionSummary>> { new KeyValuePair<string, ExecutionSummary>("assembly", assembly) });
+                var handler = TestableDefaultRunnerReporterMessageHandler.Create();
 
-            handler.OnMessage(message);
+                handler.OnMessage(message);
 
-            Assert.Collection(handler.Messages,
-                msg => Assert.Equal("[Imp] => === TEST EXECUTION SUMMARY ===", msg),
-                msg => Assert.Equal("[Imp] =>    assembly  Total: 2112, Errors: 6, Failed: 42, Skipped: 8, Time: 1.235s", msg)
-            );
+                Assert.Collection(handler.Messages,
+                    msg => Assert.Equal("[Imp] => === TEST EXECUTION SUMMARY ===", msg),
+                    msg => Assert.Equal("[Imp] =>    assembly  Total: 2112, Errors: 6, Failed: 42, Skipped: 8, Time: 1.235s", msg)
+                );
+            });
         }
 
         [Fact]
         public void MultipleAssemblies()
         {
-            var clockTime = TimeSpan.FromSeconds(12.3456);
-            var @short = new ExecutionSummary { Total = 2112, Errors = 6, Failed = 42, Skipped = 8, Time = 1.2345M };
-            var nothing = new ExecutionSummary { Total = 0 };
-            var longerName = new ExecutionSummary { Total = 10240, Errors = 7, Failed = 96, Skipped = 4, Time = 3.4567M };
-            var message = new TestExecutionSummary(clockTime, new List<KeyValuePair<string, ExecutionSummary>> {
-                new KeyValuePair<string, ExecutionSummary>("short", @short),
-                new KeyValuePair<string, ExecutionSummary>("nothing", nothing),
-                new KeyValuePair<string, ExecutionSummary>("longerName", longerName),
+            ExecutionHelper.ExecuteWithCulture(CultureInfo.InvariantCulture, () =>
+            {
+                var clockTime = TimeSpan.FromSeconds(12.3456);
+                var @short = new ExecutionSummary { Total = 2112, Errors = 6, Failed = 42, Skipped = 8, Time = 1.2345M };
+                var nothing = new ExecutionSummary { Total = 0 };
+                var longerName = new ExecutionSummary { Total = 10240, Errors = 7, Failed = 96, Skipped = 4, Time = 3.4567M };
+                var message = new TestExecutionSummary(clockTime, new List<KeyValuePair<string, ExecutionSummary>>
+                {
+                    new KeyValuePair<string, ExecutionSummary>("short", @short),
+                    new KeyValuePair<string, ExecutionSummary>("nothing", nothing),
+                    new KeyValuePair<string, ExecutionSummary>("longerName", longerName),
+                });
+                var handler = TestableDefaultRunnerReporterMessageHandler.Create();
+
+                handler.OnMessage(message);
+
+                Assert.Collection(handler.Messages,
+                    msg => Assert.Equal("[Imp] => === TEST EXECUTION SUMMARY ===", msg),
+                    msg => Assert.Equal("[Imp] =>    short       Total:  2112, Errors:  6, Failed:  42, Skipped:  8, Time: 1.235s", msg),
+                    msg => Assert.Equal("[Imp] =>    nothing     Total:     0", msg),
+                    msg => Assert.Equal("[Imp] =>    longerName  Total: 10240, Errors:  7, Failed:  96, Skipped:  4, Time: 3.457s", msg),
+                    msg => Assert.Equal("[Imp] =>                       -----          --          ---           --        ------", msg),
+                    msg => Assert.Equal("[Imp] =>          GRAND TOTAL: 12352          13          138           12        4.691s (12.346s)", msg)
+                );
             });
-            var handler = TestableDefaultRunnerReporterMessageHandler.Create();
-
-            handler.OnMessage(message);
-
-            Assert.Collection(handler.Messages,
-                msg => Assert.Equal("[Imp] => === TEST EXECUTION SUMMARY ===", msg),
-                msg => Assert.Equal("[Imp] =>    short       Total:  2112, Errors:  6, Failed:  42, Skipped:  8, Time: 1.235s", msg),
-                msg => Assert.Equal("[Imp] =>    nothing     Total:     0", msg),
-                msg => Assert.Equal("[Imp] =>    longerName  Total: 10240, Errors:  7, Failed:  96, Skipped:  4, Time: 3.457s", msg),
-                msg => Assert.Equal("[Imp] =>                       -----          --          ---           --        ------", msg),
-                msg => Assert.Equal("[Imp] =>          GRAND TOTAL: 12352          13          138           12        4.691s (12.346s)", msg)
-            );
         }
     }
 


### PR DESCRIPTION
Two tests were failing on my machine because my default culture is different from English. Here comma is used instead of dot as a decimal separator. So I had "Time: 1,235s" instead of "Time: 1.235s".

I wrote a simple method that executes given delegate with given culture. It sets default culture before execution of the delegate and returns it back after that. Then I rewrote failing tests using this method. Now they pass on my machine.