### PR TITLE
Adding support for wildcard in method filter ('method' command-line p…

### DIFF
--- a/src/xunit.console/CommandLine.cs
+++ b/src/xunit.console/CommandLine.cs
@@ -271,7 +271,7 @@ namespace Xunit.ConsoleClient
                     if (option.Value == null)
                         throw new ArgumentException("missing argument for -method");
 
-                    project.Filters.IncludedMethods.Add(option.Value);
+                    project.Filters.AddIncludedMethod(option.Value);
                 }
                 else if (optionName == "namespace")
                 {

--- a/src/xunit.runner.utility/Project/XunitFilters.cs
+++ b/src/xunit.runner.utility/Project/XunitFilters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit.Abstractions;
 
 namespace Xunit
@@ -10,6 +11,8 @@ namespace Xunit
     /// </summary>
     public class XunitFilters
     {
+        List<Regex> includedMethodRegexes;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="XunitFilters"/> class.
         /// </summary>
@@ -19,6 +22,7 @@ namespace Xunit
             IncludedTraits = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
             IncludedClasses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             IncludedMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            includedMethodRegexes = new List<Regex>();
             IncludedNameSpaces = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -41,6 +45,44 @@ namespace Xunit
         /// Gets the set of method filters for tests to include.
         /// </summary>
         public HashSet<string> IncludedMethods { get; }
+
+        /// <summary>
+        /// Add an include method filter. 
+        /// It can either be a fully-qualified method name, or a wildcard pattern.
+        /// </summary>
+        public void AddIncludedMethod(string methodNameOrWildcard)
+        {
+            if (methodNameOrWildcard.Contains("*"))
+            {
+                var regexPattern = WildcardToRegex(methodNameOrWildcard);
+                var regex = new Regex(regexPattern);
+                includedMethodRegexes.Add(regex);
+            }
+            else
+            {
+                IncludedMethods.Add(methodNameOrWildcard);
+            }
+        }
+
+        /// <summary>
+        /// Checks whether there are any included method filters.
+        /// </summary>
+        public bool HasIncludedMethods()
+        {
+            return IncludedMethods.Count != 0 || includedMethodRegexes.Count != 0; 
+        }
+
+        /// <summary>
+        /// Converts a wildcard to a regex.
+        /// </summary>
+        /// <param name="pattern">The wildcard pattern to convert.</param>
+        /// <returns>A regex equivalent of the given wildcard.</returns>
+        public string WildcardToRegex(string pattern)
+        {
+            return "^" + Regex.Escape(pattern).
+                 Replace("\\*", ".*").
+                 Replace("\\?", ".") + "$";
+        }
 
         /// <summary>
         /// Gets the set of assembly filters for tests to include.
@@ -81,15 +123,31 @@ namespace Xunit
         bool FilterIncludedMethodsAndClasses(ITestCase testCase)
         {
             // No methods or classes in the filter == everything is okay
-            if (IncludedMethods.Count == 0 && IncludedClasses.Count == 0)
+            if (!HasIncludedMethods() && IncludedClasses.Count == 0)
                 return true;
 
             if (IncludedClasses.Count != 0 && IncludedClasses.Contains(testCase.TestMethod.TestClass.Class.Name))
                 return true;
 
-            if (IncludedMethods.Count != 0 && IncludedMethods.Contains($"{testCase.TestMethod.TestClass.Class.Name}.{testCase.TestMethod.Method.Name}"))
+            var testCaseMethod = $"{testCase.TestMethod.TestClass.Class.Name}.{testCase.TestMethod.Method.Name}";
+            if (IncludedMethods.Count != 0 && IncludedMethods.Contains(testCaseMethod))
                 return true;
 
+            if (includedMethodRegexes != null && FilterIncludedMethodWildcards(testCaseMethod))
+                return true;
+
+            return false;
+        }
+
+        bool FilterIncludedMethodWildcards(string testCaseMethod)
+        {
+            foreach(var regex in includedMethodRegexes)
+            {
+                if (regex.IsMatch(testCaseMethod))
+                {
+                    return true;
+                }
+            }
             return false;
         }
 

--- a/test/test.xunit.runner.utility/Project/XunitFiltersTests.cs
+++ b/test/test.xunit.runner.utility/Project/XunitFiltersTests.cs
@@ -180,11 +180,31 @@ public class XunitFiltersTests
             var method2 = Mocks.TestCase<Namespace1.ClassInNamespace1.InnerClass1>("Name2");
             var method3 = Mocks.TestCase<Namespace1.ClassInNamespace1.InnerClass1>("Name3");
             filters.IncludedMethods.Add("Namespace1.ClassInNamespace1+InnerClass1.Name1");
+            filters.AddIncludedMethod("Namespace1.ClassInNamespace1+InnerClass1.Name2");
 
             Assert.True(filters.Filter(method1));
-            Assert.False(filters.Filter(method2));
+            Assert.True(filters.Filter(method2));
             Assert.False(filters.Filter(method3));
         }
+
+        [Fact]
+        public static void CanFilterFactsByWildcardName()
+        {
+            var filters = new XunitFilters();
+            var method1 = Mocks.TestCase<Namespace1.ClassInNamespace1.InnerClass1>("Name1");
+            var method2 = Mocks.TestCase<Namespace1.ClassInNamespace1.InnerClass1>("Name2");
+            var method3 = Mocks.TestCase<Namespace1.ClassInNamespace1.InnerClass1>("Name3");
+            var method4 = Mocks.TestCase<Namespace1.ClassInNamespace1.InnerClass2>("Name3");
+            filters.AddIncludedMethod("*.Name1");
+            filters.AddIncludedMethod("Namespace1.*.Name2");
+            filters.AddIncludedMethod("*+InnerClass2.*");
+
+            Assert.True(filters.Filter(method1));
+            Assert.True(filters.Filter(method2));
+            Assert.False(filters.Filter(method3));
+            Assert.True(filters.Filter(method4));
+        }
+
 
         [Fact]
         public static void MultipleNameFiltersAreAnOrOperation()


### PR DESCRIPTION
Specifying method filters with the fully-specified method name is rather unfriendly and tedious.
By adding wildcard support to the 'method' parameter on the console runner, the user can run a single method with `*.MyMethod` or `*.MyClass.MyMethod`, which is more convenient.

One thing gave me some trouble with this change: the `IncludedMethods` member of the filters class. Because it is public, I left it as-is, to avoid breaking code that depends on it. But ideally, I wanted to make it private and to make adding method filters use the new public method `AddIncludedMethod` instead.

Re-submitting with missing comment.

Regards,
Julien
