### PR TITLE
Alter NUnitXml.xslt for TC compatibility

### DIFF
--- a/src/xunit.console/NUnitXml.xslt
+++ b/src/xunit.console/NUnitXml.xslt
@@ -32,45 +32,12 @@
         </xsl:attribute>
       </environment>
       <culture-info current-culture="unknown" current-uiculture="unknown" />
-      <test-suite type="Assemblies" name="xUnit.net Tests" executed="True">
-        <xsl:attribute name="success">
-          <xsl:if test="sum(assembly/@failed) > 0">False</xsl:if>
-          <xsl:if test="sum(assembly/@failed) = 0">True</xsl:if>
-        </xsl:attribute>
-        <xsl:attribute name="result">
-          <xsl:if test="sum(assembly/@failed) > 0">Failure</xsl:if>
-          <xsl:if test="sum(assembly/@failed) = 0">Success</xsl:if>
-        </xsl:attribute>
-        <xsl:attribute name="time">
-          <xsl:value-of select="sum(assembly/@time)"/>
-        </xsl:attribute>
-        <results>
-          <xsl:apply-templates select="assembly"/>
-        </results>
-      </test-suite>
+      <xsl:apply-templates select="assembly"/>
     </test-results>
   </xsl:template>
 
   <xsl:template match="assembly">
-    <test-suite type="Assembly" executed="True">
-      <xsl:attribute name="name">
-        <xsl:value-of select="@name"/>
-      </xsl:attribute>
-      <xsl:attribute name="result">
-        <xsl:if test="@failed > 0">Failure</xsl:if>
-        <xsl:if test="@failed = 0">Success</xsl:if>
-      </xsl:attribute>
-      <xsl:attribute name="success">
-        <xsl:if test="@failed > 0">False</xsl:if>
-        <xsl:if test="@failed = 0">True</xsl:if>
-      </xsl:attribute>
-      <xsl:attribute name="time">
-        <xsl:value-of select="@time"/>
-      </xsl:attribute>
-      <results>
-        <xsl:apply-templates select="collection"/>
-      </results>
-    </test-suite>
+    <xsl:apply-templates select="collection"/>
   </xsl:template>
 
   <xsl:template match="collection">


### PR DESCRIPTION
Importing NUnit generated output into TeamCity using the XML processing build feature can cause tests to be included twice if the hierarchy is different from than output during the build (using ##teamcity prefix).

** This commit simplifies the output of the NUnit xml report so that it matches the build output.**

_NB: Alternatively we could (a) have a different version just for TC or change the build-log output to have the same hierarchy.