### PR TITLE
Fix 'Mixed mode assembly is built against version 'v2.0.50727' of the runtime' error (console runner)

### DIFF
--- a/src/xunit.console/App.config
+++ b/src/xunit.console/App.config
@@ -12,7 +12,7 @@
     </transforms>
   </xunit>
 
-  <startup>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>
 </configuration>


### PR DESCRIPTION
This seems to occur when running tests that reference and invoke an assembly that was built on .NET 2.0 (or used SGEN?). In our case it was the SMO (SQL Server Management Objects) library. This commit adds the useLegacyV2RuntimeActivationPolicy attribute for the console runner and sets it to true.

_NB: Not sure how this affects test assemblies that don't require this runtime attribute :(_

```
      System.IO.FileLoadException : Mixed mode assembly is built against version 'v2.0.50727' of the runtime and cannot be loaded in the 4.0 runtime without additional configuration information.
      Stack Trace:
           at System.Reflection.RuntimeAssembly.GetType(RuntimeAssembly assembly, String name, Boolean throwOnError, Boolean ignoreCase, ObjectHandleOnStack type)
           at System.Reflection.RuntimeAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
           at Microsoft.SqlServer.Management.Common.ServerConnection.GetStatements(String query, ExecutionTypes executionType, Int32& statementsToReverse)
           at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(String sqlCommand, ExecutionTypes executionType)
        src\Infrastructure.Testing.Setup\Persistence\TestDatabase.cs(86,0): at MyProject.Infrastructure.Testing.Setup.Persistence.TestDatabase.Initialize(String databaseName)
        src\Infrastructure.Testing.Setup\Persistence\TestDatabase.cs(27,0): at Myproject.Infrastructure.Testing.Setup.Persistence.TestDatabase..ctor(String databaseName, ITestOutputHelper output)
        src\Infrastructure.Testing.Setup\Persistence\DatabaseCreator.cs(27,0): at MyProject.Infrastructure.Testing.Setup.Persistence.DatabaseCreator.CreateTestDomainDatabase()
        src\Bus.Wonker.Tests.Acceptance\TestHelper.cs(26,0): at MyProject.Bus.Wonker.Tests.Acceptance.TestHelper.Setup(ITestOutputHelper output)
        src\Bus.Wonker.Tests.Acceptance\Handlers\RecordWonkerCredentials\CommandHandlerTests.cs(37,0): at MyProject.Bus.Wonker.Tests.Acceptance.Handlers.RecordWonkerCredentials.CommandHandlerTests..ctor(ITestOutputHelper output)
```