### PR TITLE
Console runner: add -appdomain option

### DIFF
--- a/src/xunit.console/AppDomainOption.cs
+++ b/src/xunit.console/AppDomainOption.cs
@@ -1,0 +1,9 @@
+﻿namespace Xunit.ConsoleClient
+{
+    public enum AppDomainOption
+    {
+        ifavailable,
+        required,
+        denied
+    }
+}

--- a/src/xunit.console/xunit.console.csproj
+++ b/src/xunit.console/xunit.console.csproj
@@ -72,6 +72,7 @@
     <Compile Include="..\common\XmlTestExecutionVisitor.cs">
       <Link>Common\XmlTestExecutionVisitor.cs</Link>
     </Compile>
+    <Compile Include="AppDomainOption.cs" />
     <Compile Include="CommandLine.cs" />
     <Compile Include="Config\TransformConfigurationElement.cs" />
     <Compile Include="Config\TransformConfigurationElementCollection.cs" />

--- a/test/test.xunit.console/CommandLineTests.cs
+++ b/test/test.xunit.console/CommandLineTests.cs
@@ -236,6 +236,68 @@ public class CommandLineTests
         }
     }
 
+    public class NoAppDomainOption
+    {
+        [Fact]
+        public static void NoAppDomainNotSetNoAppDomainIsFalseAndAppDomainIsNull()
+        {
+            var commandLine = TestableCommandLine.Parse("assemblyName.dll");
+
+            Assert.False(commandLine.NoAppDomain);
+            Assert.Null(commandLine.AppDomain);
+        }
+
+        [Fact]
+        public static void NoAppDomainSetNoAppDomainIsTrueAndAppDomainIsDenied()
+        {
+            var commandLine = TestableCommandLine.Parse("assemblyName.dll", "-noappdomain");
+
+            Assert.True(commandLine.NoAppDomain);
+            Assert.Equal(AppDomainSupport.Denied, commandLine.AppDomain);
+        }
+    }
+
+    public class AppDomainOption
+    {
+        [Fact]
+        public static void NotSetDefaultValueIsNull()
+        {
+            var commandLine = TestableCommandLine.Parse("assemblyName.dll");
+
+            Assert.Null(commandLine.AppDomain);
+        }
+
+        [Fact]
+        public static void MissingValue()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => TestableCommandLine.Parse("assemblyName.dll", "-appdomain"));
+
+            Assert.Equal("missing argument for -appdomain", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public static void InvalidValues(string value)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => TestableCommandLine.Parse("assemblyName.dll", "-appdomain", value));
+
+            Assert.Equal("incorrect argument value for -appdomain", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("ifavailable", AppDomainSupport.IfAvailable)]
+        [InlineData("required", AppDomainSupport.Required)]
+        [InlineData("denied", AppDomainSupport.Denied)]
+        public static void ValidValues(string value, AppDomainSupport expected)
+        {
+            var commandLine = TestableCommandLine.Parse("assemblyName", "-appdomain", value);
+
+            Assert.True(commandLine.AppDomain.HasValue);
+            Assert.Equal(expected, commandLine.AppDomain.Value);
+        }
+    }
+
     public class NoLogoOption
     {
         [Fact]


### PR DESCRIPTION
Fixes #724 (as per #723). 

The one thing I'm not sure about is if all of the values should be implemented (`IfAvailable`, `Required`, `Denied`) or if it should just be a simple boolean switch since the console runner is linked against xunit.runner.utility.desktop and therefore `IfAvailable` might not be necessary.

If this is the case, I'll rebase with just a simple boolean.
