### PR TITLE
Allow asserting that a specific piece of code raises a specific event.

### DIFF
--- a/src/xunit.assert/Asserts/EventAsserts.cs
+++ b/src/xunit.assert/Asserts/EventAsserts.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    public partial class Assert
+    {
+        /// <summary>
+        /// Verifies that a event with the exact event args is raised.
+        /// </summary>
+        /// <typeparam name="T">The type of the event arguments to expect</typeparam>
+        /// <param name="attach">Code to attach the event handler</param>
+        /// <param name="detach">Code to detach the event handler</param>
+        /// <param name="testCode">A delegate to the code to be tested</param>
+        /// <returns>The event sender and arguments wrapped in an object</returns>
+        /// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+        public static RaisedEvent<T> Raises<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Action testCode) 
+            where T : EventArgs
+        {
+            var raisedEvent = RaisesInternal(attach, detach, testCode);
+
+            if (raisedEvent == null)
+                throw new RaisesException(typeof(T));
+
+            if (!raisedEvent.Arguments.GetType().Equals(typeof(T)))
+                throw new RaisesException(typeof(T), raisedEvent.Arguments.GetType());
+
+            return raisedEvent;
+        }
+
+        /// <summary>
+        /// Verifies that an event with the exact or a derived event args is raised.
+        /// </summary>
+        /// <typeparam name="T">The type of the event arguments to expect</typeparam>
+        /// <param name="attach">Code to attach the event handler</param>
+        /// <param name="detach">Code to detach the event handler</param>
+        /// <param name="testCode">A delegate to the code to be tested</param>
+        /// <returns>The event sender and arguments wrapped in an object</returns>
+        /// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+        public static RaisedEvent<T> RaisesAny<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Action testCode)
+            where T : EventArgs
+        {
+            var raisedEvent = RaisesInternal(attach, detach, testCode);
+
+            if (raisedEvent == null)
+                throw new RaisesException(typeof(T));
+
+            return raisedEvent;
+        }
+
+        /// <summary>
+        /// Verifies that a event with the exact event args (and not a derived type) is raised.
+        /// </summary>
+        /// <typeparam name="T">The type of the event arguments to expect</typeparam>
+        /// <param name="attach">Code to attach the event handler</param>
+        /// <param name="detach">Code to detach the event handler</param>
+        /// <param name="testCode">A delegate to the code to be tested</param>
+        /// <returns>The event sender and arguments wrapped in an object</returns>
+        /// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+        public static async Task<RaisedEvent<T>> RaisesAsync<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Func<Task> testCode)
+            where T : EventArgs
+        {
+            var raisedEvent = await RaisesAsyncInternal(attach, detach, testCode);
+
+            if (raisedEvent == null)
+                throw new RaisesException(typeof(T));
+
+            if (!raisedEvent.Arguments.GetType().Equals(typeof(T)))
+                throw new RaisesException(typeof(T), raisedEvent.Arguments.GetType());
+
+            return raisedEvent;
+        }
+
+        /// <summary>
+        /// Verifies that a event with the exact event args (and not a derived type) is raised.
+        /// </summary>
+        /// <typeparam name="T">The type of the event arguments to expect</typeparam>
+        /// <param name="attach">Code to attach the event handler</param>
+        /// <param name="detach">Code to detach the event handler</param>
+        /// <param name="testCode">A delegate to the code to be tested</param>
+        /// <returns>The event sender and arguments wrapped in an object</returns>
+        /// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+        public static async Task<RaisedEvent<T>> RaisesAnyAsync<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Func<Task> testCode)
+            where T : EventArgs
+        {
+            var raisedEvent = await RaisesAsyncInternal(attach, detach, testCode);
+
+            if (raisedEvent == null)
+                throw new RaisesException(typeof(T));
+
+            return raisedEvent;
+        }
+
+        static RaisedEvent<T> RaisesInternal<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Action testCode)
+            where T : EventArgs
+        {
+            RaisedEvent<T> raisedEvent = null;
+            EventHandler<T> handler = delegate(object s, T args) { raisedEvent = new RaisedEvent<T>(s, args); };
+            attach(handler);
+            testCode();
+            detach(handler);
+            return raisedEvent;
+        }
+
+        static async Task<RaisedEvent<T>> RaisesAsyncInternal<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Func<Task> testCode) 
+            where T : EventArgs
+        {
+            RaisedEvent<T> raisedEvent = null;
+            EventHandler<T> handler = delegate(object s, T args) { raisedEvent = new RaisedEvent<T>(s, args); };
+            attach(handler);
+            await testCode();
+            detach(handler);
+            return raisedEvent;
+        }
+
+        /// <summary>
+        /// Represents a raised event after the fact.
+        /// </summary>
+        /// <typeparam name="T">The type of the event arguments.</typeparam>
+        public class RaisedEvent<T>
+            where T : EventArgs
+        {
+            /// <summary>
+            /// The sender of the event.
+            /// </summary>
+            public object Sender { get; }
+
+            /// <summary>
+            /// The event arguments.
+            /// </summary>
+            public T Arguments { get; }
+
+            /// <summary>
+            /// Creates a new instance of the <see cref="RaisedEvent{T}" /> class.
+            /// </summary>
+            /// <param name="sender">The sender of the event.</param>
+            /// <param name="args">The event arguments</param>
+            public RaisedEvent(object sender, T args)
+            {
+                this.Sender = sender;
+                this.Arguments = args;
+            }
+        }
+    }
+}

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/RaisesException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/RaisesException.cs
@@ -1,0 +1,91 @@
+﻿namespace Xunit.Sdk
+{
+    using System;
+    using System.Collections;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Exception thrown when code unexpectedly fails to raise an event.
+    /// </summary>
+    public class RaisesException : XunitException
+    {
+        readonly string stackTrace = null;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="RaisesException" /> class. Call this constructor
+        /// when no event was raised.
+        /// </summary>
+        /// <param name="expected">The type of the event args that was expected</param>
+        public RaisesException(Type expected)
+            : base("(No event was raised)")
+        {
+            Expected = ConvertToSimpleTypeName(expected.GetTypeInfo());
+            Actual = base.UserMessage;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="RaisesException" /> class. Call this constructor
+        /// when an
+        /// </summary>
+        /// <param name="expected"></param>
+        /// <param name="actual"></param>
+        public RaisesException(Type expected, Type actual)
+            : base("(Raised event did not match expected event)")
+        {
+            Expected = ConvertToSimpleTypeName(expected.GetTypeInfo());
+            Actual = ConvertToSimpleTypeName(actual.GetTypeInfo());
+        }
+
+        /// <summary>
+        /// Gets the actual value.
+        /// </summary>
+        public string Actual { get; }
+
+        /// <summary>
+        /// Gets the expected value.
+        /// </summary>
+        public string Expected { get; }
+
+        /// <summary>
+        /// Gets a message that describes the current exception. Includes the expected and actual values.
+        /// </summary>
+        /// <returns>The error message that explains the reason for the exception, or an empty string("").</returns>
+        /// <filterpriority>1</filterpriority>
+        public override string Message
+        {
+            get
+            {
+                return string.Format(CultureInfo.CurrentCulture,
+                                     "{0}{3}{1}{3}{2}",
+                                     base.Message,
+                                     Expected ?? "(null)",
+                                     Actual ?? "(null)",
+                                     Environment.NewLine);
+            }
+        }
+
+        /// <summary>
+        /// Gets a string representation of the frames on the call stack at the time the current exception was thrown.
+        /// </summary>
+        /// <returns>A string that describes the contents of the call stack, with the most recent method call appearing first.</returns>
+        public override string StackTrace
+        {
+            get { return stackTrace ?? base.StackTrace; }
+        }
+
+        static string ConvertToSimpleTypeName(TypeInfo typeInfo)
+        {
+            if (!typeInfo.IsGenericType)
+                return typeInfo.Name;
+
+            var simpleNames = typeInfo.GenericTypeArguments.Select(type => ConvertToSimpleTypeName(type.GetTypeInfo()));
+            var backTickIdx = typeInfo.Name.IndexOf('`');
+            if (backTickIdx < 0)
+                backTickIdx = typeInfo.Name.Length;  // F# doesn't use backticks for generic type names
+
+            return string.Format("{0}<{1}>", typeInfo.Name.Substring(0, backTickIdx), string.Join(", ", simpleNames));
+        }
+    }
+}

--- a/src/xunit.assert/xunit.assert.csproj
+++ b/src/xunit.assert/xunit.assert.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Asserts\CollectionAsserts.cs" />
     <Compile Include="Asserts\Comparers.cs" />
     <Compile Include="Asserts\EqualityAsserts.cs" />
+    <Compile Include="Asserts\EventAsserts.cs" />
     <Compile Include="Asserts\ExceptionAsserts.cs" />
     <Compile Include="Asserts\Guards.cs" />
     <Compile Include="Asserts\Record.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="Asserts\Sdk\Exceptions\ProperSubsetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\ProperSupersetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\PropertyChangedException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\RaisesException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SameException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SingleException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\StartsWithException.cs" />

--- a/test/test.xunit.assert/Asserts/EventAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/EventAssertsTests.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+public class EventAssertsTests
+{
+    public class Raises_Generic
+    {
+        [Fact]
+        public static void ExpectedEventButCodeDoesNotRaise()
+        {
+            try
+            {
+                var x = new RaisingClass();
+                Assert.Raises<EventArgs>(h => x.Completed += h, h => x.Completed -= h, () => { });
+            }
+            catch (RaisesException exception)
+            {
+                Assert.Equal("(No event was raised)", exception.Actual);
+                Assert.Equal("EventArgs", exception.Expected);
+            }
+        }
+
+        [Fact]
+        public static void ExpectedEventButRaisesEventWithDerivedArgs()
+        {
+            try
+            {
+                var x = new RaisingClass();
+                Assert.Raises<EventArgs>(
+                    h => x.Completed += h,
+                    h => x.Completed -= h,
+                    () => x.RaiseWithArgs(new DerivedEventArgs()));
+            }
+            catch (RaisesException exception)
+            {
+                Assert.Equal("DerivedEventArgs", exception.Actual);
+                Assert.Equal("EventArgs", exception.Expected);
+                Assert.Equal("(Raised event did not match expected event)", exception.UserMessage);
+            }
+        }
+
+        [Fact]
+        public static void GotExpectedEvent()
+        {
+            var x = new RaisingClass();
+            var evt = Assert.Raises<EventArgs>(
+                h => x.Completed += h, 
+                h => x.Completed -= h, 
+                () => x.RaiseWithArgs(EventArgs.Empty));
+            Assert.NotNull(evt);
+            Assert.Equal(x, evt.Sender);
+            Assert.Equal(EventArgs.Empty, evt.Arguments);
+        }
+    }
+
+    public class RaisesAny_Generic
+    {
+        [Fact]
+        public static void ExpectedEventButCodeDoesNotRaise()
+        {
+            try
+            {
+                var x = new RaisingClass();
+                Assert.RaisesAny<EventArgs>(h => x.Completed += h, h => x.Completed -= h, () => { });
+            }
+            catch (RaisesException exception)
+            {
+                Assert.Equal("(No event was raised)", exception.Actual);
+                Assert.Equal("EventArgs", exception.Expected);
+            }
+        }
+
+        [Fact]
+        public static void GotExpectedEvent()
+        {
+            var x = new RaisingClass();
+            var evt = Assert.RaisesAny<EventArgs>(
+                h => x.Completed += h,
+                h => x.Completed -= h,
+                () => x.RaiseWithArgs(EventArgs.Empty));
+            Assert.NotNull(evt);
+            Assert.Equal(x, evt.Sender);
+            Assert.Equal(EventArgs.Empty, evt.Arguments);
+        }
+
+
+        [Fact]
+        public static void GotDerivedEvent()
+        {
+            var x = new RaisingClass();
+            var args = new DerivedEventArgs();
+            var evt = Assert.RaisesAny<EventArgs>(
+                h => x.Completed += h,
+                h => x.Completed -= h,
+                () => x.RaiseWithArgs(args));
+            Assert.NotNull(evt);
+            Assert.Equal(x, evt.Sender);
+            Assert.Equal(args, evt.Arguments);
+        }
+    }
+
+    public class RaisesAnyAsync_Generic
+    {
+        [Fact]
+        public static async Task ExpectedEventButCodeDoesNotRaise()
+        {
+            try
+            {
+                var x = new RaisingClass();
+                await Assert.RaisesAnyAsync<EventArgs>(h => x.Completed += h, h => x.Completed -= h, () => Task.Run(() => { }));
+            }
+            catch (RaisesException exception)
+            {
+                Assert.Equal("(No event was raised)", exception.Actual);
+                Assert.Equal("EventArgs", exception.Expected);
+            }
+        }
+
+        [Fact]
+        public static async Task GotExpectedEvent()
+        {
+            var x = new RaisingClass();
+            var evt = await Assert.RaisesAnyAsync<EventArgs>(
+                h => x.Completed += h,
+                h => x.Completed -= h,
+                () => Task.Run(() => x.RaiseWithArgs(EventArgs.Empty)));
+            Assert.NotNull(evt);
+            Assert.Equal(x, evt.Sender);
+            Assert.Equal(EventArgs.Empty, evt.Arguments);
+        }
+
+
+        [Fact]
+        public static async Task GotDerivedEvent()
+        {
+            var x = new RaisingClass();
+            var args = new DerivedEventArgs();
+            var evt = await Assert.RaisesAnyAsync<EventArgs>(
+                h => x.Completed += h,
+                h => x.Completed -= h,
+                () => Task.Run(() => x.RaiseWithArgs(args)));
+            Assert.NotNull(evt);
+            Assert.Equal(x, evt.Sender);
+            Assert.Equal(args, evt.Arguments);
+        }
+    }
+
+    public class RaisesAsync_Generic
+    {
+        [Fact]
+        public static async Task ExpectedEventButCodeDoesNotRaise()
+        {
+            try
+            {
+                var x = new RaisingClass();
+                await Assert.RaisesAsync<EventArgs>(h => x.Completed += h, h => x.Completed -= h, () => Task.Run(() => {}));
+            }
+            catch (RaisesException exception)
+            {
+                Assert.Equal("(No event was raised)", exception.Actual);
+                Assert.Equal("EventArgs", exception.Expected);
+            }
+        }
+
+        [Fact]
+        public static async Task ExpectedEventButRaisesEventWithDerivedArgs()
+        {
+            try
+            {
+                var x = new RaisingClass();
+                await Assert.RaisesAsync<EventArgs>(
+                    h => x.Completed += h,
+                    h => x.Completed -= h,
+                    () => Task.Run(() => x.RaiseWithArgs(new DerivedEventArgs())));
+            }
+            catch (RaisesException exception)
+            {
+                Assert.Equal("DerivedEventArgs", exception.Actual);
+                Assert.Equal("EventArgs", exception.Expected);
+                Assert.Equal("(Raised event did not match expected event)", exception.UserMessage);
+            }
+        }
+
+        [Fact]
+        public static async Task GotExpectedEvent()
+        {
+            var x = new RaisingClass();
+            var evt = await Assert.RaisesAsync<EventArgs>(
+                h => x.Completed += h,
+                h => x.Completed -= h,
+                () => Task.Run(() => x.RaiseWithArgs(EventArgs.Empty)));
+            Assert.NotNull(evt);
+            Assert.Equal(x, evt.Sender);
+            Assert.Equal(EventArgs.Empty, evt.Arguments);
+        }
+    }
+
+    private class RaisingClass
+    {
+        public void RaiseWithArgs(EventArgs args)
+        {
+            Completed.Invoke(this, args);
+        }
+
+        public event EventHandler<EventArgs> Completed;
+    }
+
+    private class DerivedEventArgs : EventArgs { }
+}

--- a/test/test.xunit.assert/test.xunit.assert.csproj
+++ b/test/test.xunit.assert/test.xunit.assert.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Asserts\BooleanAssertsTests.cs" />
     <Compile Include="Asserts\CollectionAssertsTests.cs" />
     <Compile Include="Asserts\EqualityAssertsTests.cs" />
+    <Compile Include="Asserts\EventAssertsTests.cs" />
     <Compile Include="Asserts\ExceptionAssertsTests.cs" />
     <Compile Include="Asserts\IdentityAssertsTests.cs" />
     <Compile Include="Asserts\NullAssertsTests.cs" />


### PR DESCRIPTION
A pattern I've encountered quite a few times when unit testing recently is to assure an event is raised as the direct cause of some action. This can be quite cumbersome:

```cs
var completedRaised = false;
var x = new Foo();
x.Completed += (sender, args) => completedRaised = true;
x.Start();
Assert.True(completedRaised);
```

This pull request makes this a little easier to do, especially when you have multiple events to test:

```cs
var x = new Foo();
var raisedEvent = Assert.Raises<EventArgs>(
    h => x.Completed += h, 
    h => x.Completed -= h,
    () => x.Start());
```

There are several advantages:
- much shorter
- ensures proper setup and teardown of the event handlers
- easier to inspect the sender and arguments
- easily fail the test if you get event arguments derived from what you expect
- supports `async` methods (`RaisesAsync` and `RaisesAnyAsync`)
- supports accepting derived event args (`RaisesAny` and `RaisesAnyAsync`)

I've tried my best to stick to the coding style in the project, but please let me know if I've missed anything, and I'll be happy to fix it.