### PR TITLE
catch special case of ArgumentFormatter.Format(object) where the para…

### DIFF
--- a/src/xunit.assert/Asserts/Sdk/ArgumentFormatter.cs
+++ b/src/xunit.assert/Asserts/Sdk/ArgumentFormatter.cs
@@ -172,6 +172,11 @@ namespace Xunit.Sdk
 
             // Strip off generic suffix
             var name = typeInfo.FullName;
+
+            // catch special case of generic parameters not being bound to a specific type:
+            if (name == null)
+                return typeInfo.Name;
+
             var tickIdx = name.IndexOf('`');
             if (tickIdx > 0)
                 name = name.Substring(0, tickIdx);

--- a/test/test.xunit.execution/ArgumentFormatterTests.cs
+++ b/test/test.xunit.execution/ArgumentFormatterTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    public class ArgumentFormatterTests
+    {
+        [Theory]
+        [InlineData(typeof(int), "typeof(int)")]
+        [InlineData(typeof(long), "typeof(long)")]
+        [InlineData(typeof(string), "typeof(string)")]
+        [InlineData(typeof(String), "typeof(string)")]
+        [InlineData(typeof(int), "typeof(int)")]
+        [InlineData(typeof(List<int>), "typeof(System.Collections.Generic.List<int>)")]
+        [InlineData(typeof(Dictionary<int, string>), "typeof(System.Collections.Generic.Dictionary<int, string>)")]
+        [InlineData(typeof(List<>), "typeof(System.Collections.Generic.List<>)")]
+        [InlineData(typeof(Dictionary<,>), "typeof(System.Collections.Generic.Dictionary<,>)")]
+        public void ArgumentFormatterFormatTypeNames(Type type, string expectedResult)
+        {
+            Assert.Equal(ArgumentFormatter.Format(type), expectedResult);
+        }
+
+        [Fact]
+        public void ArgumentFormatterFormatTypeNameGenericTypeParameter()
+        {
+            var typeInfo = typeof (List<>).GetTypeInfo();
+            var genericTypeParameters = typeInfo.GenericTypeParameters;
+            var parameterType = genericTypeParameters.First();
+                                
+            Assert.Equal(ArgumentFormatter.Format(parameterType), "typeof(T)");
+        }
+
+        [Fact]
+        public void ArgumentFormatterFormatTypeNameGenericTypeParameters()
+        {
+            var typeInfo = typeof(Dictionary<,>).GetTypeInfo();
+            var genericTypeParameters = typeInfo.GenericTypeParameters;
+            var parameterTKey = genericTypeParameters.First();
+
+            Assert.Equal(ArgumentFormatter.Format(parameterTKey), "typeof(TKey)");
+
+            var parameterTValue = genericTypeParameters.Last();
+            Assert.Equal(ArgumentFormatter.Format(parameterTValue), "typeof(TValue)");
+
+        }
+    }
+}

--- a/test/test.xunit.execution/test.xunit.execution.csproj
+++ b/test/test.xunit.execution/test.xunit.execution.csproj
@@ -93,6 +93,7 @@
     </Compile>
     <Compile Include="Common\XunitSerializationInfoTests.cs" />
     <Compile Include="Extensions\ReflectionAbstractionExtensionsTests.cs" />
+    <Compile Include="ArgumentFormatterTests.cs" />
     <Compile Include="Sdk\ArgumentFormatterTests.cs" />
     <Compile Include="Sdk\DefaultTestCaseOrdererTests.cs" />
     <Compile Include="Sdk\ExtensibilityPointFactoryTests.cs" />


### PR DESCRIPTION
solving bug in `ArgumentFormatter.Format(object)` when parameter is a generic type parameter not bound to a specific type, as explained in #634. 