### PR TITLE
Cast test method arguments before calling test method.

### DIFF
--- a/test/test.xunit.execution/SerializationTests.cs
+++ b/test/test.xunit.execution/SerializationTests.cs
@@ -119,4 +119,33 @@ public class SerializationTests
         [MemberData("Data")]
         public void Test(object x) { }
     }
+
+    public class ClassWithTheoryDataTypeDiffrentToArgumentType
+    {
+        public class A
+        {
+        }
+
+        public class B
+        {
+            public static explicit operator A(B value)
+            {
+                return new A();
+            }
+
+            public static explicit operator B(A value)
+            {
+                return new B();
+            }
+        }
+
+        public static IEnumerable<object[]> Data = new[] { new object[] { new B() }, new object[] { new B() } };
+
+        [Theory]
+        [MemberData("Data")]
+        public void Test(A x)
+        {
+            Console.WriteLine("Test");
+        }
+    }
 }

--- a/test/test.xunit.execution/SerializationTests.cs
+++ b/test/test.xunit.execution/SerializationTests.cs
@@ -119,33 +119,4 @@ public class SerializationTests
         [MemberData("Data")]
         public void Test(object x) { }
     }
-
-    public class ClassWithTheoryDataTypeDiffrentToArgumentType
-    {
-        public class A
-        {
-        }
-
-        public class B
-        {
-            public static explicit operator A(B value)
-            {
-                return new A();
-            }
-
-            public static explicit operator B(A value)
-            {
-                return new B();
-            }
-        }
-
-        public static IEnumerable<object[]> Data = new[] { new object[] { new B() }, new object[] { new B() } };
-
-        [Theory]
-        [MemberData("Data")]
-        public void Test(A x)
-        {
-            Console.WriteLine("Test");
-        }
-    }
 }

--- a/test/test.xunit.execution/TheoryDataTypeTests.cs
+++ b/test/test.xunit.execution/TheoryDataTypeTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Xunit
+{
+    public class TheoryDataTypeTests
+    {
+        public class ClassWithTheoryDataTypeDiffrentToArgumentType
+        {
+            public class A
+            {
+            }
+
+            public class B
+            {
+                public static explicit operator A(B value)
+                {
+                    return new A();
+                }
+
+                public static explicit operator B(A value)
+                {
+                    return new B();
+                }
+            }
+
+            public static IEnumerable<object[]> Data = new[] { new object[] { new B() }, new object[] { new B() } };
+
+            [Theory]
+            [MemberData("Data")]
+            public void Test(A x) { }
+        }
+    }
+}

--- a/test/test.xunit.execution/test.xunit.execution.csproj
+++ b/test/test.xunit.execution/test.xunit.execution.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Acceptance\FixtureAcceptanceTests.cs" />
     <Compile Include="Acceptance\Xunit2AcceptanceTests.cs" />
     <Compile Include="Acceptance\Xunit2TheoryAcceptanceTests.cs" />
+    <Compile Include="TheoryDataTypeTests.cs" />
     <Compile Include="Common\AssemblyExtensionsTests.cs" />
     <Compile Include="Common\SerializationHelperTests.cs" />
     <Compile Include="Common\TraitHelperTests.cs" />


### PR DESCRIPTION
Add code to cast all given test method arguments to the types get from the MethodInfo.
See discussion [here](https://github.com/xunit/xunit/issues/547#issuecomment-182578848).