### PR TITLE
Do not attempt to unnecessarily convert types which are compatible.

### DIFF
--- a/src/xunit.execution/Sdk/Reflection/Reflector.cs
+++ b/src/xunit.execution/Sdk/Reflection/Reflector.cs
@@ -44,7 +44,7 @@ namespace Xunit.Sdk
 
         internal static object ConvertArgument(object arg, Type type)
         {
-            if (arg != null && arg.GetType() != type)
+            if (arg != null && !type.IsAssignableFrom(arg.GetType()))
             {
                 try
                 {


### PR DESCRIPTION
Fixes https://github.com/xunit/xunit/issues/841

In cases where there are assignable types passed in, this could would still attempt to convert them by calling Convert.ChangeType.  This method throws when 'arg' is not IConvertible.