### PR TITLE
Refactor AssertEqualityComparer to handle sets

### DIFF
--- a/src/xunit.assert.nuspec
+++ b/src/xunit.assert.nuspec
@@ -22,6 +22,8 @@ Supported platforms:
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <group targetFramework="dotnet">
+        <dependency id="System.Linq.Expressions" version="4.0.0" />
+        <dependency id="System.Linq.Queryable" version="4.0.0" />
         <dependency id="System.Collections" version="4.0.0" />
         <dependency id="System.Diagnostics.Debug" version="4.0.0" />
         <dependency id="System.Globalization" version="4.0.0" />

--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -28,6 +28,8 @@ Supported platforms:
       <group targetFramework="dotnet">
         <dependency id="xunit.extensibility.core" version="[99.99.99-dev]" />
         <dependency id="xunit.extensibility.execution" version="[99.99.99-dev]" />
+        <dependency id="System.Linq.Expressions" version="4.0.0" />
+        <dependency id="System.Linq.Queryable" version="4.0.0" />
         <dependency id="System.Collections" version="4.0.0" />
         <dependency id="System.Diagnostics.Debug" version="4.0.0" />
         <dependency id="System.Globalization" version="4.0.0" />

--- a/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/CollectionAssertsTests.cs
@@ -463,6 +463,49 @@ public class CollectionAssertsTests
         }
     }
 
+    public class EqualSet
+    {
+        [Fact]
+        public static void InOrderSet()
+        {
+            var expected = new HashSet<int> { 1, 2, 3};
+            var actual = new HashSet<int>  { 1, 2, 3 };
+
+            Assert.Equal(expected, actual);
+            Assert.Throws<NotEqualException>(() => Assert.NotEqual(expected, actual));
+        }
+
+        [Fact]
+        public static void OutOfOrderSet()
+        {
+            var expected = new HashSet<int> { 1, 2, 3 };
+            var actual = new HashSet<int> { 2, 3, 1 };
+
+            Assert.Equal(expected, actual);
+            Assert.Throws<NotEqualException>(() => Assert.NotEqual(expected, actual));
+        }
+
+        [Fact]
+        public static void ExpectedLarger()
+        {
+            var expected = new HashSet<int> { 1, 2, 3 };
+            var actual = new HashSet<int> { 1, 2};
+
+            Assert.NotEqual(expected, actual);
+            Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
+        }
+
+        [Fact]
+        public static void ActualLarger()
+        {
+            var expected = new HashSet<int> { 1, 2};
+            var actual = new HashSet<int> { 1, 2, 3 };
+
+            Assert.NotEqual(expected, actual);
+            Assert.Throws<EqualException>(() => Assert.Equal(expected, actual));
+        }
+    }
+
     public class Equal_WithComparer
     {
         [Fact]


### PR DESCRIPTION
Issue #240 

It was a little tricky checking whether the type implements `ISet` as there is no non generic `ISet` (as opposed to `IDictionary`).

I added the `ObjectEqualityComparerAdapter` class to be able to use the innerComparer if there is one and I couldn't use the `DefaultInnerComparer` since `AssertEqualityComparerAdapter` doesn't implement `GetHashCode`. Although, I couldn't find a way to pass a custom inner comparer (opened a suggestion - issue #640).