### PR TITLE
Trait discoverers requiring method information. Assembly and namespace traits

### DIFF
--- a/src/xunit.core/AssemblyTraitAttribute.cs
+++ b/src/xunit.core/AssemblyTraitAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>
+    /// Attribute used to decorate an assembly with arbitrary name/value pairs ("traits").
+    /// </summary>
+    [TraitDiscoverer("Xunit.Sdk.AssemblyTraitDiscoverer", "xunit.core")]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed class AssemblyTraitAttribute : Attribute, ITraitAttribute
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="AssemblyTraitAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The trait name</param>
+        /// <param name="value">The trait value</param>
+        public AssemblyTraitAttribute(string name, string value) { }
+    }
+}

--- a/src/xunit.core/NamespaceTraitAttribute.cs
+++ b/src/xunit.core/NamespaceTraitAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>
+    /// Attribute used to decorate a namespace with arbitrary name/value pairs ("traits").
+    /// </summary>
+    [TraitDiscoverer("Xunit.Sdk.NamespaceTraitDiscoverer", "xunit.core")]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed class NamespaceTraitAttribute : Attribute, ITraitAttribute
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="NamespaceTraitAttribute"/> class.
+        /// </summary>
+        /// <param name="namespace">The namespace to apply the trait to. Null or empty value will be ignored.</param>
+        /// <param name="name">The trait name</param>
+        /// <param name="value">The trait value</param>
+        public NamespaceTraitAttribute(string @namespace, string name, string value) { }
+
+        /// <summary>
+        /// Gets or sets if namespace is case insensitive.
+        /// </summary>
+        public bool NamespaceCaseInsensitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets if the trait should not be applied to nested namespaces.
+        /// </summary>
+        public bool NotApplicableToNestedNamespaces { get; set; }
+    }
+}

--- a/src/xunit.core/Sdk/AssemblyTraitDiscoverer.cs
+++ b/src/xunit.core/Sdk/AssemblyTraitDiscoverer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// The implementation of <see cref="ITraitDiscoverer"/> which returns the trait values
+    /// for <see cref="AssemblyTraitAttribute"/>.
+    /// </summary>
+    public class AssemblyTraitDiscoverer : ITraitDiscoverer
+    {
+        /// <inheritdoc/>
+        public virtual IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            var ctorArgs = traitAttribute.GetConstructorArguments().Cast<string>().ToList();
+            yield return new KeyValuePair<string, string>(ctorArgs[0], ctorArgs[1]);
+        }
+    }
+}

--- a/src/xunit.core/Sdk/IMethodedTraitDiscoverer.cs
+++ b/src/xunit.core/Sdk/IMethodedTraitDiscoverer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Xunit.Abstractions;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// This interface is implemented by discoverers that provide trait values to
+    /// xUnit.net v2 tests and require method information.
+    /// </summary>
+    public interface IMethodedTraitDiscoverer
+    {
+        /// <summary>
+        /// Gets the trait values from the trait attribute.
+        /// </summary>
+        /// <param name="traitAttribute">The trait attribute containing the trait values.</param>
+        /// <param name="methodInfo">The method for which traits should be produced.</param>
+        /// <returns>The trait values.</returns>
+        IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute, IMethodInfo methodInfo);
+    }
+}

--- a/src/xunit.core/Sdk/NamespaceTraitDiscoverer.cs
+++ b/src/xunit.core/Sdk/NamespaceTraitDiscoverer.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// The implementation of <see cref="IMethodedTraitDiscoverer"/> which returns the trait values
+    /// for <see cref="NamespaceTraitAttribute"/>.
+    /// </summary>
+    public class NamespaceTraitDiscoverer : IMethodedTraitDiscoverer
+    {
+        /// <inheritdoc/>
+        public virtual IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute, IMethodInfo methodInfo)
+        {
+            var ctorArgs = traitAttribute.GetConstructorArguments().Cast<string>().ToList();
+
+            if (string.IsNullOrWhiteSpace(ctorArgs[0]))
+                yield break;
+
+            var attributeNamespaceParts = ctorArgs[0].Split('.');
+
+            var methodNamespaceParts = GetMethodNamespaceParts(methodInfo);
+            if (methodNamespaceParts.Length == 0)
+                yield break;
+
+            var caseInsensitiveMatching = traitAttribute.GetNamedArgument<bool>("NamespaceCaseInsensitive");
+            var notForNestedNamespaces = traitAttribute.GetNamedArgument<bool>("NotApplicableToNestedNamespaces");
+
+            if (!CorrespondingNamespace(methodNamespaceParts, attributeNamespaceParts, caseInsensitiveMatching, notForNestedNamespaces))
+                yield break;
+
+            yield return new KeyValuePair<string, string>(ctorArgs[1], ctorArgs[2]);
+        }
+
+        static string[] GetMethodNamespaceParts(IMethodInfo methodInfo)
+        {
+            var name = methodInfo?.Type?.Name;
+            if(string.IsNullOrWhiteSpace(name))
+                return new string[0];
+
+            var nameParts = name.Split('.');
+
+            if(nameParts.Length < 2)
+                return new string[0];
+
+            return nameParts.Take(nameParts.Length - 1).ToArray();
+        }
+
+        static bool CorrespondingNamespace(string[] methodNamespaceParts, string[] attributeNamespaceParts, bool caseInsensitiveMatching, bool notForNestedNamespaces)
+        {
+            if (attributeNamespaceParts.Length > methodNamespaceParts.Length)
+                return false;
+
+            if (notForNestedNamespaces && attributeNamespaceParts.Length < methodNamespaceParts.Length)
+                return false;
+
+            var comparison = caseInsensitiveMatching
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            for (int i = 0; i < attributeNamespaceParts.Length; i++)
+            {
+                if (!string.Equals(attributeNamespaceParts[i], methodNamespaceParts[i], comparison))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/xunit.core/xunit.core.csproj
+++ b/src/xunit.core/xunit.core.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\xunit.assert\Asserts\Sdk\AssertEqualityComparerAdapter.cs">
       <Link>Sdk\AssertEqualityComparerAdapter.cs</Link>
     </Compile>
+    <Compile Include="AssemblyTraitAttribute.cs" />
     <Compile Include="ClassDataAttribute.cs" />
     <Compile Include="CollectionAttribute.cs" />
     <Compile Include="CollectionBehavior.cs" />
@@ -74,9 +75,12 @@
     <Compile Include="MemberDataAttribute.cs" />
     <Compile Include="MemberDataAttributeBase.cs" />
     <Compile Include="Extensions\PropertyDataAttribute.cs" />
+    <Compile Include="NamespaceTraitAttribute.cs" />
     <Compile Include="Record.cs" />
+    <Compile Include="Sdk\AssemblyTraitDiscoverer.cs" />
     <Compile Include="Sdk\BeforeAfterTestAttribute.cs" />
     <Compile Include="Sdk\DataAttribute.cs" />
+    <Compile Include="Sdk\IMethodedTraitDiscoverer.cs" />
     <Compile Include="Sdk\MemberDataDiscoverer.cs" />
     <Compile Include="Sdk\DataDiscoverer.cs" />
     <Compile Include="Sdk\DataDiscovererAttribute.cs" />
@@ -92,6 +96,7 @@
     <Compile Include="Sdk\IXunitTestCaseDiscoverer.cs" />
     <Compile Include="Sdk\IXunitTestCase.cs" />
     <Compile Include="Sdk\IXunitTestCollectionFactory.cs" />
+    <Compile Include="Sdk\NamespaceTraitDiscoverer.cs" />
     <Compile Include="Sdk\PlatformSpecificAssemblyAttribute.cs" />
     <Compile Include="Sdk\RunSummary.cs" />
     <Compile Include="Sdk\TestFrameworkDiscovererAttribute.cs" />

--- a/src/xunit.execution/Sdk/TraitHelper.cs
+++ b/src/xunit.execution/Sdk/TraitHelper.cs
@@ -30,12 +30,27 @@ namespace Xunit.Sdk
                     continue;
 
                 var discoverer = ExtensibilityPointFactory.GetTraitDiscoverer(messageSink, Reflector.Wrap(discovererAttributeData));
-                if (discoverer == null)
+                if (discoverer != null)
+                {
+                    var traits = discoverer.GetTraits(Reflector.Wrap(traitAttributeData));
+                    if (traits != null)
+                        result.AddRange(traits);
                     continue;
+                }
 
-                var traits = discoverer.GetTraits(Reflector.Wrap(traitAttributeData));
-                if (traits != null)
-                    result.AddRange(traits);
+                var methodedDiscoverer = ExtensibilityPointFactory.GetMethodedTraitDiscoverer(messageSink, Reflector.Wrap(discovererAttributeData));
+                if (methodedDiscoverer != null)
+                {
+                    var methodInfo = member as MethodInfo;
+                    if(methodInfo == null)
+                    { continue; }
+
+                    var traits = methodedDiscoverer.GetTraits(Reflector.Wrap(traitAttributeData), Reflector.Wrap(methodInfo));
+                    if (traits != null)
+                        result.AddRange(traits);
+                    continue;
+                }
+
             }
 
             return result;

--- a/test/GlobalTestAssemblyInfo.cs
+++ b/test/GlobalTestAssemblyInfo.cs
@@ -1,6 +1,15 @@
 using System.Reflection;
 using TestDriven.Framework;
+using Xunit;
 using Xunit.Runner.TdNet;
 
 [assembly: CustomTestRunner(typeof(TdNetRunner))]
 [assembly: AssemblyVersion("99.99.99.0")]
+
+[assembly: AssemblyTrait("Assembly", "Trait")]
+[assembly: NamespaceTrait("OuterNamespace", "OuterNamespace", "Trait")]
+[assembly: NamespaceTrait("outerNamespace", "outerNamespace", "Trait")]
+[assembly: NamespaceTrait("outerNamespace", "ciOuterNamespace", "Trait", NamespaceCaseInsensitive = true, NotApplicableToNestedNamespaces = true)]
+
+[assembly: NamespaceTrait("OuterNamespace.InnerNamespace", "InnerNamespace", "Trait")]
+

--- a/test/test.xunit.execution/Common/TraitHelperTests.cs
+++ b/test/test.xunit.execution/Common/TraitHelperTests.cs
@@ -41,7 +41,8 @@ public class TraitHelperTests
 
         Assert.Collection(traits.Select(kvp => $"{kvp.Key} = {kvp.Value}").OrderBy(_ => _, StringComparer.OrdinalIgnoreCase),
             value => Assert.Equal("Baz = 2112", value),
-            value => Assert.Equal("Foo = Biff", value)
+            value => Assert.Equal("Foo = Biff", value),
+            value => Assert.Equal("MethodName = CustomTrait", value)
         );
     }
 
@@ -69,6 +70,7 @@ public class TraitHelperTests
         public void Trait() { }
 
         [CustomTrait]
+        [CustomMethodedTrait]
         public void CustomTrait() { }
 
         [Trait("foo", "bar")]
@@ -80,12 +82,23 @@ public class TraitHelperTests
     [TraitDiscoverer("TraitHelperTests+CustomTraitDiscoverer", "test.xunit.execution")]
     class CustomTraitAttribute : Attribute, ITraitAttribute { }
 
+    [TraitDiscoverer("TraitHelperTests+CustomMethodedTraitDiscoverer", "test.xunit.execution")]
+    class CustomMethodedTraitAttribute : Attribute, ITraitAttribute { }
+
     class CustomTraitDiscoverer : ITraitDiscoverer
     {
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             yield return new KeyValuePair<string, string>("Foo", "Biff");
             yield return new KeyValuePair<string, string>("Baz", "2112");
+        }
+    }
+
+    class CustomMethodedTraitDiscoverer : IMethodedTraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute, IMethodInfo method)
+        {
+            yield return new KeyValuePair<string, string>("MethodName", method.Name);
         }
     }
 }

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
@@ -69,6 +69,11 @@ public class XunitTestCaseTests
                 passingTest => Assert.Collection(passingTest.TestCase.Traits.OrderBy(x => x.Key),
                     namedTrait =>
                     {
+                        Assert.Equal("Assembly", namedTrait.Key);
+                        Assert.Collection(namedTrait.Value, value => Assert.Equal("Trait", value));
+                    },
+                    namedTrait =>
+                    {
                         Assert.Equal("Author", namedTrait.Key);
                         Assert.Collection(namedTrait.Value, value => Assert.Equal("Some Schmoe", value));
                     },

--- a/test/test.xunit.execution/Sdk/TestCaseSerializerTests.cs
+++ b/test/test.xunit.execution/Sdk/TestCaseSerializerTests.cs
@@ -46,6 +46,11 @@ public class TestCaseSerializerTests
             Assert.Collection(result.Traits.Keys,
                 key =>
                 {
+                    Assert.Equal("Assembly", key);
+                    Assert.Equal("Trait", Assert.Single(result.Traits[key]));
+                },
+                key =>
+                {
                     Assert.Equal("name", key);
                     Assert.Equal("value", Assert.Single(result.Traits[key]));
                 });
@@ -107,6 +112,11 @@ public class TestCaseSerializerTests
             Assert.Equal(testCase.SkipReason, result.SkipReason);
             Assert.Null(result.TestMethodArguments);
             Assert.Collection(result.Traits.Keys,
+                key =>
+                {
+                    Assert.Equal("Assembly", key);
+                    Assert.Equal("Trait", Assert.Single(result.Traits[key]));
+                },
                 key =>
                 {
                     Assert.Equal("name", key);


### PR DESCRIPTION
I think it would be nice to be able to put traits not only on classes and methods, but also on assemblies and namespaces. For example my solution in Visual Studio can contain several projects with unit tests and several projects with integration tests. I would like to put in projects with unit tests trait "TestType" = "Unit" and in projects with integration tests trait "TestType" = "Integration". So I implemented AssemblyTrait attribute and made XUnit to check assembly attributes for traits as well.

Here is another example. My solution may have one project with unit tests and one project with integration tests. I may want to place trait "SubSystem" = "Data" on namespaces in both projects to be able to run all tests for given sub-system. It is more difficult to solve this problem. C# does not allow to actually place attributes on namespaces. So NamespaceAttribute is also applied to assembly.  ITraitDiscoverer does not have any information about namespace of method for which it should provide traits. So I introduced new interface IMethodedTraitDiscoverer that accepts both IAttributeInfo and IMethodInfo into the GetTraits method. From IMethodInfo one can extract information about namespace of current method.

NamespaceAttribute has two properties. NamespaceCaseInsensitive specifies if namespace of current method should be compared with namespace of attribute disregarding case of letters. Default value is false as C# is case sensitive language. NotApplicableToNestedNamespaces allows not to apply this trait to "nested" namespaces. For example if trait is applied to "OuterNamespace" namespace then by default it also applied to "OuterNamespace.InnerNamespace" namespace. Default value of this property is false.

