### PR TITLE
fixing some affected tests of #616 by defining the culture of test environment

### DIFF
--- a/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
@@ -190,6 +190,8 @@ public class Xunit2AcceptanceTests
         [Fact]
         public void CompositeTestFailureResultsFromFailingTestsPlusThrowingDisposeInTestClass()
         {
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+
             var messages = Run<ITestFailed>(typeof(ClassUnderTest_FailingTestAndDisposeFailure));
 
             var msg = Assert.Single(messages);

--- a/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
@@ -229,7 +229,7 @@ public class Xunit2TheoryAcceptanceTests
         [Fact]
         public void IncompatibleDataThrows()
         {
-            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
 
             var testMessages = Run<ITestResultMessage>(typeof(ClassWithIncompatibleData));
 
@@ -729,6 +729,8 @@ public class Xunit2TheoryAcceptanceTests
         [Fact]
         public void TestDataWithInternalConstructor_ReturnsSingleFailingTheory()
         {
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+
             var testMessages = Run<IMessageSinkMessage>(typeof(ClassWithCustomDataWithInternalDataCtor));
 
             var types = testMessages.Select(t => t.GetType()).ToList();

--- a/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -227,6 +229,8 @@ public class Xunit2TheoryAcceptanceTests
         [Fact]
         public void IncompatibleDataThrows()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var testMessages = Run<ITestResultMessage>(typeof(ClassWithIncompatibleData));
 
             var failed = Assert.Single(testMessages.Cast<ITestFailed>());

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/TestAssemblyRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/TestAssemblyRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -279,6 +280,8 @@ public class TestAssemblyRunnerTests
         [Fact]
         public static async void TestCaseOrdererWhichThrowsLogsMessageAndDoesNotReorderTests()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var collection1 = Mocks.TestCollection(displayName: "AAA");
             var testCase1 = Mocks.TestCase(collection1);
             var collection2 = Mocks.TestCollection(displayName: "ZZZZ");

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/TestClassRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/TestClassRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -235,6 +236,8 @@ public class TestClassRunnerTests
         [Fact]
         public static async void TestCaseOrdererWhichThrowsLogsMessageAndDoesNotReorderTests()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var passing1 = Mocks.TestCase<ClassUnderTest>("Passing");
             var passing2 = Mocks.TestCase<ClassUnderTest>("Passing");
             var other1 = Mocks.TestCase<ClassUnderTest>("Other");

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunnerTests.cs
@@ -250,7 +250,7 @@ public class XunitTestAssemblyRunnerTests
         [Fact]
         public static void SettingTestCaseOrdererWithThrowingConstructorLogsDiagnosticMessage()
         {
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             var ordererAttribute = Mocks.TestCaseOrdererAttribute<MyCtorThrowingTestCaseOrderer>();
             var assembly = Mocks.TestAssembly(new[] { ordererAttribute });

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunnerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -249,6 +250,8 @@ public class XunitTestAssemblyRunnerTests
         [Fact]
         public static void SettingTestCaseOrdererWithThrowingConstructorLogsDiagnosticMessage()
         {
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
             var ordererAttribute = Mocks.TestCaseOrdererAttribute<MyCtorThrowingTestCaseOrderer>();
             var assembly = Mocks.TestAssembly(new[] { ordererAttribute });
             var runner = TestableXunitTestAssemblyRunner.Create(assembly: assembly);
@@ -313,6 +316,8 @@ public class XunitTestAssemblyRunnerTests
         [Fact]
         public static void SettingTestCollectionOrdererWithThrowingConstructorLogsDiagnosticMessage()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var ordererAttribute = Mocks.TestCollectionOrdererAttribute<MyCtorThrowingTestCollectionOrderer>();
             var assembly = Mocks.TestAssembly(new[] { ordererAttribute });
             var runner = TestableXunitTestAssemblyRunner.Create(assembly: assembly);

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestClassRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestClassRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -219,6 +220,8 @@ public class XunitTestClassRunnerTests
         [Fact]
         public static async void SettingTestCaseOrdererWithThrowingConstructorLogsDiagnosticMessage()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var testCase = Mocks.XunitTestCase<TestClassWithCtorThrowingTestCaseOrder>("Passing");
             var runner = TestableXunitTestClassRunner.Create(testCase);
 

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTestCollectionRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -71,6 +72,8 @@ public class XunitTestCollectionRunnerTests
         [Fact]
         public static async void SettingTestCaseOrdererWithThrowingConstructorLogsDiagnosticMessage()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var collection = new TestCollection(Mocks.TestAssembly(), Reflector.Wrap(typeof(CollectionWithCtorThrowingTestCaseOrderer)), "TestCollectionDisplayName");
             var testCase = Mocks.XunitTestCase<XunitTestCollectionRunnerTests>("DisposesFixtures", collection);
             var runner = TestableXunitTestCollectionRunner.Create(testCase);

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using NSubstitute;
@@ -29,6 +30,8 @@ public class XunitTheoryTestCaseRunnerTests
     [Fact]
     public static async void DiscovererWhichThrowsReturnsASingleFailedTest()
     {
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
         var messageBus = new SpyMessageBus();
         var runner = TestableXunitTheoryTestCaseRunner.Create<ClassUnderTest>("TestWithThrowingData", messageBus, "Display Name");
 

--- a/test/test.xunit.execution/Sdk/TestFrameworkProxyTests.cs
+++ b/test/test.xunit.execution/Sdk/TestFrameworkProxyTests.cs
@@ -46,7 +46,7 @@ public class TestFrameworkProxyTests
     [Fact]
     public void Attribute_ThrowingDiscovererCtor()
     {
-        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
         var attribute = Mocks.TestFrameworkAttribute(typeof(AttributeWithThrowingDiscovererCtor));
         var assembly = Mocks.AssemblyInfo(attributes: new[] { attribute });
@@ -76,7 +76,7 @@ public class TestFrameworkProxyTests
     [Fact]
     public void Attribute_ThrowingDiscovererMethod()
     {
-        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
         var attribute = Mocks.TestFrameworkAttribute(typeof(AttributeWithThrowingDiscovererMethod));
         var assembly = Mocks.AssemblyInfo(attributes: new[] { attribute });

--- a/test/test.xunit.execution/Sdk/TestFrameworkProxyTests.cs
+++ b/test/test.xunit.execution/Sdk/TestFrameworkProxyTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
+using System.Threading;
 using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
@@ -44,6 +46,8 @@ public class TestFrameworkProxyTests
     [Fact]
     public void Attribute_ThrowingDiscovererCtor()
     {
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
         var attribute = Mocks.TestFrameworkAttribute(typeof(AttributeWithThrowingDiscovererCtor));
         var assembly = Mocks.AssemblyInfo(attributes: new[] { attribute });
 
@@ -72,6 +76,8 @@ public class TestFrameworkProxyTests
     [Fact]
     public void Attribute_ThrowingDiscovererMethod()
     {
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
         var attribute = Mocks.TestFrameworkAttribute(typeof(AttributeWithThrowingDiscovererMethod));
         var assembly = Mocks.AssemblyInfo(attributes: new[] { attribute });
 
@@ -95,6 +101,8 @@ public class TestFrameworkProxyTests
     [Fact]
     public void Attribute_ThrowingTestFrameworkCtor()
     {
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
         var attribute = Mocks.TestFrameworkAttribute(typeof(AttributeWithThrowingTestFrameworkCtor));
         var assembly = Mocks.AssemblyInfo(attributes: new[] { attribute });
 

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -180,6 +180,8 @@ public class DefaultRunnerReporterMessageHandlerTests
         [Fact]
         public void MultipleAssemblies()
         {
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+
             var clockTime = TimeSpan.FromSeconds(12.3456);
             var @short = new ExecutionSummary { Total = 2112, Errors = 6, Failed = 42, Skipped = 8, Time = 1.2345M };
             var nothing = new ExecutionSummary { Total = 0 };

--- a/test/test.xunit.runner.utility/Frameworks/v1/Xunit1ExceptionUtilityTests.cs
+++ b/test/test.xunit.runner.utility/Frameworks/v1/Xunit1ExceptionUtilityTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 public class Xunit1ExceptionUtilityTests
@@ -6,6 +8,8 @@ public class Xunit1ExceptionUtilityTests
     [Fact]
     public static void CanParseEmbeddedExceptions()
     {
+        Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
         try
         {
             try { throw new DivideByZeroException(); }

--- a/test/test.xunit.runner.utility/Frameworks/v1/Xunit1Tests.cs
+++ b/test/test.xunit.runner.utility/Frameworks/v1/Xunit1Tests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Web.UI;
 using NSubstitute;
 using Xunit;
@@ -521,7 +523,9 @@ public class Xunit1Tests
         [Fact]
         public void ExceptionThrownDuringRunTests_ResultsInErrorMessage()
         {
-            using (var xunit1 = new TestableXunit1("AssemblyName.dll", "ConfigFile.config"))
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
+            using(var xunit1 = new TestableXunit1("AssemblyName.dll", "ConfigFile.config"))
             {
                 var testCases = new[] {
                     new Xunit1TestCase("assembly", "config", "type1", "passing", "type1.passing")

--- a/test/test.xunit.runner.utility/Utility/ExceptionUtilityTests.cs
+++ b/test/test.xunit.runner.utility/Utility/ExceptionUtilityTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -115,6 +117,8 @@ public class ExceptionUtilityTests
         [Fact]
         public void AggregateException()
         {
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
             var failureInfo = new FailureInformation {
                 { new AggregateException(), -1 },
                 { new DivideByZeroException("inner #1"), 0 },
@@ -156,6 +160,8 @@ public class ExceptionUtilityTests
         [Fact]
         public void XunitException()
         {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             Action testCode = () => { throw new XunitException(); };
             var ex = Record.Exception(testCode);
             var failureInfo = new FailureInformation { ex };
@@ -170,6 +176,8 @@ public class ExceptionUtilityTests
         [Fact]
         public void NonXunitException()
         {
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
             Action testCode = () => { throw new Exception(); };
             var ex = Record.Exception(testCode);
             var failureInfo = new FailureInformation { ex };
@@ -184,6 +192,8 @@ public class ExceptionUtilityTests
         [Fact]
         public void NonXunitExceptionWithInnerExceptions()
         {
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
             Action innerTestCode = () => { throw new DivideByZeroException(); };
             var inner = Record.Exception(innerTestCode);
             Action outerTestCode = () => { throw new Exception("message", inner); };
@@ -202,6 +212,8 @@ public class ExceptionUtilityTests
         [Fact]
         public void AggregateException()
         {
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+
             Action inner1TestCode = () => { throw new DivideByZeroException(); };
             var inner1 = Record.Exception(inner1TestCode);
             Action inner2TestCode = () => { throw new NotImplementedException("inner #2"); };

--- a/test/test.xunit.runner.utility/Utility/ExceptionUtilityTests.cs
+++ b/test/test.xunit.runner.utility/Utility/ExceptionUtilityTests.cs
@@ -117,7 +117,7 @@ public class ExceptionUtilityTests
         [Fact]
         public void AggregateException()
         {
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             var failureInfo = new FailureInformation {
                 { new AggregateException(), -1 },
@@ -176,7 +176,7 @@ public class ExceptionUtilityTests
         [Fact]
         public void NonXunitException()
         {
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             Action testCode = () => { throw new Exception(); };
             var ex = Record.Exception(testCode);
@@ -192,7 +192,7 @@ public class ExceptionUtilityTests
         [Fact]
         public void NonXunitExceptionWithInnerExceptions()
         {
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             Action innerTestCode = () => { throw new DivideByZeroException(); };
             var inner = Record.Exception(innerTestCode);
@@ -212,7 +212,7 @@ public class ExceptionUtilityTests
         [Fact]
         public void AggregateException()
         {
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-us");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             Action inner1TestCode = () => { throw new DivideByZeroException(); };
             var inner1 = Record.Exception(inner1TestCode);


### PR DESCRIPTION
This pull requests fixes some of the errors reported in issue #616.

It's fixed here for all tests where the expected exceptions are thrown in the same thread the test method starts in.

reduces the number of failing tests (in my German Windows 10 environment) from 29 to 13 without changing any functionality.