### PR TITLE
Add null check for tuple

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/TestRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/TestRunner.cs
@@ -147,8 +147,11 @@ namespace Xunit.Sdk
                     if (!aggregator.HasExceptions)
                     {
                         var tuple = await aggregator.RunAsync(() => InvokeTestAsync(aggregator));
-                        runSummary.Time = tuple.Item1;
-                        output = tuple.Item2;
+                        if (tuple != null)
+                        {
+                            runSummary.Time = tuple.Item1;
+                            output = tuple.Item2;
+                        }
                     }
 
                     var exception = aggregator.ToException();


### PR DESCRIPTION
I've been seeing this error a few times during test runs, running 2.1:

System.NullReferenceException: Object reference not set to an instance of an object.
   at Xunit.Sdk.TestRunner`1.<RunAsync>d__43.MoveNext() in C:\BuildAgent\work\cb37e9acf085d108\src\xunit.execution\Sdk\Frameworks\Runners\TestRunner.cs:line 150

The offender is the default constructor for tuples in .Net 4.0+ - default(Tuple<T1, T2>) returns null. If the InvokeTestAsync function above raises, this is what is returned by RunAsync and hence we see a NullReferenceException.