### PR TITLE
Fix TeamCity Suite grouping (test count)

### DIFF
--- a/src/xunit.runner.reporters/Utility/TeamCityDisplayNameFormatter.cs
+++ b/src/xunit.runner.reporters/Utility/TeamCityDisplayNameFormatter.cs
@@ -22,12 +22,24 @@ namespace Xunit.Runner.Reporters
                 }
             }
 
-            return $"{testCollection.DisplayName} ({id})";
+            return EscapeValue($"{testCollection.DisplayName}");
         }
 
         public virtual string DisplayName(ITest test)
         {
             return test.DisplayName;
+        }
+
+        static string EscapeValue(string value)
+        {
+            value = value.Replace("|", "||");
+            value = value.Replace("'", "|'");
+            value = value.Replace("[", "|[");
+            value = value.Replace("]", "|]");
+            value = value.Replace("\r", "|r");
+            value = value.Replace("\n", "|n");
+
+            return value;
         }
     }
 }


### PR DESCRIPTION
**This PR excludes the assembly id suffix and escapes as per TC reqs.**

It appears TeamCity uses the test-suite name to not only group test results but to derive the count. Unfortunately in TC 9.x it seems to take exception to the suffixed assembly attribute (issue [TW-46190](https://youtrack.jetbrains.com/issue/TW-46190)).

For example;

```
##teamcity[testSuiteStarted name='Test collection for MyTestAssembly.Handlers.RecordCredentials.CommandHandlerTests (2)' …]
```

vs;

```
##teamcity[testSuiteStarted name='Test collection for MyTestAssembly.Handlers.RecordCredentials.CommandHandlerTests' …]
```

In addition the output DisplayName was not escaped as per: https://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity
