### PR TITLE
Fix governance link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Before you file a bug...
 
-* Did you [read the documentation](http://xunit.github.io/)?
+* Did you [read the documentation](https://xunit.github.io/)?
 * Did you search the issues list to see if someone already reported it?
 * Did you create a simple repro for the problem?
 
 # Before you submit a PR...
 
 * Did you ensure this is an [accepted up-for-grabs issue](https://github.com/xunit/xunit/issues?q=is%3Aopen+is%3Aissue+label%3A%22%5Bs%5D+Up+For+Grabs%22)? (If not, open one to start the discussion)
-* Did you read the [project governance](xunit.github.io/governance.html)?
+* Did you read the [project governance](https://xunit.github.io/governance.html)?
 * Does the code follow existing coding styles? (spaces, comments, no regions, etc.)?
 * Did you write unit tests?


### PR DESCRIPTION
The governance link was linking relative to the GitHub repo, rather than to the (separate) `xunit.github.io` domain.