### PR TITLE
Add JsonReporter with tests

### DIFF
--- a/src/xunit.runner.reporters/JsonExtentions.cs
+++ b/src/xunit.runner.reporters/JsonExtentions.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+#if PLATFORM_DOTNET
+using Newtonsoft.Json;
+#else
+using System.Web.Script.Serialization;
+#endif
+
+namespace Xunit.Runner.Reporters
+{
+    public static class JsonExtentions
+    {
+        static string ToJson(object data)
+        {
+            #if PLATFORM_DOTNET
+                                return JsonConvert.SerializeObject(data);
+            #else
+                        return new JavaScriptSerializer().Serialize(data);
+            #endif
+        }
+
+        #region Field Adders
+        delegate void AddFields(object obj, Dictionary<string,object> dict);
+
+        static AddFields AddFieldsForITestCollectionMessage = (obj, dict) =>
+        {
+            var testCollectionMesage = obj as ITestCollectionMessage;
+            if (testCollectionMesage == null) return;
+
+            dict["assembly"] = testCollectionMesage.TestAssembly.Assembly.Name;
+            dict["collectionName"] = testCollectionMesage.TestCollection.DisplayName;
+            dict["collectionId"] = testCollectionMesage.TestCollection.UniqueID;
+        };
+
+        static AddFields AddFieldsForIFinishedMessage = (obj, dict) =>
+        {
+            var finishedMessage = obj as IFinishedMessage;
+            if (finishedMessage == null) return;
+
+            dict["executionTime"] = finishedMessage.ExecutionTime;
+            dict["testsFailed"] = finishedMessage.TestsFailed;
+            dict["testsRun"] = finishedMessage.TestsRun;
+            dict["testsSkipped"] = finishedMessage.TestsSkipped;
+        };
+
+        static AddFields AddFieldsForITestResultMessage = (obj, dict) =>
+        {
+            var testResultMessage = obj as ITestResultMessage;
+            if (testResultMessage == null) return;
+
+            dict["executionTime"] = testResultMessage.ExecutionTime;
+            dict["testStdOut"] = testResultMessage.Output;
+        };
+
+        static AddFields AddFieldsForITestMessage = (obj, dict) =>
+        {
+            var testMessage = obj as ITestMessage;
+            if (testMessage == null) return;
+
+            dict["testName"] = testMessage.Test.DisplayName;
+        };
+
+
+        static AddFields AddFieldsForIFailureInformation = (obj, dict) =>
+        {
+            var failureInformation = obj as IFailureInformation;
+            if (failureInformation == null) return;
+
+            dict["errorMessages"] = ExceptionUtility.CombineMessages(failureInformation);
+            dict["stackTraces"] = ExceptionUtility.CombineStackTraces(failureInformation);
+        };
+
+        static Dictionary<Type, List<AddFields>> TypeToFieldAdders = new Dictionary<Type, List<AddFields>>()
+        {
+            {typeof(ITestCollectionStarting), new List<AddFields> { AddFieldsForITestCollectionMessage } },
+            {typeof(ITestStarting), new List<AddFields> { AddFieldsForITestMessage } },
+            {typeof(ITestSkipped), new List<AddFields> { AddFieldsForITestResultMessage, AddFieldsForITestMessage } },
+            {typeof(IErrorMessage), new List<AddFields> { AddFieldsForIFailureInformation } },
+            {typeof(ITestPassed), new List<AddFields> { AddFieldsForITestResultMessage } },
+            {typeof(ITestFailed), new List<AddFields> { AddFieldsForITestResultMessage, AddFieldsForIFailureInformation, AddFieldsForITestMessage } },
+            {typeof(ITestMethodCleanupFailure), new List<AddFields> { AddFieldsForIFailureInformation } },
+            {typeof(ITestCleanupFailure), new List<AddFields> { AddFieldsForIFailureInformation } },
+            {typeof(ITestCollectionFinished), new List<AddFields> { AddFieldsForITestCollectionMessage, AddFieldsForIFinishedMessage } },
+            {typeof(ITestCollectionCleanupFailure), new List<AddFields> { AddFieldsForIFailureInformation, AddFieldsForITestCollectionMessage } },
+            {typeof(ITestClassCleanupFailure), new List<AddFields> { AddFieldsForIFailureInformation } },
+            {typeof(ITestAssemblyCleanupFailure), new List<AddFields> { AddFieldsForIFailureInformation } },
+            {typeof(ITestCaseCleanupFailure), new List<AddFields> { AddFieldsForIFailureInformation } }
+        };
+
+        #endregion
+
+        static Dictionary<string, object> initObject(string messageName, object message, Type messageType, string flowId = null)
+        {
+            TypeToFieldAdders[typeof(ITestCollectionStarting)].Add(AddFieldsForITestCollectionMessage);
+            var dict = new Dictionary<string, object>();
+            dict["message"] = messageName;
+            if (flowId != null) dict["flowId"] = flowId;
+            foreach (var adder in TypeToFieldAdders[messageType])
+                adder(message, dict);
+
+            return dict;
+        }
+
+        #region Json Serializations
+        public static string ToJson(this ITestCollectionStarting testCollectionStarting, string flowId)
+        {
+            var json = initObject("testCollectionStarting", testCollectionStarting, typeof(ITestCollectionStarting), flowId);
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestCollectionFinished testCollectionFinished, string flowId)
+        {
+            var json = initObject("testCollectionFinished", testCollectionFinished, typeof(ITestCollectionFinished), flowId);
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestFailed testFailed, string flowId)
+        {
+            var json = initObject("testFailed", testFailed, typeof(ITestFailed), flowId);
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestSkipped testSkipped, string flowId)
+        {
+            var json = initObject("testSkipped", testSkipped, typeof(ITestSkipped), flowId);
+            json["reason"] = testSkipped.Reason;
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestStarting testStarting, string flowId)
+        {
+            var json = initObject("testStarting", testStarting, typeof(ITestStarting), flowId);
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this IErrorMessage errorMessage)
+        {
+            var json = initObject("fatalError", errorMessage, typeof(IErrorMessage));
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestPassed testPassed, string flowId)
+        {
+            var json = initObject("testPassed", testPassed, typeof(ITestPassed), flowId);
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestMethodCleanupFailure ITestMethodCleanupFailure)
+        {
+            var json = initObject("testMethodCleanupFailure", ITestMethodCleanupFailure, typeof(ITestMethodCleanupFailure));
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestCleanupFailure testCleanupFailure)
+        {
+            var json = initObject("testCleanupFailure", testCleanupFailure, typeof(ITestCleanupFailure));
+
+            return ToJson(json);
+        }
+
+
+        public static string ToJson(this ITestCollectionCleanupFailure testCollectionCleanupFailure)
+        {
+            var json = initObject("testCollectionCleanupFailure", testCollectionCleanupFailure, typeof(ITestCollectionCleanupFailure));
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestClassCleanupFailure testClassCleanupFailure)
+        {
+            var json = initObject("testClassCleanupFailure", testClassCleanupFailure, typeof(ITestClassCleanupFailure));
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestAssemblyCleanupFailure testAssemblyCleanupFailure)
+        {
+            var json = initObject("testAssemblyCleanupFailure", testAssemblyCleanupFailure, typeof(ITestAssemblyCleanupFailure));
+
+            return ToJson(json);
+        }
+
+        public static string ToJson(this ITestCaseCleanupFailure testAssemblyCleanupFailure)
+        {
+            var json = initObject("testAssemblyCleanupFailure", testAssemblyCleanupFailure, typeof(ITestCaseCleanupFailure));
+
+            return ToJson(json);
+        }
+
+        #endregion
+    }
+}

--- a/src/xunit.runner.reporters/JsonReporter.cs
+++ b/src/xunit.runner.reporters/JsonReporter.cs
@@ -1,0 +1,19 @@
+using Xunit.Abstractions;
+
+namespace Xunit.Runner.Reporters
+{
+    public class JsonReporter : IRunnerReporter
+    {
+        public string Description
+          => "show progress messages in JSON format";
+
+        public bool IsEnvironmentallyEnabled
+            => false;
+
+        public string RunnerSwitch
+            => "json";
+
+        public IMessageSink CreateMessageHandler(IRunnerLogger logger)
+            => new JsonReporterMessageHandler(logger);
+    }
+}

--- a/src/xunit.runner.reporters/JsonReporterMessageHandler.cs
+++ b/src/xunit.runner.reporters/JsonReporterMessageHandler.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace Xunit.Runner.Reporters
+{
+    public class JsonReporterMessageHandler : TestMessageVisitor
+    {
+        readonly Func<string, string> flowIdMapper;
+        readonly Dictionary<string, string> flowMappings = new Dictionary<string, string>();
+        readonly ReaderWriterLockSlim flowMappingsLock = new ReaderWriterLockSlim();
+        readonly IRunnerLogger logger;
+
+        public JsonReporterMessageHandler(IRunnerLogger logger)
+        {
+            this.logger = logger;
+            this.flowIdMapper = (_ => Guid.NewGuid().ToString("N"));
+        }
+
+        protected override bool Visit(IErrorMessage error)
+        {
+            logger.LogImportantMessage(error.ToJson());
+
+            return base.Visit(error);
+        }
+
+        protected override bool Visit(ITestAssemblyCleanupFailure cleanupFailure)
+        {
+            logger.LogImportantMessage(cleanupFailure.ToJson());
+
+            return base.Visit(cleanupFailure);
+        }
+
+        protected override bool Visit(ITestCaseCleanupFailure cleanupFailure)
+        {
+            logger.LogImportantMessage(cleanupFailure.ToJson());
+
+            return base.Visit(cleanupFailure);
+        }
+
+        protected override bool Visit(ITestClassCleanupFailure cleanupFailure)
+        {
+            logger.LogImportantMessage(cleanupFailure.ToJson());
+
+            return base.Visit(cleanupFailure);
+        }
+
+        protected override bool Visit(ITestCollectionCleanupFailure cleanupFailure)
+        {
+            logger.LogImportantMessage(cleanupFailure.ToJson());
+
+            return base.Visit(cleanupFailure);
+        }
+
+        protected override bool Visit(ITestCollectionFinished testCollectionFinished)
+        {
+            logger.LogImportantMessage(testCollectionFinished.ToJson(ToFlowId(testCollectionFinished.TestCollection.DisplayName)));
+
+            return base.Visit(testCollectionFinished);
+        }
+
+        protected override bool Visit(ITestCollectionStarting testCollectionStarting)
+        {
+            logger.LogImportantMessage(testCollectionStarting.ToJson(ToFlowId(testCollectionStarting.TestCollection.DisplayName)));
+
+            return base.Visit(testCollectionStarting);
+        }
+
+        protected override bool Visit(ITestCleanupFailure cleanupFailure)
+        {
+            logger.LogImportantMessage(cleanupFailure.ToJson());
+
+            return base.Visit(cleanupFailure);
+        }
+
+        protected override bool Visit(ITestFailed testFailed)
+        {
+            logger.LogImportantMessage(testFailed.ToJson(ToFlowId(testFailed.TestCollection.DisplayName)));
+
+            return base.Visit(testFailed);
+        }
+
+        protected override bool Visit(ITestMethodCleanupFailure cleanupFailure)
+        {
+            logger.LogImportantMessage(cleanupFailure.ToJson());
+
+            return base.Visit(cleanupFailure);
+        }
+
+        protected override bool Visit(ITestPassed testPassed)
+        {
+            logger.LogImportantMessage(testPassed.ToJson(ToFlowId(testPassed.TestCollection.DisplayName)));
+
+            return base.Visit(testPassed);
+        }
+
+        protected override bool Visit(ITestSkipped testSkipped)
+        {
+            logger.LogImportantMessage(testSkipped.ToJson(ToFlowId(testSkipped.TestCollection.DisplayName)));
+
+            return base.Visit(testSkipped);
+        }
+
+        protected override bool Visit(ITestStarting testStarting)
+        {
+            logger.LogImportantMessage(testStarting.ToJson(ToFlowId(testStarting.TestCollection.DisplayName)));
+
+            return base.Visit(testStarting);
+        }
+
+        string ToFlowId(string testCollectionName)
+        {
+            string result;
+
+            flowMappingsLock.EnterReadLock();
+
+            try
+            {
+                if (flowMappings.TryGetValue(testCollectionName, out result))
+                    return result;
+            }
+            finally
+            {
+                flowMappingsLock.ExitReadLock();
+            }
+
+            flowMappingsLock.EnterWriteLock();
+
+            try
+            {
+                if (!flowMappings.TryGetValue(testCollectionName, out result))
+                {
+                    result = flowIdMapper(testCollectionName);
+                    flowMappings[testCollectionName] = result;
+                }
+
+                return result;
+            }
+            finally
+            {
+                flowMappingsLock.ExitWriteLock();
+            }
+        }
+    }
+}

--- a/test/test.xunit.runner.reporters/JsonReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.reporters/JsonReporterMessageHandlerTests.cs
@@ -1,0 +1,94 @@
+﻿using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+using Xunit.Abstractions;
+
+namespace Xunit.Runner.Reporters
+{
+    public class JsonReporterMessageHandlerTests
+    {
+        static TMessageType MakeFailureInformationSubstitute<TMessageType>()
+            where TMessageType : class, IFailureInformation
+        {
+            var result = Substitute.For<TMessageType, InterfaceProxy<TMessageType>>();
+            result.ExceptionTypes.Returns(new[] { "ExceptionType" });
+            result.Messages.Returns(new[] { "This is my message \t\r\n" });
+            result.StackTraces.Returns(new[] { "Line 1\r\nLine 2\r\nLine 3" });
+            return result;
+        }
+
+        public static IEnumerable<object[]> Messages
+        {
+            get
+            {
+                yield return new[] { Mocks.TestSkipped("This is my display name \t\r\n", "This is my skip reason \t\r\n") };
+                yield return new[] { Mocks.TestStarting("This is my display name \t\r\n") };
+                yield return new[] { Mocks.TestPassed("This is my display name \t\r\n", "This is\t\r\noutput") };
+                yield return new[] { Mocks.TestFailed("This is my display name \t\r\n", 1.2345M, "ExceptionType", "This is my message \t\r\n", "Line 1\r\nLine 2\r\nLine 3", "This is\t\r\noutput") };
+                yield return new[] { Mocks.TestCollectionStarting() };
+                yield return new[] { Mocks.TestCollectionFinished() };
+
+                // IErrorMessage
+                yield return new object[] { MakeFailureInformationSubstitute<IErrorMessage>()};
+
+                // ITestAssemblyCleanupFailure
+                var assemblyCleanupFailure = MakeFailureInformationSubstitute<ITestAssemblyCleanupFailure>();
+                var testAssembly = Mocks.TestAssembly(@"C:\Foo\bar.dll");
+                assemblyCleanupFailure.TestAssembly.Returns(testAssembly);
+                yield return new object[] { assemblyCleanupFailure };
+
+                // ITestCollectionCleanupFailure
+                var collectionCleanupFailure = MakeFailureInformationSubstitute<ITestCollectionCleanupFailure>();
+                var testCollection = Mocks.TestCollection(displayName: "FooBar");
+                collectionCleanupFailure.TestCollection.Returns(testCollection);
+                yield return new object[] { collectionCleanupFailure };
+
+                // ITestClassCleanupFailure
+                var classCleanupFailure = MakeFailureInformationSubstitute<ITestClassCleanupFailure>();
+                var testClass = Mocks.TestClass("MyType");
+                classCleanupFailure.TestClass.Returns(testClass);
+                yield return new object[] { classCleanupFailure };
+
+                // ITestMethodCleanupFailure
+                var methodCleanupFailure = MakeFailureInformationSubstitute<ITestMethodCleanupFailure>();
+                var testMethod = Mocks.TestMethod(methodName: "MyMethod");
+                methodCleanupFailure.TestMethod.Returns(testMethod);
+                yield return new object[] { methodCleanupFailure };
+
+                // ITestCaseCleanupFailure
+                var testCaseCleanupFailure = MakeFailureInformationSubstitute<ITestCaseCleanupFailure>();
+                var testCase = Mocks.TestCase(typeof(object), "ToString", displayName: "MyTestCase");
+                testCaseCleanupFailure.TestCase.Returns(testCase);
+                yield return new object[] { testCaseCleanupFailure };
+
+                // ITestCleanupFailure
+                var testCleanupFailure = MakeFailureInformationSubstitute<ITestCleanupFailure>();
+                var test = Mocks.Test(testCase, "MyTest");
+                testCleanupFailure.Test.Returns(test);
+                yield return new object[] { testCleanupFailure };
+
+            }
+        }
+
+        [Theory]
+        [MemberData("Messages")]
+        public static void LogsMessage(IMessageSinkMessage message)
+        {
+            //Arrange
+            var logger = Substitute.For<IRunnerLogger>();
+            var jsonReporterMessageHandler = new JsonReporterMessageHandler(logger);
+            string output = null;
+            logger.LogImportantMessage(Arg.Do<string>(str => output = str));
+
+            //Act
+            jsonReporterMessageHandler.OnMessage(message);
+
+            //Assert
+            var json = new System.Web.Script.Serialization.JavaScriptSerializer().DeserializeObject(output);
+        }
+    }
+}

--- a/test/test.xunit.runner.reporters/test.xunit.runner.reporters.csproj
+++ b/test/test.xunit.runner.reporters/test.xunit.runner.reporters.csproj
@@ -37,6 +37,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
(issue #287)
Added a JsonReporter that can be used with the flag '-json'.
I added the messages and fields I thought would be useful, but I built it in a way that would make it easy to add more fields.
The tests verify that all of the messages are valid JSONs.

Here is an output example (running on the reporters test assembly):
https://gist.github.com/odedw/01cdda96f1ae5143406f#file-gistfile1-txt