### PR TITLE
"Pretty" Display Name Implementation for Test Cases

### DIFF
--- a/src/common/TestMethodDisplayOptions.cs
+++ b/src/common/TestMethodDisplayOptions.cs
@@ -1,0 +1,63 @@
+#if XUNIT_FRAMEWORK
+namespace Xunit.Sdk
+#else
+namespace Xunit
+#endif
+{
+    using System;
+
+    /// <summary>
+    /// Indicates the method display options for test methods.
+    /// </summary>
+    [Flags]
+    public enum TestMethodDisplayOptions
+    {
+        /// <summary>
+        /// Indicates no additional method display options.
+        /// </summary>
+        /// <remarks>This is the default configuration option.</remarks>
+        None = 0x00,
+
+        /// <summary>
+        /// Replace underscores in display names with a space.
+        /// </summary>
+        ReplaceUnderscoreWithSpace = 0x01,
+
+        /// <summary>
+        /// Replace well-known monikers with their equivalent operator.
+        /// </summary>
+        /// <list type="bullet">
+        /// <item><description>lt : &lt;</description></item>
+        /// <item><description>le : &lt;=</description></item>
+        /// <item><description>eq : =</description></item>
+        /// <item><description>ne : !=</description></item>
+        /// <item><description>gt : &gt;</description></item>
+        /// <item><description>ge : &gt;=</description></item>
+        /// </list>
+        UseOperatorMonikers = 0x02,
+
+        /// <summary>
+        /// Replace supported escape sequences with their equivalent character.
+        /// <list type="table">
+        /// <listheader>
+        ///  <term>Encoding</term>
+        ///  <description>Format</description>
+        /// </listheader>
+        /// <item><term>ASCII</term><description>X hex-digit hex-digit (ex: X2C)</description></item>
+        /// <item><term>Unicode</term><description>U hex-digit hex-digit hex-digit hex-digit (ex: U00A9)</description></item>
+        /// </list>
+        /// </summary>
+        UseEscapeSequences = 0x04,
+
+        /// <summary>
+        /// Replaces the period delimiter used in namespace and type references with a comma.
+        /// </summary>
+        /// <remarks>This option is only honored if the <see cref="TestMethodDisplay.ClassAndMethod"/> setting is also enabled.</remarks>
+        ReplacePeriodWithComma = 0x08,
+
+        /// <summary>
+        /// Enables all method display options.
+        /// </summary>
+        All = ReplaceUnderscoreWithSpace | UseOperatorMonikers | UseEscapeSequences | ReplacePeriodWithComma
+    }
+}

--- a/src/common/TestOptionsNames.cs
+++ b/src/common/TestOptionsNames.cs
@@ -5,6 +5,7 @@ static class TestOptionsNames
         public static readonly string DiagnosticMessages = "xunit.discovery.DiagnosticMessages";
         public static readonly string InternalDiagnosticMessages = "xunit.discovery.InternalDiagnosticMessages";
         public static readonly string MethodDisplay = "xunit.discovery.MethodDisplay";
+        public static readonly string MethodDisplayOptions = "xunit.discovery.MethodDisplayOptions";
         public static readonly string PreEnumerateTheories = "xunit.discovery.PreEnumerateTheories";
         public static readonly string SynchronousMessageReporting = "xunit.discovery.SynchronousMessageReporting";
     }

--- a/src/xunit.core/xunit.core.csproj
+++ b/src/xunit.core/xunit.core.csproj
@@ -10,6 +10,7 @@
     <Compile Include="..\common\ExceptionExtensions.cs" LinkBase="Common" />
     <Compile Include="..\common\Guard.cs" LinkBase="Common" />
     <Compile Include="..\common\TestMethodDisplay.cs" LinkBase="Common" />
+    <Compile Include="..\common\TestMethodDisplayOptions.cs" LinkBase="Common" />
     <Compile Include="..\xunit.assert\Asserts\Sdk\ArgumentFormatter.cs" LinkBase="Common\Asserts" />
     <Compile Include="..\xunit.assert\Asserts\Sdk\AssertEqualityComparer.cs" LinkBase="Common\Asserts" />
     <Compile Include="..\xunit.assert\Asserts\Sdk\AssertEqualityComparerAdapter.cs" LinkBase="Common\Asserts" />

--- a/src/xunit.execution/Extensions/TestFrameworkOptionsReadExtensions.cs
+++ b/src/xunit.execution/Extensions/TestFrameworkOptionsReadExtensions.cs
@@ -36,6 +36,15 @@ public static class TestFrameworkOptionsReadExtensions
     }
 
     /// <summary>
+    /// Gets a flag that determines the default display options to format test methods.
+    /// </summary>
+    public static TestMethodDisplayOptions? MethodDisplayOptions(this ITestFrameworkDiscoveryOptions discoveryOptions)
+    {
+        var methodDisplayOptionsString = discoveryOptions.GetValue<string>(TestOptionsNames.Discovery.MethodDisplayOptions);
+        return methodDisplayOptionsString != null ? (TestMethodDisplayOptions?)Enum.Parse(typeof(TestMethodDisplayOptions), methodDisplayOptionsString) : null;
+    }
+
+    /// <summary>
     /// Gets a flag that determines the default display name format for test methods. If the flag is not present,
     /// returns the default value (<see cref="TestMethodDisplay.ClassAndMethod"/>).
     /// </summary>
@@ -45,8 +54,17 @@ public static class TestFrameworkOptionsReadExtensions
     }
 
     /// <summary>
-    /// Gets a flag that determines whether theories are pre-enumerated. If enabled, then the
-    /// discovery system will return a test case for each row of test data; if disabled, the
+    /// Gets the options that determine the default display formatting options for test methods. If no options are not present,
+    /// returns the default value (<see cref="TestMethodDisplayOptions.None"/>).
+    /// </summary>
+    public static TestMethodDisplayOptions MethodDisplayOptionsOrDefault(this ITestFrameworkDiscoveryOptions discoveryOptions)
+    {
+        return discoveryOptions.MethodDisplayOptions() ?? TestMethodDisplayOptions.None;
+    }
+
+    /// <summary>
+    /// Gets a flag that determines whether theories are pre-enumerated. If they enabled, then the
+    /// discovery system will return a test case for each row of test data; they are disabled, then the
     /// discovery system will return a single test case for the theory.
     /// </summary>
     public static bool? PreEnumerateTheories(this ITestFrameworkDiscoveryOptions discoveryOptions)

--- a/src/xunit.execution/Sdk/Frameworks/DisplayNameFormatter.cs
+++ b/src/xunit.execution/Sdk/Frameworks/DisplayNameFormatter.cs
@@ -1,0 +1,284 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using static Xunit.Sdk.TestMethodDisplay;
+using static Xunit.Sdk.TestMethodDisplayOptions;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Represents a formatter that formats the display name of a class and/or method into a more
+    /// human readable form using additional options.
+    /// </summary>
+    public class DisplayNameFormatter
+    {
+        private readonly CharacterRule rule;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisplayNameFormatter"/> class.
+        /// </summary>
+        public DisplayNameFormatter()
+        {
+            rule = new CharacterRule();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisplayNameFormatter"/> class.
+        /// </summary>
+        /// <param name="display">The <see cref="TestMethodDisplay"/> used by the formatter.</param>
+        /// <param name="displayOptions">The <see cref="TestMethodDisplayOptions"/> used by the formatter.</param>
+        public DisplayNameFormatter(TestMethodDisplay display, TestMethodDisplayOptions displayOptions)
+        {
+            rule = new CharacterRule();
+
+            if ((displayOptions & UseEscapeSequences) == UseEscapeSequences)
+            {
+                rule = new ReplaceEscapeSequenceRule() { Next = rule };
+            }
+
+            if ((displayOptions & ReplaceUnderscoreWithSpace) == ReplaceUnderscoreWithSpace)
+            {
+                rule = new ReplaceUnderscoreRule() { Next = rule };
+            }
+
+            if ((displayOptions & UseOperatorMonikers) == UseOperatorMonikers)
+            {
+                rule = new ReplaceOperatorMonikerRule() { Next = rule };
+            }
+
+            if (display == ClassAndMethod)
+            {
+                if ((displayOptions & ReplacePeriodWithComma) == ReplacePeriodWithComma)
+                {
+                    rule = new ReplacePeriodRule() { Next = rule };
+                }
+                else
+                {
+                    rule = new KeepPeriodRule() { Next = rule };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Formats the specified display name.
+        /// </summary>
+        /// <param name="displayName">The display name to format.</param>
+        /// <returns>The formatted display name.</returns>
+        public string Format(string displayName)
+        {
+            var context = new FormatContext(displayName);
+
+            while (context.HasMoreText)
+            {
+                rule.Evaluate(context, context.ReadNext());
+            }
+
+            context.Flush();
+
+            return context.FormattedDisplayName.ToString();
+        }
+
+        private sealed class FormatContext
+        {
+            private readonly string text;
+            private readonly int length;
+            private int position;
+
+            public FormatContext(string text)
+            {
+                this.text = text;
+                length = text.Length;
+            }
+
+            public StringBuilder FormattedDisplayName { get; } = new StringBuilder();
+
+            public StringBuilder Buffer { get; } = new StringBuilder();
+
+            public bool HasMoreText => position < length;
+
+            public char ReadNext() => text[position++];
+
+            public void Flush()
+            {
+                FormattedDisplayName.Append(Buffer);
+                Buffer.Clear();
+            }
+        }
+
+        private class CharacterRule
+        {
+            public virtual void Evaluate(FormatContext context, char character) => context.Buffer.Append(character);
+
+            public CharacterRule Next { get; set; }
+        }
+
+        private sealed class ReplaceOperatorMonikerRule : CharacterRule
+        {
+            private static readonly Dictionary<string, string> tokenMonikers =
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["eq"] = "=",
+                    ["ne"] = "!=",
+                    ["lt"] = "<",
+                    ["le"] = "<=",
+                    ["gt"] = ">",
+                    ["ge"] = ">="
+                };
+
+            public override void Evaluate(FormatContext context, char character)
+            {
+                if (character == '_')
+                {
+                    if (TryConsumeMoniker(context, context.Buffer.ToString()))
+                    {
+                        context.Buffer.Append(' ');
+                        context.Flush();
+                    }
+                    else
+                    {
+                        Next?.Evaluate(context, character);
+                    }
+
+                    return;
+                }
+
+                if (context.HasMoreText)
+                {
+                    Next?.Evaluate(context, character);
+                }
+                else if (TryConsumeMoniker(context, context.Buffer.ToString() + character))
+                {
+                    context.Flush();
+                }
+                else
+                {
+                    Next?.Evaluate(context, character);
+                }
+            }
+
+            private bool TryConsumeMoniker(FormatContext context, string token)
+            {
+                var @operator = default(string);
+
+                if (!tokenMonikers.TryGetValue(token, out @operator))
+                {
+                    return false;
+                }
+
+                context.Buffer.Clear();
+                context.Buffer.Append(@operator);
+                return true;
+            }
+        }
+
+        private sealed class ReplaceUnderscoreRule : CharacterRule
+        {
+            public override void Evaluate(FormatContext context, char character)
+            {
+                if (character == '_')
+                {
+                    context.Buffer.Append(' ');
+                    context.Flush();
+                }
+                else
+                {
+                    Next?.Evaluate(context, character);
+                }
+            }
+        }
+
+        private sealed class ReplaceEscapeSequenceRule : CharacterRule
+        {
+            public override void Evaluate(FormatContext context, char character)
+            {
+                switch (character)
+                {
+                    case 'U':
+                        // same as \uHHHH without the leading '\u'
+                        TryConsumeEscapeSequence(context, character, 4);
+                        break;
+                    case 'X':
+                        // same as \xHH without the leading '\x'
+                        TryConsumeEscapeSequence(context, character, 2);
+                        break;
+                    default:
+                        Next?.Evaluate(context, character);
+                        break;
+                }
+            }
+
+            private static void TryConsumeEscapeSequence(FormatContext context, char @char, int allowedLength)
+            {
+                var escapeSequence = new char[allowedLength];
+                var consumed = 0;
+
+                while (consumed < allowedLength && context.HasMoreText)
+                {
+                    var nextChar = context.ReadNext();
+
+                    escapeSequence[consumed++] = nextChar;
+
+                    if (IsHex(nextChar))
+                    {
+                        continue;
+                    }
+
+                    context.Buffer.Append(@char);
+                    context.Buffer.Append(escapeSequence, 0, consumed);
+                    return;
+                }
+
+                context.Buffer.Append(char.ConvertFromUtf32(HexToInt32(escapeSequence)));
+            }
+
+            private static bool IsHex(char c) => (c > 64 && c < 71) || (c > 47 && c < 58);
+
+            private static int HexToInt32(char[] hex)
+            {
+                var @int = 0;
+                var length = hex.Length - 1;
+
+                for (var i = 0; i <= length; i++)
+                {
+                    var c = hex[i];
+                    var v = c < 58 ? c - 48 : c - 55;
+                    @int += v << ((length - i) << 2);
+                }
+
+                return @int;
+            }
+        }
+
+        private sealed class ReplacePeriodRule : CharacterRule
+        {
+            public override void Evaluate(FormatContext context, char character)
+            {
+                if (character == '.')
+                {
+                    context.Buffer.Append(", ");
+                    context.Flush();
+                }
+                else
+                {
+                    Next?.Evaluate(context, character);
+                }
+            }
+        }
+
+        private sealed class KeepPeriodRule : CharacterRule
+        {
+            public override void Evaluate(FormatContext context, char character)
+            {
+                if (character == '.')
+                {
+                    context.Buffer.Append(character);
+                    context.Flush();
+                }
+                else
+                {
+                    Next?.Evaluate(context, character);
+                }
+            }
+        }
+    }
+}

--- a/src/xunit.execution/Sdk/Frameworks/ExecutionErrorTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/ExecutionErrorTestCase.cs
@@ -22,10 +22,16 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
         /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
         /// <param name="testMethod">The test method.</param>
         /// <param name="errorMessage">The error message to report for the test.</param>
-        public ExecutionErrorTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, string errorMessage)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        public ExecutionErrorTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            string errorMessage)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
         {
             ErrorMessage = errorMessage;
         }

--- a/src/xunit.execution/Sdk/Frameworks/FactDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/FactDiscoverer.cs
@@ -32,7 +32,7 @@ namespace Xunit.Sdk
         /// <param name="factAttribute">The attribute that decorates the test method.</param>
         /// <returns></returns>
         protected virtual IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
-            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
 
         /// <summary>
         /// Discover test cases from a test method. By default, if the method is generic, or
@@ -48,9 +48,9 @@ namespace Xunit.Sdk
             IXunitTestCase testCase;
 
             if (testMethod.Method.GetParameters().Any())
-                testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[Fact] methods are not allowed to have parameters. Did you mean to use [Theory]?");
+                testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, "[Fact] methods are not allowed to have parameters. Did you mean to use [Theory]?");
             else if (testMethod.Method.IsGenericMethodDefinition)
-                testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[Fact] methods are not allowed to be generic.");
+                testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, "[Fact] methods are not allowed to be generic.");
             else
                 testCase = CreateTestCase(discoveryOptions, testMethod, factAttribute);
 

--- a/src/xunit.execution/Sdk/Frameworks/TestMethodTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestMethodTestCase.cs
@@ -22,21 +22,32 @@ namespace Xunit.Sdk
         IMethodInfo method;
         ITypeInfo[] methodGenericTypes;
         volatile string uniqueID;
+        DisplayNameFormatter formatter;
 
         /// <summary>
         /// Used for de-serialization.
         /// </summary>
-        protected TestMethodTestCase() { }
+        protected TestMethodTestCase()
+        {
+            formatter = new DisplayNameFormatter();
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestMethodTestCase"/> class.
         /// </summary>
         /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
         /// <param name="testMethod">The test method this test case belongs to.</param>
         /// <param name="testMethodArguments">The arguments for the test method.</param>
-        protected TestMethodTestCase(TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
+        protected TestMethodTestCase(
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            object[] testMethodArguments = null)
         {
             DefaultMethodDisplay = defaultMethodDisplay;
+            DefaultMethodDisplayOptions = defaultMethodDisplayOptions;
+            formatter = new DisplayNameFormatter(defaultMethodDisplay, defaultMethodDisplayOptions);
             TestMethod = testMethod;
             TestMethodArguments = testMethodArguments;
         }
@@ -47,11 +58,13 @@ namespace Xunit.Sdk
         protected string BaseDisplayName
         {
             get
-            {
+            { 
                 if (DefaultMethodDisplay == TestMethodDisplay.ClassAndMethod)
-                    return $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}";
+                {
+                    return formatter.Format($"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}");
+                }
 
-                return TestMethod.Method.Name;
+                return formatter.Format(TestMethod.Method.Name);
             }
         }
 
@@ -59,6 +72,11 @@ namespace Xunit.Sdk
         /// Returns the default method display to use (when not customized).
         /// </summary>
         protected internal TestMethodDisplay DefaultMethodDisplay { get; private set; }
+
+        /// <summary>
+        /// Returns the default method display options to use (when not customized).
+        /// </summary>
+        protected internal TestMethodDisplayOptions DefaultMethodDisplayOptions { get; private set; }
 
         /// <inheritdoc/>
         public string DisplayName
@@ -278,6 +296,7 @@ namespace Xunit.Sdk
             data.AddValue("TestMethod", TestMethod);
             data.AddValue("TestMethodArguments", TestMethodArguments);
             data.AddValue("DefaultMethodDisplay", DefaultMethodDisplay.ToString());
+            data.AddValue("DefaultMethodDisplayOptions", DefaultMethodDisplayOptions.ToString());
         }
 
         /// <inheritdoc/>
@@ -286,6 +305,8 @@ namespace Xunit.Sdk
             TestMethod = data.GetValue<ITestMethod>("TestMethod");
             TestMethodArguments = data.GetValue<object[]>("TestMethodArguments");
             DefaultMethodDisplay = (TestMethodDisplay)Enum.Parse(typeof(TestMethodDisplay), data.GetValue<string>("DefaultMethodDisplay"));
+            DefaultMethodDisplayOptions = (TestMethodDisplayOptions)Enum.Parse(typeof(TestMethodDisplayOptions), data.GetValue<string>("DefaultMethodDisplayOptions"));
+            formatter = new DisplayNameFormatter(DefaultMethodDisplay, DefaultMethodDisplayOptions);
         }
     }
 }

--- a/src/xunit.execution/Sdk/Frameworks/TheoryDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TheoryDiscoverer.cs
@@ -30,7 +30,7 @@ namespace Xunit.Sdk
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Please override CreateTestCasesForDataRow instead")]
         protected virtual IXunitTestCase CreateTestCaseForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
-            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow);
+            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow);
 
         /// <summary>
         /// Creates test cases for a single row of data. By default, returns a single instance of <see cref="XunitTestCase"/>
@@ -50,7 +50,7 @@ namespace Xunit.Sdk
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Please override CreateTestCasesForSkip instead")]
         protected virtual IXunitTestCase CreateTestCaseForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, string skipReason)
-            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
 
         /// <summary>
         /// Creates test cases for a skipped theory. By default, returns a single instance of <see cref="XunitTestCase"/>
@@ -70,7 +70,7 @@ namespace Xunit.Sdk
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Please override CreateTestCasesForTheory instead")]
         protected virtual IXunitTestCase CreateTestCaseForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
-            => new XunitTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new XunitTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
 
         /// <summary>
         /// Creates test cases for the entire theory. This is used when one or more of the theory data items
@@ -91,7 +91,7 @@ namespace Xunit.Sdk
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Please override CreateTestCasesForSkippedDataRow instead")]
         protected virtual IXunitTestCase CreateTestCaseForSkippedDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow, string skipReason)
-            => new XunitSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, skipReason, dataRow);
+            => new XunitSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, skipReason, dataRow);
 
         /// <summary>
         /// Creates test cases for a single row of skipped data. By default, returns a single instance of <see cref="XunitSkippedDataRowTestCase"/>
@@ -156,6 +156,7 @@ namespace Xunit.Sdk
                                     new ExecutionErrorTestCase(
                                         DiagnosticMessageSink,
                                         discoveryOptions.MethodDisplayOrDefault(),
+                                        discoveryOptions.MethodDisplayOptionsOrDefault(),
                                         testMethod,
                                         $"Data discoverer specified for {reflectionAttribute.Attribute.GetType()} on {testMethod.TestClass.Class.Name}.{testMethod.Method.Name} does not implement IDataDiscoverer."
                                     )
@@ -165,6 +166,7 @@ namespace Xunit.Sdk
                                     new ExecutionErrorTestCase(
                                         DiagnosticMessageSink,
                                         discoveryOptions.MethodDisplayOrDefault(),
+                                        discoveryOptions.MethodDisplayOptionsOrDefault(),
                                         testMethod,
                                         $"A data discoverer specified on {testMethod.TestClass.Class.Name}.{testMethod.Method.Name} does not implement IDataDiscoverer."
                                     )
@@ -182,6 +184,7 @@ namespace Xunit.Sdk
                                     new ExecutionErrorTestCase(
                                         DiagnosticMessageSink,
                                         discoveryOptions.MethodDisplayOrDefault(),
+                                        discoveryOptions.MethodDisplayOptionsOrDefault(),
                                         testMethod,
                                         $"Data discoverer specified for {reflectionAttribute.Attribute.GetType()} on {testMethod.TestClass.Class.Name}.{testMethod.Method.Name} does not exist."
                                     )
@@ -191,6 +194,7 @@ namespace Xunit.Sdk
                                     new ExecutionErrorTestCase(
                                         DiagnosticMessageSink,
                                         discoveryOptions.MethodDisplayOrDefault(),
+                                        discoveryOptions.MethodDisplayOptionsOrDefault(),
                                         testMethod,
                                         $"A data discoverer specified on {testMethod.TestClass.Class.Name}.{testMethod.Method.Name} does not exist."
                                     )
@@ -211,6 +215,7 @@ namespace Xunit.Sdk
                                 new ExecutionErrorTestCase(
                                     DiagnosticMessageSink,
                                     discoveryOptions.MethodDisplayOrDefault(),
+                                    discoveryOptions.MethodDisplayOptionsOrDefault(),
                                     testMethod,
                                     $"Test data returned null for {testMethod.TestClass.Class.Name}.{testMethod.Method.Name}. Make sure it is statically initialized before this test method is called."
                                 )
@@ -242,6 +247,7 @@ namespace Xunit.Sdk
                     if (results.Count == 0)
                         results.Add(new ExecutionErrorTestCase(DiagnosticMessageSink,
                                                                discoveryOptions.MethodDisplayOrDefault(),
+                                                               discoveryOptions.MethodDisplayOptionsOrDefault(),
                                                                testMethod,
                                                                $"No data found for {testMethod.TestClass.Class.Name}.{testMethod.Method.Name}"));
 

--- a/src/xunit.execution/Sdk/Frameworks/XunitSkippedDataRowTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitSkippedDataRowTestCase.cs
@@ -22,11 +22,12 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
         /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
         /// <param name="testMethod">The test method this test case belongs to.</param>
         /// <param name="skipReason">The reason that this test case will be skipped</param>
         /// <param name="testMethodArguments">The arguments for the test method.</param>
-        public XunitSkippedDataRowTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, string skipReason, object[] testMethodArguments = null) :
-            base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        public XunitSkippedDataRowTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, string skipReason, object[] testMethodArguments = null) :
+            base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
             this.skipReason = skipReason;
         }

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
@@ -35,13 +35,15 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
         /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
         /// <param name="testMethod">The test method this test case belongs to.</param>
         /// <param name="testMethodArguments">The arguments for the test method.</param>
         public XunitTestCase(IMessageSink diagnosticMessageSink,
                              TestMethodDisplay defaultMethodDisplay,
+                             TestMethodDisplayOptions defaultMethodDisplayOptions,
                              ITestMethod testMethod,
                              object[] testMethodArguments = null)
-            : base(defaultMethodDisplay, testMethod, testMethodArguments)
+            : base(defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
             DiagnosticMessageSink = diagnosticMessageSink;
         }

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscoverer.cs
@@ -85,7 +85,7 @@ namespace Xunit.Sdk
             if (factAttributes.Count > 1)
             {
                 var message = $"Test method '{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}' has multiple [Fact]-derived attributes";
-                var testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, TestMethodDisplay.ClassAndMethod, testMethod, message);
+                var testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod, message);
                 return ReportDiscoveredTestCase(testCase, includeSourceInformation, messageBus);
             }
 
@@ -164,7 +164,7 @@ namespace Xunit.Sdk
                 var className = testCase.TestMethod?.TestClass?.Class?.Name;
                 var methodName = testCase.TestMethod?.Method?.Name;
                 if (className != null && methodName != null && (xunitTestCase.TestMethodArguments == null || xunitTestCase.TestMethodArguments.Length == 0))
-                    return $":F:{className}:{methodName}:{(int)xunitTestCase.DefaultMethodDisplay}:{testCase.TestMethod.TestClass.TestCollection.UniqueID.ToString("N")}";
+                    return $":F:{className}:{methodName}:{(int)xunitTestCase.DefaultMethodDisplay}:{(int) xunitTestCase.DefaultMethodDisplayOptions}:{testCase.TestMethod.TestClass.TestCollection.UniqueID.ToString("N")}";
             }
 
             return base.Serialize(testCase);

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkExecutor.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkExecutor.cs
@@ -46,17 +46,30 @@ namespace Xunit.Sdk
         {
             if (value.Length > 3 && value.StartsWith(":F:"))
             {
-                // Format from XunitTestFrameworkDiscoverer.Serialize: ":F:{typeName}:{methodName}:{defaultMethodDisplay}:{collectionId}"
+                // Format from XunitTestFrameworkDiscoverer.Serialize: ":F:{typeName}:{methodName}:{defaultMethodDisplay}:{defaultMethodDisplayOptions}:{collectionId}"
                 var parts = value.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length > 4)
                 {
                     var typeInfo = discoverer.Value.AssemblyInfo.GetType(parts[1]);
-                    var testCollectionUniqueId = Guid.Parse(parts[4]);
+                    var testCollectionUniqueId = default(Guid);
+                    var defaultMethodDisplayOptions = default(TestMethodDisplayOptions);
+
+                    if (parts.Length > 5)
+                    {
+                        defaultMethodDisplayOptions = (TestMethodDisplayOptions)int.Parse(parts[4]);
+                        testCollectionUniqueId = Guid.Parse(parts[5]);
+                    }
+                    else
+                    {
+                        testCollectionUniqueId = Guid.Parse(parts[4]);
+                        defaultMethodDisplayOptions = TestMethodDisplayOptions.None;
+                    }
+
                     var testClass = discoverer.Value.CreateTestClass(typeInfo, testCollectionUniqueId);
                     var methodInfo = testClass.Class.GetMethod(parts[2], true);
                     var testMethod = new TestMethod(testClass, methodInfo);
                     var defaultMethodDisplay = (TestMethodDisplay)int.Parse(parts[3]);
-                    return new XunitTestCase(DiagnosticMessageSink, defaultMethodDisplay, testMethod);
+                    return new XunitTestCase(DiagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod);
                 }
             }
 

--- a/src/xunit.execution/Sdk/Frameworks/XunitTheoryTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTheoryTestCase.cs
@@ -22,9 +22,10 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
         /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
         /// <param name="testMethod">The method under test.</param>
-        public XunitTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod) { }
+        public XunitTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
 
         /// <inheritdoc />
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,

--- a/src/xunit.runner.utility/Configuration/ConfigReader_Configuration.cs
+++ b/src/xunit.runner.utility/Configuration/ConfigReader_Configuration.cs
@@ -37,6 +37,7 @@ namespace Xunit
                         result.InternalDiagnosticMessages = GetBoolean(settings, Configuration.InternalDiagnosticMessages) ?? result.InternalDiagnosticMessages;
                         result.MaxParallelThreads = GetInt(settings, Configuration.MaxParallelThreads) ?? result.MaxParallelThreads;
                         result.MethodDisplay = GetEnum<TestMethodDisplay>(settings, Configuration.MethodDisplay) ?? result.MethodDisplay;
+                        result.MethodDisplayOptions = GetEnum<TestMethodDisplayOptions>(settings, Configuration.MethodDisplayOptions) ?? result.MethodDisplayOptions;
                         result.ParallelizeAssembly = GetBoolean(settings, Configuration.ParallelizeAssembly) ?? result.ParallelizeAssembly;
                         result.ParallelizeTestCollections = GetBoolean(settings, Configuration.ParallelizeTestCollections) ?? result.ParallelizeTestCollections;
                         result.PreEnumerateTheories = GetBoolean(settings, Configuration.PreEnumerateTheories) ?? result.PreEnumerateTheories;
@@ -106,6 +107,7 @@ namespace Xunit
             public const string InternalDiagnosticMessages = "xunit.internalDiagnosticMessages";
             public const string MaxParallelThreads = "xunit.maxParallelThreads";
             public const string MethodDisplay = "xunit.methodDisplay";
+            public const string MethodDisplayOptions = "xunit.methodDisplayOptions";
             public const string ParallelizeAssembly = "xunit.parallelizeAssembly";
             public const string ParallelizeTestCollections = "xunit.parallelizeTestCollections";
             public const string PreEnumerateTheories = "xunit.preEnumerateTheories";

--- a/src/xunit.runner.utility/Configuration/ConfigReader_Json.cs
+++ b/src/xunit.runner.utility/Configuration/ConfigReader_Json.cs
@@ -82,6 +82,19 @@ namespace Xunit
                                 catch { }
                             }
                         }
+                        else if (string.Equals(propertyName, Configuration.MethodDisplayOptions, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var stringValue = propertyValue as JsonString;
+                            if (stringValue != null)
+                            {
+                                try
+                                {
+                                    var methodDisplayOptions = Enum.Parse(typeof(TestMethodDisplayOptions), stringValue, true);
+                                    result.MethodDisplayOptions = (TestMethodDisplayOptions)methodDisplayOptions;
+                                }
+                                catch { }
+                            }
+                        }
                         else if (string.Equals(propertyName, Configuration.AppDomain, StringComparison.OrdinalIgnoreCase))
                         {
                             var stringValue = propertyValue as JsonString;
@@ -167,6 +180,7 @@ namespace Xunit
             public const string InternalDiagnosticMessages = "internalDiagnosticMessages";
             public const string MaxParallelThreads = "maxParallelThreads";
             public const string MethodDisplay = "methodDisplay";
+            public const string MethodDisplayOptions = "methodDisplayOptions";
             public const string ParallelizeAssembly = "parallelizeAssembly";
             public const string ParallelizeTestCollections = "parallelizeTestCollections";
             public const string PreEnumerateTheories = "preEnumerateTheories";

--- a/src/xunit.runner.utility/Extensions/TestFrameworkOptionsReadWriteExtensions.cs
+++ b/src/xunit.runner.utility/Extensions/TestFrameworkOptionsReadWriteExtensions.cs
@@ -62,6 +62,24 @@ public static class TestFrameworkOptionsReadWriteExtensions
     }
 
     /// <summary>
+    /// Gets a flag that determines the default display name format options for test methods.
+    /// </summary>
+    public static TestMethodDisplayOptions? GetMethodDisplayOptions( this ITestFrameworkDiscoveryOptions discoveryOptions )
+    {
+        var methodDisplayOptionsString = discoveryOptions.GetValue<string>( TestOptionsNames.Discovery.MethodDisplayOptions );
+        return methodDisplayOptionsString != null ? (TestMethodDisplayOptions?) Enum.Parse( typeof( TestMethodDisplayOptions ), methodDisplayOptionsString ) : null;
+    }
+
+    /// <summary>
+    /// Gets a flag that determines the default display name format options for test methods. If the flag is not present,
+    /// returns the default value (<see cref="TestMethodDisplayOptions.None"/>).
+    /// </summary>
+    public static TestMethodDisplayOptions GetMethodDisplayOptionsOrDefault( this ITestFrameworkDiscoveryOptions discoveryOptions )
+    {
+        return discoveryOptions.GetMethodDisplayOptions() ?? TestMethodDisplayOptions.None;
+    }
+
+    /// <summary>
     /// Gets a flag that determines whether theories are pre-enumerated. If they enabled, then the
     /// discovery system will return a test case for each row of test data; they are disabled, then the
     /// discovery system will return a single test case for the theory.
@@ -121,6 +139,14 @@ public static class TestFrameworkOptionsReadWriteExtensions
     public static void SetMethodDisplay(this ITestFrameworkDiscoveryOptions discoveryOptions, TestMethodDisplay? value)
     {
         discoveryOptions.SetValue(TestOptionsNames.Discovery.MethodDisplay, value.HasValue ? value.GetValueOrDefault().ToString() : null);
+    }
+
+    /// <summary>
+    /// Sets the flags that determine the default display options for test methods.
+    /// </summary>
+    public static void SetMethodDisplayOptions(this ITestFrameworkDiscoveryOptions discoveryOptions, TestMethodDisplayOptions? value)
+    {
+        discoveryOptions.SetValue(TestOptionsNames.Discovery.MethodDisplayOptions, value.HasValue ? value.GetValueOrDefault().ToString() : null);
     }
 
     /// <summary>

--- a/src/xunit.runner.utility/Frameworks/TestAssemblyConfiguration.cs
+++ b/src/xunit.runner.utility/Frameworks/TestAssemblyConfiguration.cs
@@ -80,6 +80,17 @@ namespace Xunit
         public TestMethodDisplay MethodDisplayOrDefault { get { return MethodDisplay ?? TestMethodDisplay.ClassAndMethod; } }
 
         /// <summary>
+        /// Gets or sets the default display options for test methods.
+        /// </summary>
+        public TestMethodDisplayOptions? MethodDisplayOptions { get; set; }
+
+        /// <summary>
+        /// Gets the default display options for test methods. If the value is not set, returns
+        /// the default value (<see cref="TestMethodDisplayOptions.None"/>).
+        /// </summary>
+        public TestMethodDisplayOptions MethodDisplayOptionsOrDefault { get { return MethodDisplayOptions ?? TestMethodDisplayOptions.None; } }
+
+        /// <summary>
         /// Gets or sets a flag indicating that this assembly is safe to parallelize against
         /// other assemblies.
         /// </summary>

--- a/src/xunit.runner.utility/Frameworks/TestFrameworkOptions.cs
+++ b/src/xunit.runner.utility/Frameworks/TestFrameworkOptions.cs
@@ -34,6 +34,7 @@ namespace Xunit
                 result.SetDiagnosticMessages(configuration.DiagnosticMessages);
                 result.SetInternalDiagnosticMessages(configuration.InternalDiagnosticMessages);
                 result.SetMethodDisplay(configuration.MethodDisplay);
+                result.SetMethodDisplayOptions(configuration.MethodDisplayOptions);
                 result.SetPreEnumerateTheories(configuration.PreEnumerateTheories);
             }
 

--- a/src/xunit.runner.utility/Reporters/DefaultRunnerReporterMessageHandler.cs
+++ b/src/xunit.runner.utility/Reporters/DefaultRunnerReporterMessageHandler.cs
@@ -187,9 +187,9 @@ namespace Xunit
             if (discoveryStarting.DiscoveryOptions.GetDiagnosticMessagesOrDefault())
             {
 #if NET35 || NET452
-                Logger.LogImportantMessage($"  Discovering: {assemblyDisplayName} (app domain = {(discoveryStarting.AppDomain ? $"on [{(discoveryStarting.ShadowCopy ? "shadow copy" : "no shadow copy")}]" : "off")}, method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()})");
+                Logger.LogImportantMessage($"  Discovering: {assemblyDisplayName} (app domain = {(discoveryStarting.AppDomain ? $"on [{(discoveryStarting.ShadowCopy ? "shadow copy" : "no shadow copy")}]" : "off")}, method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()}, method display options = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOptionsOrDefault()})");
 #else
-                Logger.LogImportantMessage($"  Discovering: {assemblyDisplayName} (method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()})");
+                Logger.LogImportantMessage( $"  Discovering: {assemblyDisplayName} (method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()}, method display options = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOptionsOrDefault()})" );
 #endif
             }
             else

--- a/src/xunit.runner.utility/Reporters/DefaultRunnerReporterWithTypesMessageHandler.cs
+++ b/src/xunit.runner.utility/Reporters/DefaultRunnerReporterWithTypesMessageHandler.cs
@@ -205,9 +205,9 @@ namespace Xunit
             if (discoveryStarting.DiscoveryOptions.GetDiagnosticMessagesOrDefault())
             {
 #if NET35 || NET452
-                Logger.LogImportantMessage($"  Discovering: {assemblyDisplayName} (app domain = {(discoveryStarting.AppDomain ? $"on [{(discoveryStarting.ShadowCopy ? "shadow copy" : "no shadow copy")}]" : "off")}, method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()})");
+                Logger.LogImportantMessage($"  Discovering: {assemblyDisplayName} (app domain = {(discoveryStarting.AppDomain ? $"on [{(discoveryStarting.ShadowCopy ? "shadow copy" : "no shadow copy")}]" : "off")}, method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()}, method display options = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOptionsOrDefault()})");
 #else
-                Logger.LogImportantMessage($"  Discovering: {assemblyDisplayName} (method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()})");
+                Logger.LogImportantMessage( $"  Discovering: {assemblyDisplayName} (method display = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOrDefault()}, method display options = {discoveryStarting.DiscoveryOptions.GetMethodDisplayOptionsOrDefault()})" );
 #endif
             }
             else

--- a/src/xunit.runner.utility/Runners/AssemblyRunner.cs
+++ b/src/xunit.runner.utility/Runners/AssemblyRunner.cs
@@ -162,7 +162,7 @@ namespace Xunit.Runners
             executionCompleteEvent.SafeDispose();
         }
 
-        ITestFrameworkDiscoveryOptions GetDiscoveryOptions(bool? diagnosticMessages, TestMethodDisplay? methodDisplay, bool? preEnumerateTheories, bool? internalDiagnosticMessages)
+        ITestFrameworkDiscoveryOptions GetDiscoveryOptions(bool? diagnosticMessages, TestMethodDisplay? methodDisplay, TestMethodDisplayOptions? methodDisplayOptions, bool? preEnumerateTheories, bool? internalDiagnosticMessages)
         {
             var discoveryOptions = TestFrameworkOptions.ForDiscovery(configuration);
             discoveryOptions.SetSynchronousMessageReporting(true);
@@ -173,6 +173,8 @@ namespace Xunit.Runners
                 discoveryOptions.SetDiagnosticMessages(internalDiagnosticMessages);
             if (methodDisplay.HasValue)
                 discoveryOptions.SetMethodDisplay(methodDisplay);
+            if (methodDisplayOptions.HasValue)
+                discoveryOptions.SetMethodDisplayOptions(methodDisplayOptions);
             if (preEnumerateTheories.HasValue)
                 discoveryOptions.SetPreEnumerateTheories(preEnumerateTheories);
 
@@ -206,6 +208,8 @@ namespace Xunit.Runners
         /// By default, uses the value from the assembly configuration file.</param>
         /// <param name="methodDisplay">Set to choose the default display name style for test methods.
         /// By default, uses the value from the assembly configuration file. (This parameter is ignored for xUnit.net v1 tests.)</param>
+        /// <param name="methodDisplayOptions">Set to choose the default display name style options for test methods.
+        /// By default, uses the value from the assembly configuration file. (This parameter is ignored for xUnit.net v1 tests.)</param>
         /// <param name="preEnumerateTheories">Set to <c>true</c> to pre-enumerate individual theory tests; set to <c>false</c> to use
         /// a single test case for the theory. By default, uses the value from the assembly configuration file. (This parameter is ignored
         /// for xUnit.net v1 tests.)</param>
@@ -218,6 +222,7 @@ namespace Xunit.Runners
         public void Start(string typeName = null,
                           bool? diagnosticMessages = null,
                           TestMethodDisplay? methodDisplay = null,
+                          TestMethodDisplayOptions? methodDisplayOptions = null,
                           bool? preEnumerateTheories = null,
                           bool? parallel = null,
                           int? maxParallelThreads = null,
@@ -237,7 +242,7 @@ namespace Xunit.Runners
 
             XunitWorkerThread.QueueUserWorkItem(() =>
             {
-                var discoveryOptions = GetDiscoveryOptions(diagnosticMessages, methodDisplay, preEnumerateTheories, internalDiagnosticMessages);
+                var discoveryOptions = GetDiscoveryOptions(diagnosticMessages, methodDisplay, methodDisplayOptions, preEnumerateTheories, internalDiagnosticMessages);
                 if (typeName != null)
                     controller.Find(typeName, false, this, discoveryOptions);
                 else

--- a/src/xunit.runner.utility/xunit.runner.utility.csproj
+++ b/src/xunit.runner.utility/xunit.runner.utility.csproj
@@ -29,6 +29,7 @@
     <Compile Include="..\common\SerializationHelper.cs" LinkBase="Common" />
     <Compile Include="..\common\SourceInformation.cs" LinkBase="Common" />
     <Compile Include="..\common\TestMethodDisplay.cs" LinkBase="Common" />
+    <Compile Include="..\common\TestMethodDisplayOptions.cs" LinkBase="Common" />
     <Compile Include="..\common\TestOptionsNames.cs" LinkBase="Common" />
     <Compile Include="..\common\XunitSerializationInfo.cs" LinkBase="Common" />
     <Compile Include="..\common\XunitWorkerThread.cs" LinkBase="Common" />

--- a/test/test.utility/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
+++ b/test/test.utility/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
@@ -22,7 +22,10 @@ namespace TestUtility
             if (cultures == null || cultures.Length == 0)
                 cultures = new[] { "en-US", "fr-FR" };
 
-            return cultures.Select(culture => new CulturedXunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, culture)).ToList();
+            var methodDisplay = discoveryOptions.MethodDisplayOrDefault();
+            var methodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
+
+            return cultures.Select(culture => new CulturedXunitTestCase(diagnosticMessageSink, methodDisplay, methodDisplayOptions, testMethod, culture)).ToList();
         }
     }
 }

--- a/test/test.utility/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
+++ b/test/test.utility/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
@@ -13,13 +13,13 @@ namespace TestUtility
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
             var cultures = GetCultures(theoryAttribute);
-            return cultures.Select(culture => new CulturedXunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, culture, dataRow)).ToList();
+            return cultures.Select(culture => new CulturedXunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture, dataRow)).ToList();
         }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
             var cultures = GetCultures(theoryAttribute);
-            return cultures.Select(culture => new CulturedXunitTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, culture)).ToList();
+            return cultures.Select(culture => new CulturedXunitTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture)).ToList();
         }
 
         static string[] GetCultures(IAttributeInfo culturedTheoryAttribute)

--- a/test/test.utility/CultureAwareTesting/CulturedXunitTestCase.cs
+++ b/test/test.utility/CultureAwareTesting/CulturedXunitTestCase.cs
@@ -18,10 +18,11 @@ namespace TestUtility
 
         public CulturedXunitTestCase(IMessageSink diagnosticMessageSink,
                                      TestMethodDisplay defaultMethodDisplay,
+                                     TestMethodDisplayOptions defaultMethodDisplayOptions,
                                      ITestMethod testMethod,
                                      string culture,
                                      object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
             Initialize(culture);
         }

--- a/test/test.utility/CultureAwareTesting/CulturedXunitTheoryTestCase.cs
+++ b/test/test.utility/CultureAwareTesting/CulturedXunitTheoryTestCase.cs
@@ -19,9 +19,10 @@ namespace TestUtility
         /// </summary>
         /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
         /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
         /// <param name="testMethod">The method under test.</param>
-        public CulturedXunitTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, string culture)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        public CulturedXunitTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, string culture)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
         {
             Initialize(culture);
         }

--- a/test/test.utility/TestDoubles/Mocks.cs
+++ b/test/test.utility/TestDoubles/Mocks.cs
@@ -8,6 +8,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
+using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
 
 public static class Mocks
 {
@@ -92,7 +93,7 @@ public static class Mocks
     public static ExecutionErrorTestCase ExecutionErrorTestCase(string message, IMessageSink diagnosticMessageSink = null)
     {
         var testMethod = TestMethod();
-        return new ExecutionErrorTestCase(diagnosticMessageSink ?? new Xunit.NullMessageSink(), TestMethodDisplay.ClassAndMethod, testMethod, message);
+        return new ExecutionErrorTestCase(diagnosticMessageSink ?? new Xunit.NullMessageSink(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod, message);
     }
 
     public static IReflectionAttributeInfo FactAttribute(string displayName = null, string skip = null)
@@ -586,14 +587,14 @@ public static class Mocks
     {
         var method = TestMethod(typeof(TClassUnderTest), methodName, collection);
 
-        return new XunitTestCase(diagnosticMessageSink ?? new Xunit.NullMessageSink(), TestMethodDisplay.ClassAndMethod, method, testMethodArguments);
+        return new XunitTestCase(diagnosticMessageSink ?? new Xunit.NullMessageSink(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, method, testMethodArguments);
     }
 
     public static XunitTheoryTestCase XunitTheoryTestCase<TClassUnderTest>(string methodName, ITestCollection collection = null, IMessageSink diagnosticMessageSink = null)
     {
         var method = TestMethod(typeof(TClassUnderTest), methodName, collection);
 
-        return new XunitTheoryTestCase(diagnosticMessageSink ?? new Xunit.NullMessageSink(), TestMethodDisplay.ClassAndMethod, method);
+        return new XunitTheoryTestCase(diagnosticMessageSink ?? new Xunit.NullMessageSink(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, method);
     }
 
     // Helpers

--- a/test/test.xunit.execution/Sdk/Frameworks/DisplayNameFormatterTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/DisplayNameFormatterTests.cs
@@ -1,0 +1,397 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Sdk;
+using static Xunit.Sdk.TestMethodDisplay;
+using static Xunit.Sdk.TestMethodDisplayOptions;
+using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
+
+public class DisplayNameFormatterTests
+{
+    [Theory]
+    [MemberData(nameof(ClassAndMethodWithoutOptions))]
+    public void FormatShouldReturnExpectedDisplayNameFromClassAndMethodWithoutAnyOptions(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: ClassAndMethod, displayOptions: None);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodWithoutOptions))]
+    public void FormatShouldReturnExpectedDisplayNameFromMethodWithoutAnyOptions(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: Method, displayOptions: None);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(ClassAndMethodWithAllOptions))]
+    public void FormatShouldReturnExpectedDisplayNameFromClassAndMethodWithAllOptions(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: ClassAndMethod, displayOptions: All);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodWithAllOptions))]
+    public void FormatShouldReturnExpectedDisplayNameFromMethodWithAllOptions(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: Method, displayOptions: All);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(ClassAndMethodWithReplaceUnderscoreOption))]
+    public void FormatShouldReturnExpectedDisplayNameFromClassAndMethodWithSpacesInsteadOfUnderscores(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: ClassAndMethod, displayOptions: ReplaceUnderscoreWithSpace);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodWithReplaceUnderscoreOption))]
+    public void FormatShouldReturnExpectedDisplayNameFromMethodWithSpacesInsteadOfUnderscores(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: Method, displayOptions: ReplaceUnderscoreWithSpace);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(ClassAndMethodWithReplaceUnderscoreAndOperatorOption))]
+    public void FormatShouldReturnExpectedDisplayNameFromClassAndMethodWithReplacedSpacesAndOperators(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: ClassAndMethod, displayOptions: ReplaceUnderscoreWithSpace | UseOperatorMonikers);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodWithReplaceUnderscoreAndOperatorOption))]
+    public void FormatShouldReturnExpectedDisplayNameFromMethodWithReplacedSpacesAndOperators(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: Method, displayOptions: ReplaceUnderscoreWithSpace | UseOperatorMonikers);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(ClassAndMethodWithReplaceUnderscoreAndEscapeSequenceOption))]
+    public void FormatShouldReturnExpectedDisplayNameFromClassAndMethodWithReplacedSpacesAndEscapeSequences(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: ClassAndMethod, displayOptions: ReplaceUnderscoreWithSpace | UseEscapeSequences);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(MethodWithReplaceUnderscoreAndEscapeSequenceOption))]
+    public void FormatShouldReturnExpectedDisplayNameFromMethodWithReplacedSpacesAndEscapeSequences(string name, string expected)
+    {
+        var formatter = new DisplayNameFormatter(display: Method, displayOptions: ReplaceUnderscoreWithSpace | UseEscapeSequences);
+        var actual = formatter.Format(name);
+
+        Assert.Equal(expected, actual);
+    }
+
+    public static IEnumerable<object[]> ClassAndMethodWithoutOptions => NoOptionsDisplayData(ClassAndMethod);
+
+    public static IEnumerable<object[]> MethodWithoutOptions => NoOptionsDisplayData(Method);
+
+    public static IEnumerable<object[]> ClassAndMethodWithAllOptions => AllOptionsDisplayData(ClassAndMethod);
+
+    public static IEnumerable<object[]> MethodWithAllOptions => AllOptionsDisplayData(Method);
+
+    public static IEnumerable<object[]> ClassAndMethodWithReplaceUnderscoreOption => ReplaceUnderscoreOnlyDisplayData(ClassAndMethod);
+
+    public static IEnumerable<object[]> MethodWithReplaceUnderscoreOption => ReplaceUnderscoreOnlyDisplayData(Method);
+
+    public static IEnumerable<object[]> ClassAndMethodWithReplaceUnderscoreAndOperatorOption => ReplaceUnderscoreAndOperatorDisplayData(ClassAndMethod);
+
+    public static IEnumerable<object[]> MethodWithReplaceUnderscoreAndOperatorOption => ReplaceUnderscoreAndOperatorDisplayData(Method);
+
+    public static IEnumerable<object[]> ClassAndMethodWithReplaceUnderscoreAndEscapeSequenceOption => ReplaceUnderscoreAndEscapeSequenceDisplayData(ClassAndMethod);
+
+    public static IEnumerable<object[]> MethodWithReplaceUnderscoreAndEscapeSequenceOption => ReplaceUnderscoreAndEscapeSequenceDisplayData(Method);
+
+    private static string NameOf(Action testMethod) => $"{testMethod.Method.DeclaringType.FullName}.{testMethod.Method.Name}";
+
+    private static IEnumerable<object[]> NoOptionsDisplayData(TestMethodDisplay methodDisplay)
+    {
+        if (methodDisplay == ClassAndMethod)
+        {
+            yield return new object[] { NameOf(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), NameOf(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_eq_1X2E0), NameOf(FormattedDisplayNameExample.api_version_1_eq_1X2E0) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_should_be_greater_than_1), NameOf(FormattedDisplayNameExample.api_version_should_be_greater_than_1) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), NameOf(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), NameOf(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), NameOf(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), NameOf(FormattedDisplayNameExample.api_version_1_should_be_le_than_2) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), NameOf(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.lt_0_should_be_an_error), NameOf(FormattedDisplayNameExample.lt_0_should_be_an_error) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), NameOf(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), NameOf(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), NameOf(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), NameOf(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), NameOf(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), NameOf(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), NameOf(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), NameOf(FormattedDisplayNameExample.TestNameShouldRemainUnchanged) };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), NameOf(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces) };
+            yield return new object[] { NameOf(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), NameOf(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2) };
+            yield break;
+        }
+
+        yield return new object[] { nameof(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), nameof(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_eq_1X2E0), nameof(FormattedDisplayNameExample.api_version_1_eq_1X2E0) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_should_be_greater_than_1), nameof(FormattedDisplayNameExample.api_version_should_be_greater_than_1) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), nameof(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), nameof(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), nameof(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), nameof(FormattedDisplayNameExample.api_version_1_should_be_le_than_2) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), nameof(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.lt_0_should_be_an_error), nameof(FormattedDisplayNameExample.lt_0_should_be_an_error) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), nameof(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), nameof(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), nameof(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), nameof(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), nameof(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), nameof(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), nameof(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), nameof(FormattedDisplayNameExample.TestNameShouldRemainUnchanged) };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), nameof(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces) };
+        yield return new object[] { nameof(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), nameof(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2) };
+    }
+
+    private static IEnumerable<object[]> AllOptionsDisplayData(TestMethodDisplay methodDisplay)
+    {
+        if (methodDisplay == ClassAndMethod)
+        {
+            yield return new object[] { NameOf(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "FormattedDisplayNameExample, unit tests are awesome! ☺" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "FormattedDisplayNameExample, api version 1 = 1.0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "FormattedDisplayNameExample, api version should be greater than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "FormattedDisplayNameExample, api version 2 should be > than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "FormattedDisplayNameExample, api version 2 should be >= than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "FormattedDisplayNameExample, api version 1 should be < than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "FormattedDisplayNameExample, api version 1 should be <= than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "FormattedDisplayNameExample, api version 1.0 should != 2.0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.lt_0_should_be_an_error), "FormattedDisplayNameExample, < 0 should be an error" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "FormattedDisplayNameExample, equals operator overload should be same as = =" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "FormattedDisplayNameExample, == operator overload should be same as equals method" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "FormattedDisplayNameExample, masculine super heroes should be buffed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "FormattedDisplayNameExample, termination date should be updated when employee is axed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "FormattedDisplayNameExample, total amount should be updated when order is taxed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "FormattedDisplayNameExample, 'stuffed' should not be ambiguous with 'st￭'" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "FormattedDisplayNameExample, 'maxed out' should not be ambiguous with 'maí out'" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "FormattedDisplayNameExample, TestNameShouldRemainUnchanged" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "FormattedDisplayNameExample, Test Name With Spaces" };
+            yield return new object[] { NameOf(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "Given a version number, when it equals 1, then it should be less than 2" };
+            yield break;
+        }
+
+        yield return new object[] { nameof(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "unit tests are awesome! ☺" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "api version 1 = 1.0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "api version should be greater than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "api version 2 should be > than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "api version 2 should be >= than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "api version 1 should be < than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "api version 1 should be <= than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "api version 1.0 should != 2.0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.lt_0_should_be_an_error), "< 0 should be an error" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "equals operator overload should be same as = =" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "== operator overload should be same as equals method" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "masculine super heroes should be buffed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "termination date should be updated when employee is axed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "total amount should be updated when order is taxed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "'stuffed' should not be ambiguous with 'st￭'" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "'maxed out' should not be ambiguous with 'maí out'" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "TestNameShouldRemainUnchanged" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "Test Name With Spaces" };
+        yield return new object[] { nameof(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "then it should be less than 2" };
+    }
+
+    private static IEnumerable<object[]> ReplaceUnderscoreOnlyDisplayData(TestMethodDisplay methodDisplay)
+    {
+        if (methodDisplay == ClassAndMethod)
+        {
+            yield return new object[] { NameOf(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "FormattedDisplayNameExample.unit tests are awesomeX21 U263A" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "FormattedDisplayNameExample.api version 1 eq 1X2E0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "FormattedDisplayNameExample.api version should be greater than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "FormattedDisplayNameExample.api version 2 should be gt than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "FormattedDisplayNameExample.api version 2 should be ge than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "FormattedDisplayNameExample.api version 1 should be lt than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "FormattedDisplayNameExample.api version 1 should be le than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "FormattedDisplayNameExample.api version 1X2E0 should ne 2U002E0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.lt_0_should_be_an_error), "FormattedDisplayNameExample.lt 0 should be an error" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "FormattedDisplayNameExample.equals operator overload should be same as eq eq" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "FormattedDisplayNameExample.X3DX3D operator overload should be same as equals method" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "FormattedDisplayNameExample.masculine super heroes should be buffed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "FormattedDisplayNameExample.termination date should be updated when employee is axed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "FormattedDisplayNameExample.total amount should be updated when order is taxed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "FormattedDisplayNameExample.X27stuffedX27 should not be ambiguous with X27stUFFEDX27" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "FormattedDisplayNameExample.X27maxed outX27 should not be ambiguous with X27maXED outX27" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "FormattedDisplayNameExample.TestNameShouldRemainUnchanged" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces" };
+            yield return new object[] { NameOf(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "Given a version number.when it equals 1.then it should be less than 2" };
+            yield break;
+        }
+
+        yield return new object[] { nameof(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "unit tests are awesomeX21 U263A" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "api version 1 eq 1X2E0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "api version should be greater than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "api version 2 should be gt than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "api version 2 should be ge than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "api version 1 should be lt than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "api version 1 should be le than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "api version 1X2E0 should ne 2U002E0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.lt_0_should_be_an_error), "lt 0 should be an error" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "equals operator overload should be same as eq eq" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "X3DX3D operator overload should be same as equals method" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "masculine super heroes should be buffed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "termination date should be updated when employee is axed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "total amount should be updated when order is taxed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "X27stuffedX27 should not be ambiguous with X27stUFFEDX27" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "X27maxed outX27 should not be ambiguous with X27maXED outX27" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "TestNameShouldRemainUnchanged" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "TestX20NameX20WithU0020Spaces" };
+        yield return new object[] { nameof(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "then it should be less than 2" };
+    }
+
+    private static IEnumerable<object[]> ReplaceUnderscoreAndOperatorDisplayData(TestMethodDisplay methodDisplay)
+    {
+        if (methodDisplay == ClassAndMethod)
+        {
+            yield return new object[] { NameOf(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "FormattedDisplayNameExample.unit tests are awesomeX21 U263A" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "FormattedDisplayNameExample.api version 1 = 1X2E0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "FormattedDisplayNameExample.api version should be greater than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "FormattedDisplayNameExample.api version 2 should be > than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "FormattedDisplayNameExample.api version 2 should be >= than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "FormattedDisplayNameExample.api version 1 should be < than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "FormattedDisplayNameExample.api version 1 should be <= than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "FormattedDisplayNameExample.api version 1X2E0 should != 2U002E0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.lt_0_should_be_an_error), "FormattedDisplayNameExample.< 0 should be an error" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "FormattedDisplayNameExample.equals operator overload should be same as = =" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "FormattedDisplayNameExample.X3DX3D operator overload should be same as equals method" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "FormattedDisplayNameExample.masculine super heroes should be buffed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "FormattedDisplayNameExample.termination date should be updated when employee is axed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "FormattedDisplayNameExample.total amount should be updated when order is taxed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "FormattedDisplayNameExample.X27stuffedX27 should not be ambiguous with X27stUFFEDX27" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "FormattedDisplayNameExample.X27maxed outX27 should not be ambiguous with X27maXED outX27" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "FormattedDisplayNameExample.TestNameShouldRemainUnchanged" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces" };
+            yield return new object[] { NameOf(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "Given a version number.when it equals 1.then it should be less than 2" };
+            yield break;
+        }
+
+        yield return new object[] { nameof(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "unit tests are awesomeX21 U263A" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "api version 1 = 1X2E0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "api version should be greater than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "api version 2 should be > than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "api version 2 should be >= than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "api version 1 should be < than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "api version 1 should be <= than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "api version 1X2E0 should != 2U002E0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.lt_0_should_be_an_error), "< 0 should be an error" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "equals operator overload should be same as = =" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "X3DX3D operator overload should be same as equals method" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "masculine super heroes should be buffed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "termination date should be updated when employee is axed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "total amount should be updated when order is taxed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "X27stuffedX27 should not be ambiguous with X27stUFFEDX27" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "X27maxed outX27 should not be ambiguous with X27maXED outX27" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "TestNameShouldRemainUnchanged" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "TestX20NameX20WithU0020Spaces" };
+        yield return new object[] { nameof(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "then it should be less than 2" };
+    }
+
+    private static IEnumerable<object[]> ReplaceUnderscoreAndEscapeSequenceDisplayData(TestMethodDisplay methodDisplay)
+    {
+        if (methodDisplay == ClassAndMethod)
+        {
+            yield return new object[] { NameOf(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "FormattedDisplayNameExample.unit tests are awesome! ☺" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "FormattedDisplayNameExample.api version 1 eq 1.0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "FormattedDisplayNameExample.api version should be greater than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "FormattedDisplayNameExample.api version 2 should be gt than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "FormattedDisplayNameExample.api version 2 should be ge than 1" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "FormattedDisplayNameExample.api version 1 should be lt than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "FormattedDisplayNameExample.api version 1 should be le than 2" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "FormattedDisplayNameExample.api version 1.0 should ne 2.0" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.lt_0_should_be_an_error), "FormattedDisplayNameExample.lt 0 should be an error" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "FormattedDisplayNameExample.equals operator overload should be same as eq eq" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "FormattedDisplayNameExample.== operator overload should be same as equals method" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "FormattedDisplayNameExample.masculine super heroes should be buffed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "FormattedDisplayNameExample.termination date should be updated when employee is axed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "FormattedDisplayNameExample.total amount should be updated when order is taxed" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "FormattedDisplayNameExample.'stuffed' should not be ambiguous with 'st￭'" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "FormattedDisplayNameExample.'maxed out' should not be ambiguous with 'maí out'" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "FormattedDisplayNameExample.TestNameShouldRemainUnchanged" };
+            yield return new object[] { NameOf(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "FormattedDisplayNameExample.Test Name With Spaces" };
+            yield return new object[] { NameOf(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "Given a version number.when it equals 1.then it should be less than 2" };
+            yield break;
+        }
+
+        yield return new object[] { nameof(FormattedDisplayNameExample.unit_tests_are_awesomeX21_U263A), "unit tests are awesome! ☺" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_eq_1X2E0), "api version 1 eq 1.0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_should_be_greater_than_1), "api version should be greater than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_gt_than_1), "api version 2 should be gt than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_2_should_be_ge_than_1), "api version 2 should be ge than 1" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_lt_than_2), "api version 1 should be lt than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1_should_be_le_than_2), "api version 1 should be le than 2" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.api_version_1X2E0_should_ne_2U002E0), "api version 1.0 should ne 2.0" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.lt_0_should_be_an_error), "lt 0 should be an error" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.equals_operator_overload_should_be_same_as_eq_eq), "equals operator overload should be same as eq eq" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X3DX3D_operator_overload_should_be_same_as_equals_method), "== operator overload should be same as equals method" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.masculine_super_heroes_should_be_buffed), "masculine super heroes should be buffed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.termination_date_should_be_updated_when_employee_is_axed), "termination date should be updated when employee is axed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.total_amount_should_be_updated_when_order_is_taxed), "total amount should be updated when order is taxed" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27), "'stuffed' should not be ambiguous with 'st￭'" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27), "'maxed out' should not be ambiguous with 'maí out'" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestNameShouldRemainUnchanged), "TestNameShouldRemainUnchanged" };
+        yield return new object[] { nameof(FormattedDisplayNameExample.TestX20NameX20WithU0020Spaces), "Test Name With Spaces" };
+        yield return new object[] { nameof(Given_a_version_number.when_it_equals_1.then_it_should_be_less_than_2), "then it should be less than 2" };
+    }
+}
+
+public static class FormattedDisplayNameExample
+{
+    public static void unit_tests_are_awesomeX21_U263A() { }
+    public static void api_version_1_eq_1X2E0() { }
+    public static void api_version_should_be_greater_than_1() { }
+    public static void api_version_2_should_be_gt_than_1() { }
+    public static void api_version_2_should_be_ge_than_1() { }
+    public static void api_version_1_should_be_lt_than_2() { }
+    public static void api_version_1_should_be_le_than_2() { }
+    public static void api_version_1X2E0_should_ne_2U002E0() { }
+    public static void lt_0_should_be_an_error() { }
+    public static void equals_operator_overload_should_be_same_as_eq_eq() { }
+    public static void X3DX3D_operator_overload_should_be_same_as_equals_method() { }
+    public static void masculine_super_heroes_should_be_buffed() { }
+    public static void termination_date_should_be_updated_when_employee_is_axed() { }
+    public static void total_amount_should_be_updated_when_order_is_taxed() { }
+    public static void X27stuffedX27_should_not_be_ambiguous_with_X27stUFFEDX27() { }
+    public static void X27maxed_outX27_should_not_be_ambiguous_with_X27maXED_outX27() { }
+    public static void TestNameShouldRemainUnchanged() { }
+    public static void TestX20NameX20WithU0020Spaces() { }
+}
+
+namespace Given_a_version_number
+{
+    public static class when_it_equals_1
+    {
+        public static void then_it_should_be_less_than_2() { }
+    }
+}

--- a/test/test.xunit.execution/Sdk/Frameworks/TestMethodTestCaseTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/TestMethodTestCaseTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 using Xunit.Sdk;
 using Xunit.Serialization;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
+using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
 
 public class TestMethodTestCaseTests
 {
@@ -164,8 +165,12 @@ public class TestMethodTestCaseTests
     {
         public TestableTestMethodTestCase() { }
 
-        public TestableTestMethodTestCase(ITestMethod testMethod, object[] testMethodArguments = null, TestMethodDisplay defaultMethodDisplay = TestMethodDisplay.ClassAndMethod)
-            : base(defaultMethodDisplay, testMethod, testMethodArguments) { }
+        public TestableTestMethodTestCase(
+            ITestMethod testMethod,
+            object[] testMethodArguments = null,
+            TestMethodDisplay defaultMethodDisplay = TestMethodDisplay.ClassAndMethod,
+            TestMethodDisplayOptions defaultMethodDisplayOptions = TestMethodDisplayOptions.None)
+            : base(defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments) { }
 
         public static TestableTestMethodTestCase Create<TClass>(string methodName, object[] testMethodArguments = null)
         {

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestCaseTests.cs
@@ -6,6 +6,7 @@ using Xunit.Abstractions;
 using Xunit.Sdk;
 using IAttributeInfo = Xunit.Abstractions.IAttributeInfo;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
+using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
 
 public class XunitTestCaseTests
 {
@@ -14,7 +15,7 @@ public class XunitTestCaseTests
     {
         var testMethod = Mocks.TestMethod("MockType", "MockMethod");
 
-        var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, testMethod);
+        var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod);
 
         Assert.Equal("MockType.MockMethod", testCase.DisplayName);
         Assert.Null(testCase.SkipReason);
@@ -26,7 +27,7 @@ public class XunitTestCaseTests
     {
         var testMethod = Mocks.TestMethod(skip: "Skip Reason");
 
-        var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, testMethod);
+        var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod);
 
         Assert.Equal("Skip Reason", testCase.SkipReason);
     }
@@ -40,7 +41,7 @@ public class XunitTestCaseTests
             var trait2 = Mocks.TraitAttribute("Trait2", "Value2");
             var testMethod = Mocks.TestMethod(methodAttributes: new[] { trait1, trait2 });
 
-            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, testMethod);
+            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod);
 
             Assert.Equal("Value1", Assert.Single(testCase.Traits["Trait1"]));
             Assert.Equal("Value2", Assert.Single(testCase.Traits["Trait2"]));
@@ -53,7 +54,7 @@ public class XunitTestCaseTests
             var trait2 = Mocks.TraitAttribute("Trait2", "Value2");
             var testMethod = Mocks.TestMethod(classAttributes: new[] { trait1, trait2 });
 
-            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, testMethod);
+            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod);
 
             Assert.Equal("Value1", Assert.Single(testCase.Traits["Trait1"]));
             Assert.Equal("Value2", Assert.Single(testCase.Traits["Trait2"]));
@@ -93,7 +94,7 @@ public class XunitTestCaseTests
             var messages = new List<IMessageSinkMessage>();
             var spy = SpyMessageSink.Create(messages: messages);
 
-            var testCase = new XunitTestCase(spy, TestMethodDisplay.ClassAndMethod, testMethod);
+            var testCase = new XunitTestCase(spy, TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod);
 
             Assert.Empty(testCase.Traits);
             var diagnosticMessages = messages.OfType<IDiagnosticMessage>();
@@ -134,7 +135,7 @@ public class XunitTestCaseTests
         {
             var testMethod = Mocks.TestMethod(displayName: "Custom Display Name");
 
-            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, testMethod);
+            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod);
 
             Assert.Equal("Custom Display Name", testCase.DisplayName);
         }
@@ -148,7 +149,7 @@ public class XunitTestCaseTests
             var testMethod = Mocks.TestMethod(displayName: "Custom Display Name", parameters: new[] { param1, param2, param3 });
             var arguments = new object[] { 42, "Hello, world!", 'A' };
 
-            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, testMethod, arguments);
+            var testCase = new XunitTestCase(SpyMessageSink.Create(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod, arguments);
 
             Assert.Equal("Custom Display Name(p1: 42, p2: \"Hello, world!\", p3: 'A')", testCase.DisplayName);
         }

--- a/test/test.xunit.execution/Sdk/TestCaseBulkDeserializerTests.cs
+++ b/test/test.xunit.execution/Sdk/TestCaseBulkDeserializerTests.cs
@@ -21,12 +21,14 @@ public class TestCaseBulkDeserializerTests
         executor = new XunitTestFrameworkExecutor(assembly.GetName(), sourceInformationProvider, diagnosticMessageSink);
     }
 
-    [Fact]
-    public void CanDeserializeSpecialFactSerialization()
+    [Theory]
+    [InlineData(":F:TestCaseBulkDeserializerTests+TestClass:FactMethod:2")]
+    [InlineData(":F:TestCaseBulkDeserializerTests+TestClass:FactMethod:2:1")]
+    public void CanDeserializeSpecialFactSerialization(string serializedTestCase)
     {
         var guid = Guid.NewGuid();
         var results = default(List<KeyValuePair<string, ITestCase>>);
-        var serializedTestCases = new List<string> { $":F:TestCaseBulkDeserializerTests+TestClass:FactMethod:2:{guid.ToString("N")}" };
+        var serializedTestCases = new List<string> { $"{serializedTestCase}:{guid.ToString("N")}" };
         Action<List<KeyValuePair<string, ITestCase>>> callback = r => results = r;
 
         new TestCaseBulkDeserializer(discoverer, executor, serializedTestCases, callback);

--- a/test/test.xunit.execution/Sdk/TestCaseDescriptorFactoryTests.cs
+++ b/test/test.xunit.execution/Sdk/TestCaseDescriptorFactoryTests.cs
@@ -109,7 +109,7 @@ public class TestCaseDescriptorFactoryTests
 
             var result = Assert.Single(callbackResults);
             var serialization = Assert.Single(result.Split('\n').Where(line => line.StartsWith("S ")));
-            Assert.Equal($"S :F:TestCaseDescriptorFactoryTests+TestClass:FactMethod:1:{testCase.TestMethod.TestClass.TestCollection.UniqueID.ToString("N")}", serialization);
+            Assert.Equal($"S :F:TestCaseDescriptorFactoryTests+TestClass:FactMethod:1:0:{testCase.TestMethod.TestClass.TestCollection.UniqueID.ToString("N")}", serialization);
         }
 
         [Fact]

--- a/test/test.xunit.runner.utility/Common/ConfigReaderTests.cs
+++ b/test/test.xunit.runner.utility/Common/ConfigReaderTests.cs
@@ -25,6 +25,7 @@ public class ConfigReaderTests
             Assert.False(result.InternalDiagnosticMessagesOrDefault);
             Assert.Equal(Environment.ProcessorCount, result.MaxParallelThreadsOrDefault);
             Assert.Equal(TestMethodDisplay.ClassAndMethod, result.MethodDisplayOrDefault);
+            Assert.Equal(TestMethodDisplayOptions.None, result.MethodDisplayOptionsOrDefault);
             Assert.False(result.ParallelizeAssemblyOrDefault);
             Assert.True(result.ParallelizeTestCollectionsOrDefault);
             Assert.True(result.PreEnumerateTheoriesOrDefault);
@@ -39,6 +40,7 @@ public class ConfigReaderTests
             Assert.True(result.InternalDiagnosticMessagesOrDefault);
             Assert.Equal(2112, result.MaxParallelThreadsOrDefault);
             Assert.Equal(TestMethodDisplay.Method, result.MethodDisplayOrDefault);
+            Assert.Equal(TestMethodDisplayOptions.All, result.MethodDisplayOptionsOrDefault);
             Assert.True(result.ParallelizeAssemblyOrDefault);
             Assert.False(result.ParallelizeTestCollectionsOrDefault);
             Assert.False(result.PreEnumerateTheoriesOrDefault);
@@ -54,6 +56,7 @@ public class ConfigReaderTests
             Assert.False(result.InternalDiagnosticMessagesOrDefault);
             Assert.Equal(Environment.ProcessorCount, result.MaxParallelThreadsOrDefault);
             Assert.Equal(TestMethodDisplay.ClassAndMethod, result.MethodDisplayOrDefault);
+            Assert.Equal(TestMethodDisplayOptions.None, result.MethodDisplayOptionsOrDefault);
             // This value was valid as a sentinel to make sure we were trying to read values from the JSON
             Assert.True(result.ParallelizeAssemblyOrDefault);
             Assert.True(result.ParallelizeTestCollectionsOrDefault);
@@ -72,6 +75,7 @@ public class ConfigReaderTests
             Assert.False(result.InternalDiagnosticMessagesOrDefault);
             Assert.Equal(Environment.ProcessorCount, result.MaxParallelThreadsOrDefault);
             Assert.Equal(TestMethodDisplay.ClassAndMethod, result.MethodDisplayOrDefault);
+            Assert.Equal(TestMethodDisplayOptions.None, result.MethodDisplayOptionsOrDefault);
             Assert.False(result.ParallelizeAssemblyOrDefault);
             Assert.True(result.ParallelizeTestCollectionsOrDefault);
             Assert.True(result.PreEnumerateTheoriesOrDefault);
@@ -86,6 +90,7 @@ public class ConfigReaderTests
             Assert.True(result.InternalDiagnosticMessagesOrDefault);
             Assert.Equal(2112, result.MaxParallelThreadsOrDefault);
             Assert.Equal(TestMethodDisplay.Method, result.MethodDisplayOrDefault);
+            Assert.Equal(TestMethodDisplayOptions.All, result.MethodDisplayOptionsOrDefault);
             Assert.True(result.ParallelizeAssemblyOrDefault);
             Assert.False(result.ParallelizeTestCollectionsOrDefault);
             Assert.False(result.PreEnumerateTheoriesOrDefault);
@@ -101,6 +106,7 @@ public class ConfigReaderTests
             Assert.False(result.InternalDiagnosticMessagesOrDefault);
             Assert.Equal(Environment.ProcessorCount, result.MaxParallelThreadsOrDefault);
             Assert.Equal(TestMethodDisplay.ClassAndMethod, result.MethodDisplayOrDefault);
+            Assert.Equal(TestMethodDisplayOptions.None, result.MethodDisplayOptionsOrDefault);
             // This value was valid as a sentinel to make sure we were trying to read values from the file
             Assert.True(result.ParallelizeAssemblyOrDefault);
             Assert.True(result.ParallelizeTestCollectionsOrDefault);

--- a/test/test.xunit.runner.utility/ConfigReader_BadValues.config
+++ b/test/test.xunit.runner.utility/ConfigReader_BadValues.config
@@ -5,6 +5,7 @@
     <add key="xunit.internalDiagnosticMessages" value="blarch"/>
     <add key="xunit.maxParallelThreads" value="abc"/>
     <add key="xunit.methodDisplay" value="fooBar"/>
+    <add key="xunit.methodDisplayOptions" value="fooBar"/>
     <!-- Leave this one valid, and different, so we know we're actually
          attempting to parse the values from this file -->
     <add key="xunit.parallelizeAssembly" value="true"/>

--- a/test/test.xunit.runner.utility/ConfigReader_BadValues.json
+++ b/test/test.xunit.runner.utility/ConfigReader_BadValues.json
@@ -3,6 +3,7 @@
     "internalDiagnosticMessages": "blarch",
     "maxParallelThreads": "abc",
     "methodDisplay": "fooBar",
+    "methodDisplayOptions": "fooBar",
     "parallelizeAssembly": true,
     "parallelizetestcollections": "biff",
     "preEnumerateTheories": "baz"

--- a/test/test.xunit.runner.utility/ConfigReader_OverrideValues.config
+++ b/test/test.xunit.runner.utility/ConfigReader_OverrideValues.config
@@ -5,6 +5,7 @@
     <add key="xunit.internalDiagnosticMessages" value="true"/>
     <add key="xunit.maxParallelThreads" value="2112"/>
     <add key="xunit.methodDisplay" value="method"/>
+    <add key="xunit.methodDisplayOptions" value="all"/>
     <add key="xunit.parallelizeAssembly" value="true"/>
     <!-- One with incorrect case just to make sure we're case insensitive -->
     <add key="xunit.parallelizetestcollections" value="false"/>

--- a/test/test.xunit.runner.utility/ConfigReader_OverrideValues.json
+++ b/test/test.xunit.runner.utility/ConfigReader_OverrideValues.json
@@ -3,6 +3,7 @@
     "internalDiagnosticMessages": true,
     "maxParallelThreads": 2112,
     "methodDisplay": "method",
+    "methodDisplayOptions": "all",
     "parallelizeAssembly": true,
     "parallelizetestcollections": false,
     "preEnumerateTheories": false,

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterMessageHandlerTests.cs
@@ -115,7 +115,7 @@ public class DefaultRunnerReporterMessageHandlerTests
     {
         [Theory]
         [InlineData(false, "[Imp] =>   Discovering: testAssembly")]
-        [InlineData(true, "[Imp] =>   Discovering: testAssembly (app domain = on [no shadow copy], method display = ClassAndMethod)")]
+        [InlineData(true, "[Imp] =>   Discovering: testAssembly (app domain = on [no shadow copy], method display = ClassAndMethod, method display options = None)")]
         public static void LogsMessage(bool diagnosticMessages, string expectedResult)
         {
             var message = Mocks.TestAssemblyDiscoveryStarting(diagnosticMessages: diagnosticMessages, appDomain: true);

--- a/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterWithTypesMessageHandlerTests.cs
+++ b/test/test.xunit.runner.utility/Extensibility/DefaultRunnerReporterWithTypesMessageHandlerTests.cs
@@ -113,7 +113,7 @@ public class DefaultRunnerReporterWithTypesMessageHandlerTests
     {
         [Theory]
         [InlineData(false, "[Imp] =>   Discovering: testAssembly")]
-        [InlineData(true, "[Imp] =>   Discovering: testAssembly (app domain = on [no shadow copy], method display = ClassAndMethod)")]
+        [InlineData(true, "[Imp] =>   Discovering: testAssembly (app domain = on [no shadow copy], method display = ClassAndMethod, method display options = None)")]
         public static void LogsMessage(bool diagnosticMessages, string expectedResult)
         {
             var message = Mocks.TestAssemblyDiscoveryStarting(diagnosticMessages: diagnosticMessages, appDomain: true);

--- a/test/test.xunit.runner.utility/Frameworks/XunitFrontControllerTests.cs
+++ b/test/test.xunit.runner.utility/Frameworks/XunitFrontControllerTests.cs
@@ -46,7 +46,7 @@ namespace Namespace1
                 }
 
                 Assert.Collection(serializations,
-                    s => Assert.Equal($":F:Namespace1.Class1:FactMethod:1:{testCollectionId.ToString("N")}", s),
+                    s => Assert.Equal($":F:Namespace1.Class1:FactMethod:1:0:{testCollectionId.ToString("N")}", s),
                     s => Assert.StartsWith("Xunit.Sdk.XunitTestCase, xunit.execution.{Platform}:", s)
                 );
 


### PR DESCRIPTION
## Summary

This PR contains the implementation for "pretty" test case display names as described in issue #759.

The default behavior for test case display names is unchanged.  Developers must still opt into changing the display name settings via the **xunit.methodDisplay** configuration setting, but now with additional options.

The following new **TestMethodDisplay** options can be used in conjunction with the existing options to control test case display names:
- **ReplaceUnderscoreWithSpace** - replaces each '_' with a ' '
- **AllowOperatorMonikers** - recognizes and replaces supported operator monikers (ex: 'eq' to "=")
- **AllowEscapeSequences** - recognizes and replaces supported escape sequences (ex: 'X2C' to ',')

Developers can choose which, if any, of these options to turn on.  I realize not everyone may agree with using all of these options, but for those that do, I believe it's significantly more productive than re-entering special text via the **DisplayName** of facts or theories for scenarios that only involve a few characters.  The **DisplayName** continues to trump all of these settings and should be used for complex test case names to prevent the corresponding method names from becoming unintelligible.
## Notes

I chose to change the **TestMethodDisplay** to be a bit vector rather than introduce a new enumeration and configuration option.  I feel these new settings are too close in meaning with the existing options to warrant creating completely new configuration options. Since the values are backward-compatible, this seemed more than reasonable.

Changing the **TestMethodDisplay** to support flags means that it should _technically_ be renamed to indicate this behavior (ex: "TestMethodDisplayOptions"). Since this would introduce a breaking change, I decided against it.

For reasons I cannot explain, the value specified for **xunit.methodDisplay** will not parse when the new options are specified unless the value is supplied as an integer.  For example, the value **"Method,AllFormatExtensions"** should work, but it doesn't; however, using **"30"** does.  I've gone through all of the parsing code, unit tests, etc. and I can't explain this behavior.  Parsing bit vector enumerations from strings this way has been supported since .NET 1.0.  The exact cause and solution escapes me. For now, I'm accepting this limitation.  If you know why this is happening, I'm happy to make the appropriate update.

I haven't signed the contribution agreement yet, but I've read it, agree with it, and I'm happy to return a signed copy to you once it's provided. I've reviewed all of the contribution guidelines and believe that I have followed them accordingly.
## Screenshots

Here are some example screenshots from a demo application using a local build:
![basic-example](https://cloud.githubusercontent.com/assets/11765008/14583796/d3b138de-03e1-11e6-8859-cc529a47b818.png)
![gwt-example](https://cloud.githubusercontent.com/assets/11765008/14583797/d59568d2-03e1-11e6-9498-3ec9a4269109.png)
