### PR TITLE
Adding timestamp for test results

### DIFF
--- a/src/xunit.console/HTML.xslt
+++ b/src/xunit.console/HTML.xslt
@@ -47,6 +47,9 @@
         <h3 class="divided">
           <b>Assemblies Run</b>
         </h3>
+        <div>
+          <xsl:value-of select="//assemblies/@timestamp"/>
+        </div>
         <xsl:apply-templates select="//assembly"/>
         <h3 class="divided">
           <b>Summary</b>

--- a/src/xunit.console/Program.cs
+++ b/src/xunit.console/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -255,6 +256,7 @@ namespace Xunit.ConsoleClient
                 }
 
                 clockTime.Stop();
+                assembliesElement.Add(new XAttribute("timestamp", DateTime.Now.ToString(CultureInfo.InvariantCulture)));
 
                 if (completionMessages.Count > 0)
                     reporterMessageHandler.OnMessage(new TestExecutionSummary(clockTime.Elapsed, completionMessages.OrderBy(kvp => kvp.Key).ToList()));


### PR DESCRIPTION
This change records the time when the tests completed and displays that timestamp in the HTML results produced by the console runner.
Let me know if you'd like me to add this to other runners and/or transforms