### PR TITLE
better documentation to avoid issue #695

### DIFF
--- a/src/xunit.core/ClassDataAttribute.cs
+++ b/src/xunit.core/ClassDataAttribute.cs
@@ -8,6 +8,7 @@ namespace Xunit
     /// <summary>
     /// Provides a data source for a data theory, with the data coming from a class
     /// which must implement IEnumerable&lt;object[]&gt;.
+    /// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class ClassDataAttribute : DataAttribute

--- a/src/xunit.core/MemberDataAttribute.cs
+++ b/src/xunit.core/MemberDataAttribute.cs
@@ -11,6 +11,7 @@ namespace Xunit
     /// 2. A static field
     /// 3. A static method (with parameters)
     /// The member must return something compatible with IEnumerable&lt;object[]&gt; with the test data.
+    /// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
     /// </summary>
     [CLSCompliant(false)]
     [DataDiscoverer("Xunit.Sdk.MemberDataDiscoverer", "xunit.core")]

--- a/src/xunit.core/MemberDataAttributeBase.cs
+++ b/src/xunit.core/MemberDataAttributeBase.cs
@@ -9,6 +9,7 @@ namespace Xunit
     /// <summary>
     /// Provides a base class for attributes that will provide member data. The member data must return
     /// something compatible with <see cref="IEnumerable&lt;Object&gt;"/>.
+    /// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
     /// </summary>
     [CLSCompliant(false)]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]

--- a/src/xunit.core/Sdk/DataAttribute.cs
+++ b/src/xunit.core/Sdk/DataAttribute.cs
@@ -8,6 +8,7 @@ namespace Xunit.Sdk
     /// Abstract attribute which represents a data source for a data theory.
     /// Data source providers derive from this attribute and implement GetData
     /// to return the data for the theory.
+    /// Caution: the property is completely enumerated by .ToList() before any test is run. Hence it should return independent object sets.
     /// </summary>
     [DataDiscoverer("Xunit.Sdk.DataDiscoverer", "xunit.core")]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]


### PR DESCRIPTION
make clear in the documentation that MemberDataAttribute should not return the same objects twice.