### PR TITLE
Fix TeamCity Suite grouping (test count);

### DIFF
--- a/src/xunit.runner.msbuild/Utility/TeamCityDisplayNameFormatter.cs
+++ b/src/xunit.runner.msbuild/Utility/TeamCityDisplayNameFormatter.cs
@@ -15,7 +15,7 @@ namespace Xunit
                 testCollection.TestAssembly.Assembly.Name,
                 key => Interlocked.Increment(ref assemblyCount));
 
-            return string.Concat(testCollection.DisplayName, " (", id, ")");
+            return testCollection.DisplayName;
         }
 
         public virtual string DisplayName(ITest test)

--- a/src/xunit.runner.reporters/Utility/TeamCityDisplayNameFormatter.cs
+++ b/src/xunit.runner.reporters/Utility/TeamCityDisplayNameFormatter.cs
@@ -22,7 +22,7 @@ namespace Xunit.Runner.Reporters
                 }
             }
 
-            return $"{testCollection.DisplayName} ({id})";
+            return $"{testCollection.DisplayName}";
         }
 
         public virtual string DisplayName(ITest test)


### PR DESCRIPTION
**Change TeamCityReport testSuiteStarted to exclude 'id'.**

~~It appears TeamCity uses the test-suite name to not only group test results but compare them with any imported build via XML report processing build feature. Unless they match it not only knocks out the hierarchy of the results but also the test count. but it seems count them and the attribute throws it.~~

~~_NB: An alternative to this might be to include the 'id' in the XML output as this would ensure the two outputs still match._~~

For examples;

```
##teamcity[testSuiteStarted name='Test collection for MyTestAssembly.Handlers.RecordCredentials.CommandHandlerTests (2)' …]
```

```
<test-suite type="TestCollection" executed="True" name="Test collection for MyTestAssembly.Handlers.RecordCredentials.CommandHandlerTests" …>
```

vs;

```
##teamcity[testSuiteStarted name='Test collection for MyTestAssembly.Handlers.RecordCredentials.CommandHandlerTests' …]
```

```
<test-suite type="TestCollection" executed="True" name="Test collection for MyTestAssembly.Handlers.RecordCredentials.CommandHandlerTests" …>
```

**EDIT:** Apologies it seems obvious now it's because `testSuiteStarted` and `testSuiteEnded` don't match because `Ended` doesn't have the assembly attribute. Closing this and coming back with that fixed instead.