### PR TITLE
Fix of tests failing depending of culture using CulturedFact attribute

### DIFF
--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -159,7 +159,7 @@ public class DefaultRunnerReporterMessageHandlerTests
 
     public class OnMessage_ITestExecutionSummary
     {
-        [Fact]
+        [CulturedFact("en-US")]
         public void SingleAssembly()
         {
             var clockTime = TimeSpan.FromSeconds(12.3456);
@@ -175,7 +175,7 @@ public class DefaultRunnerReporterMessageHandlerTests
             );
         }
 
-        [Fact]
+        [CulturedFact("en-US")]
         public void MultipleAssemblies()
         {
             var clockTime = TimeSpan.FromSeconds(12.3456);


### PR DESCRIPTION
Two tests were failing on my machine because my default culture is different from English (in class OnMessage_ITestExecutionSummary). Here comma is used instead of dot as a decimal separator. So I had "Time: 1,235s" instead of "Time: 1.235s".

I applied CulturedFact attribute to these tests. Now they pass on my machine.
