### PR TITLE
Use FileShare.Read when opening transform files

### DIFF
--- a/src/xunit.console/Utility/TransformFactory.cs
+++ b/src/xunit.console/Utility/TransformFactory.cs
@@ -60,7 +60,7 @@ namespace Xunit.ConsoleClient
             var xmlTransform = new XslCompiledTransform();
 
             using (var writer = XmlWriter.Create(outputFileName, new XmlWriterSettings { Indent = true }))
-            using (var xsltStream = File.Open(xslPath, FileMode.Open, FileAccess.Read))
+            using (var xsltStream = File.Open(xslPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var xsltReader = XmlReader.Create(xsltStream))
             using (var xmlReader = xml.CreateReader())
             {


### PR DESCRIPTION
This allows xunit process to run in parallel without contending for access to the transform file.

closes #656