### PR TITLE
Add Assert.Imply to assert implications and consequences

### DIFF
--- a/src/xunit.assert/Asserts/BooleanAsserts.cs
+++ b/src/xunit.assert/Asserts/BooleanAsserts.cs
@@ -89,5 +89,29 @@ namespace Xunit
             if (!condition.HasValue || !condition.GetValueOrDefault())
                 throw new TrueException(userMessage, condition);
         }
+
+         /// <summary>
+        /// Verifies that an expression is true.
+        /// </summary>
+        /// <param name="ifCondition">The necessary condition to be inspected</param>
+        /// <param name="thenCondition">The sufficient condition to be inspected</param>
+        /// <exception cref="ImplyException">Thrown when the condition is false</exception>
+        public static void Imply(bool ifCondition, bool thenCondition)
+        {
+            Imply(ifCondition, thenCondition, null);
+        }
+
+        /// <summary>
+        /// Verifies that an expression is true.
+        /// </summary>
+        /// <param name="ifCondition">The necessary condition to be inspected</param>
+        /// <param name="thenCondition">The sufficient condition to be inspected</param>
+        /// <param name="userMessage">The message to be shown when the implication is not valid</param>
+        /// <exception cref="ImplyException">Thrown when the condition is false</exception>
+        public static void Imply(bool ifCondition, bool thenCondition, string userMessage)
+        {
+            if (ifCondition && !thenCondition)
+                throw new ImplyException(userMessage);
+        }
     }
 }

--- a/src/xunit.assert/Asserts/Sdk/Exceptions/ImplyException.cs
+++ b/src/xunit.assert/Asserts/Sdk/Exceptions/ImplyException.cs
@@ -1,0 +1,16 @@
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when a value an implication is not satisfied.
+    /// </summary>
+    public class ImplyException : AssertActualExpectedException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ImplyException"/> class.
+        /// </summary>
+        /// <param name="userMessage">The user message to be displayed, or null for the default message</param>
+        public ImplyException(string userMessage)
+            : base("Implies", "Does not imply", userMessage ?? "Assert.Imply() Failure")
+        { }
+    }
+}

--- a/src/xunit.assert/xunit.assert.csproj
+++ b/src/xunit.assert/xunit.assert.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Asserts\Sdk\Exceptions\SubsetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\SupersetException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\ThrowsException.cs" />
+    <Compile Include="Asserts\Sdk\Exceptions\ImplyException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\TrueException.cs" />
     <Compile Include="Asserts\Sdk\Exceptions\XunitException.cs" />
     <Compile Include="Asserts\IdentityAsserts.cs" />

--- a/test/test.xunit.assert/Asserts/BooleanAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/BooleanAssertsTests.cs
@@ -85,4 +85,26 @@ public class BooleanAssertsTests
                          "Actual:   False", ex.Message);
         }
     }
+
+    public class Imply
+    {
+        [Fact]
+        public static void AssertImply()
+        {
+            Assert.Imply(true, true);
+            Assert.Imply(false, true);
+            Assert.Imply(false, false);
+        }
+
+        [Fact]
+        public static void ThrowsExceptionWhenTrueImpliesFalse()
+        {
+            var ex = Record.Exception(() => Assert.Imply(true, false));
+
+            Assert.IsType<ImplyException>(ex);
+            Assert.Equal("Assert.Imply() Failure" + Environment.NewLine +
+                         "Expected: Implies" + Environment.NewLine +
+                         "Actual:   Does not imply", ex.Message);
+        }
+    }
 }


### PR DESCRIPTION
Assert.Implies(foo, bar) would be a nice and more readable replacement for Assert.True(bar || !foo)