### PR TITLE
Fix: Console runner crashes when writing invalid characters to XML file

### DIFF
--- a/src/common/XmlTestExecutionVisitor.cs
+++ b/src/common/XmlTestExecutionVisitor.cs
@@ -275,6 +275,13 @@ namespace Xunit
             for (var idx = 0; idx < value.Length; ++idx)
                 if (value[idx] < 32)
                     escapedValue.Append($"\\x{((byte)value[idx]).ToString("x2")}");
+                else if (char.IsSurrogatePair(value, idx))
+                {
+                    escapedValue.Append(value[idx++]); // Append valid surrogate chars like normal
+                    escapedValue.Append(value[idx]);
+                }
+                else if (char.IsSurrogate(value, idx)) // Translate invalid ones to \x----
+                    escapedValue.Append($"\\x{((int)value[idx]).ToString("x4")}");
                 else
                     escapedValue.Append(value[idx]);
 

--- a/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
+++ b/test/test.xunit.execution/Common/XmlTestExecutionVisitorTests.cs
@@ -355,13 +355,35 @@ public class XmlTestExecutionVisitorTests
             var name2Element = Assert.Single(traitsElements, e => e.Attribute("name").Value == "name2");
             Assert.Equal("value2", name2Element.Attribute("value").Value);
         }
+        
+        public static IEnumerable<object[]> IllegalXmlTestData()
+        {
+            yield return new object[]
+            {
+                new string(Enumerable.Range(0, 32).Select(x => (char)x).ToArray()),
+                @"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"
+            };
+            // Invalid surrogate characters should be added as \x----, where ---- is the hex value of the char
+            yield return new object[]
+            {
+                "\xd800 Hello.World \xdc00",
+                @"\xd800 Hello.World \xdc00"
+            };
+            // ...but valid ones should be outputted like normal
+            yield return new object[]
+            {
+                "\xd800\xdfff This.Is.Valid \xda00\xdd00",
+                "\xd800\xdfff This.Is.Valid \xda00\xdd00" // note: no @
+            };
+        }
 
-        [Fact]
-        public void IllegalXmlDoesNotPreventXmlFromBeingSaved()
+        [Theory]
+        [MemberData(nameof(IllegalXmlTestData))]
+        public void IllegalXmlDoesNotPreventXmlFromBeingSaved(string inputName, string outputName)
         {
             var assemblyFinished = Substitute.For<ITestAssemblyFinished>();
             var testCase = Mocks.TestCase<ClassUnderTest>("TestMethod");
-            var test = Mocks.Test(testCase, new string(Enumerable.Range(0, 32).Select(x => (char)x).ToArray()));
+            var test = Mocks.Test(testCase, inputName);
             var testSkipped = Substitute.For<ITestSkipped>();
             testSkipped.TestCase.Returns(testCase);
             testSkipped.Test.Returns(test);
@@ -378,7 +400,7 @@ public class XmlTestExecutionVisitorTests
                 assemblyElement.Save(writer, SaveOptions.DisableFormatting);
 
                 var outputXml = writer.ToString();
-                Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-16""?><assembly total=""0"" passed=""0"" failed=""0"" skipped=""0"" time=""0.000"" errors=""0""><errors /><collection><test name=""\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"" type=""XmlTestExecutionVisitorTests+Xml+ClassUnderTest"" method=""TestMethod"" time=""0"" result=""Skip"" source-file=""""><reason><![CDATA[Bad\0\r\nString]]></reason></test></collection></assembly>", outputXml);
+                Assert.Equal($@"<?xml version=""1.0"" encoding=""utf-16""?><assembly total=""0"" passed=""0"" failed=""0"" skipped=""0"" time=""0.000"" errors=""0""><errors /><collection><test name=""{outputName}"" type=""XmlTestExecutionVisitorTests+Xml+ClassUnderTest"" method=""TestMethod"" time=""0"" result=""Skip"" source-file=""""><reason><![CDATA[Bad\0\r\nString]]></reason></test></collection></assembly>", outputXml);
             }
         }
 


### PR DESCRIPTION
Hi! First off I'd like to thank you guys for making xUnit. It's a pretty nice framework, and when I first got introduced to it via CoreFX I had a way better time using it than with NUnit.

Anyway, I recently ran into a problem while using the console runner over at dotnet/corefx#7042 where it would crash while writing invalid surrogate characters to the XML file. For example, this would fail:

```csharp
public static IEnumerable<object[]> UrlEncode_TestData()
{
    yield return new object[] { "\uD800", "%EF%BF%BD" };
}

[Theory]
[MemberData(nameof(UrlEncode_TestData))]
public static void UrlEncode(string value, string expected)
{
    Assert.Equal(expected, WebUtility.UrlEncode(value));
}

// error: The surrogate pair (0xD800, 0x22) is invalid. A high surrogate character (0xD800 - 0xDBFF) must always be paired with a low surrogate character (0xDC00 - 0xDFFF).
```

This pull request fixes that by encoding surrogate characters as `\x----` in the XML (where `----` is the hex value of the char). I've also added tests to enforce this, and make sure that valid surrogate sequences are outputted as normal.