### PR TITLE
Microoptimize TestDiscoveryVisitor and DiagnosticMessageVisitor

### DIFF
--- a/src/common/TestDiscoveryVisitor.cs
+++ b/src/common/TestDiscoveryVisitor.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using Xunit.Abstractions;
 
 #if XUNIT_FRAMEWORK
@@ -7,19 +9,55 @@ namespace Xunit.Sdk
 namespace Xunit
 #endif
 {
-    class TestDiscoveryVisitor : TestMessageVisitor<IDiscoveryCompleteMessage>
+    class TestDiscoveryVisitor : LongLivedMarshalByRefObject, IMessageSink, IDisposable
     {
         public TestDiscoveryVisitor()
         {
+            Finished = new ManualResetEvent(false);
             TestCases = new List<ITestCase>();
+        }
+
+        /// <summary>
+        /// This event is triggered when the completion message has been seen.
+        /// </summary>
+        public ManualResetEvent Finished { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            ((IDisposable)Finished).Dispose();
         }
 
         public List<ITestCase> TestCases { get; private set; }
 
-        protected override bool Visit(ITestCaseDiscoveryMessage testCaseDiscovered)
+        /// <inheritdoc/>
+        public virtual bool OnMessage(IMessageSinkMessage message)
+        {
+            var discoveryMessage = message as ITestCaseDiscoveryMessage;
+            if (discoveryMessage != null)
+            {
+                return Visit(discoveryMessage);
+            }
+
+            var completeMessage = message as IDiscoveryCompleteMessage;
+            if (message is IDiscoveryCompleteMessage)
+            {
+                var result = Visit(completeMessage);
+                Finished.Set();
+                return result;
+            }
+
+            return true;
+        }
+
+        protected virtual bool Visit(IDiscoveryCompleteMessage completeMessage)
+        {
+            return true;
+        }
+
+        protected virtual bool Visit(ITestCaseDiscoveryMessage testCaseDiscovered)
         {
             TestCases.Add(testCaseDiscovered.TestCase);
-
             return true;
         }
     }

--- a/src/xunit.console/Visitors/DiagnosticMessageVisitor.cs
+++ b/src/xunit.console/Visitors/DiagnosticMessageVisitor.cs
@@ -18,21 +18,35 @@ namespace Xunit.ConsoleClient
             this.noColor = noColor;
         }
 
-        protected override bool Visit(IDiagnosticMessage diagnosticMessage)
+        /// <inheritdoc/>
+        public override bool OnMessage(IMessageSinkMessage message)
         {
             if (showDiagnostics)
-                lock (consoleLock)
+            {
+                var diagnosticMessage = message as IDiagnosticMessage;
+                if (diagnosticMessage != null)
                 {
-                    if (!noColor)
-                        Console.ForegroundColor = ConsoleColor.Yellow;
-
-                    Console.WriteLine($"   {assemblyDisplayName}: {diagnosticMessage.Message}");
-
-                    if (!noColor)
-                        Console.ResetColor();
+                    return Visit(diagnosticMessage);
                 }
+            }
 
-            return base.Visit(diagnosticMessage);
+            return true;
+        }
+
+        protected override bool Visit(IDiagnosticMessage diagnosticMessage)
+        {
+            lock (consoleLock)
+            {
+                if (!noColor)
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+
+                Console.WriteLine($"   {assemblyDisplayName}: {diagnosticMessage.Message}");
+
+                if (!noColor)
+                    Console.ResetColor();
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
...by overriding implementation in DiagnosticMessageVisitor.OnMessage, and not using TestMessageVisitor<T> base base class for TestDiscoveryVisitor.

This seems to shave half a second off some of my test runs, but YMMV - and I find measuring performance hard.

Partially addresses #472. 