### PR TITLE
Issue#211. Apply TraitAttribute to whole assembly

### DIFF
--- a/src/xunit.core/AssemblyTraitAttribute.cs
+++ b/src/xunit.core/AssemblyTraitAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>
+    /// Attribute used to decorate an assembly with arbitrary name/value pairs ("traits").
+    /// </summary>
+    [TraitDiscoverer("Xunit.Sdk.AssemblyTraitDiscoverer", "xunit.core")]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed class AssemblyTraitAttribute : Attribute, ITraitAttribute
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="AssemblyTraitAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The trait name</param>
+        /// <param name="value">The trait value</param>
+        public AssemblyTraitAttribute(string name, string value) { }
+    }
+}

--- a/src/xunit.core/Sdk/AssemblyTraitDiscoverer.cs
+++ b/src/xunit.core/Sdk/AssemblyTraitDiscoverer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// The implementation of <see cref="ITraitDiscoverer"/> which returns the trait values
+    /// for <see cref="AssemblyTraitAttribute"/>.
+    /// </summary>
+    public class AssemblyTraitDiscoverer : ITraitDiscoverer
+    {
+        /// <inheritdoc/>
+        public virtual IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            var ctorArgs = traitAttribute.GetConstructorArguments().Cast<string>().ToList();
+            yield return new KeyValuePair<string, string>(ctorArgs[0], ctorArgs[1]);
+        }
+    }
+}

--- a/src/xunit.core/xunit.core.csproj
+++ b/src/xunit.core/xunit.core.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\xunit.assert\Asserts\Sdk\AssertEqualityComparerAdapter.cs">
       <Link>Sdk\AssertEqualityComparerAdapter.cs</Link>
     </Compile>
+    <Compile Include="AssemblyTraitAttribute.cs" />
     <Compile Include="ClassDataAttribute.cs" />
     <Compile Include="CollectionAttribute.cs" />
     <Compile Include="CollectionBehavior.cs" />
@@ -75,6 +76,7 @@
     <Compile Include="MemberDataAttributeBase.cs" />
     <Compile Include="Extensions\PropertyDataAttribute.cs" />
     <Compile Include="Record.cs" />
+    <Compile Include="Sdk\AssemblyTraitDiscoverer.cs" />
     <Compile Include="Sdk\BeforeAfterTestAttribute.cs" />
     <Compile Include="Sdk\DataAttribute.cs" />
     <Compile Include="Sdk\MemberDataDiscoverer.cs" />

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
@@ -74,8 +75,7 @@ namespace Xunit.Sdk
             DisplayName = GetDisplayName(factAttribute, baseDisplayName);
             SkipReason = GetSkipReason(factAttribute);
 
-            foreach (var traitAttribute in TestMethod.Method.GetCustomAttributes(typeof(ITraitAttribute))
-                                                            .Concat(TestMethod.TestClass.Class.GetCustomAttributes(typeof(ITraitAttribute))))
+            foreach (var traitAttribute in GetTraitAttributesData(TestMethod))
             {
                 var discovererAttribute = traitAttribute.GetCustomAttributes(typeof(TraitDiscovererAttribute)).FirstOrDefault();
                 if (discovererAttribute != null)
@@ -88,6 +88,13 @@ namespace Xunit.Sdk
                 else
                     diagnosticMessageSink.OnMessage(new DiagnosticMessage($"Trait attribute on '{DisplayName}' did not have [TraitDiscoverer]"));
             }
+        }
+
+        static IEnumerable<IAttributeInfo> GetTraitAttributesData(ITestMethod testMethod)
+        {
+            return testMethod.TestClass.Class.Assembly.GetCustomAttributes(typeof(ITraitAttribute))
+                .Concat(testMethod.Method.GetCustomAttributes(typeof(ITraitAttribute)))
+                .Concat(testMethod.TestClass.Class.GetCustomAttributes(typeof(ITraitAttribute)));
         }
 
         /// <inheritdoc/>

--- a/test/GlobalTestAssemblyInfo.cs
+++ b/test/GlobalTestAssemblyInfo.cs
@@ -1,6 +1,9 @@
 using System.Reflection;
 using TestDriven.Framework;
+using Xunit;
 using Xunit.Runner.TdNet;
 
 [assembly: CustomTestRunner(typeof(TdNetRunner))]
 [assembly: AssemblyVersion("99.99.99.0")]
+
+[assembly: AssemblyTrait("Assembly", "Trait")]

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
@@ -69,6 +69,11 @@ public class XunitTestCaseTests
                 passingTest => Assert.Collection(passingTest.TestCase.Traits.OrderBy(x => x.Key),
                     namedTrait =>
                     {
+                        Assert.Equal("Assembly", namedTrait.Key);
+                        Assert.Collection(namedTrait.Value, value => Assert.Equal("Trait", value));
+                    },
+                    namedTrait =>
+                    {
                         Assert.Equal("Author", namedTrait.Key);
                         Assert.Collection(namedTrait.Value, value => Assert.Equal("Some Schmoe", value));
                     },

--- a/test/test.xunit.execution/Sdk/TestCaseSerializerTests.cs
+++ b/test/test.xunit.execution/Sdk/TestCaseSerializerTests.cs
@@ -46,6 +46,11 @@ public class TestCaseSerializerTests
             Assert.Collection(result.Traits.Keys,
                 key =>
                 {
+                    Assert.Equal("Assembly", key);
+                    Assert.Equal("Trait", Assert.Single(result.Traits[key]));
+                }, 
+                key =>
+                {
                     Assert.Equal("name", key);
                     Assert.Equal("value", Assert.Single(result.Traits[key]));
                 });
@@ -107,6 +112,11 @@ public class TestCaseSerializerTests
             Assert.Equal(testCase.SkipReason, result.SkipReason);
             Assert.Null(result.TestMethodArguments);
             Assert.Collection(result.Traits.Keys,
+                key =>
+                {
+                    Assert.Equal("Assembly", key);
+                    Assert.Equal("Trait", Assert.Single(result.Traits[key]));
+                },
                 key =>
                 {
                     Assert.Equal("name", key);


### PR DESCRIPTION
This is the implementation of Issue #211. Another possible solution: do not create separate AssemblyTrait attribute, but allow existing Trait attribute to be set on assembly.