### PR TITLE
Update xunit.abstractions to Dotnet Core 1.0 RTM.

### DIFF
--- a/src/abstractions/xunit.abstractions.nuspec
+++ b/src/abstractions/xunit.abstractions.nuspec
@@ -17,10 +17,10 @@
       <group targetFramework="net35" />
       <group targetFramework="portable-net45+netcore45+wp8+wpa81" />
       <group targetFramework="netstandard1.0">
-        <dependency id="System.Collections" version="4.0.11-rc2-24027" />
-        <dependency id="System.Diagnostics.Tools" version="4.0.1-rc2-24027" />
-        <dependency id="System.Reflection" version="4.1.0-rc2-24027" />
-        <dependency id="System.Runtime" version="4.1.0-rc2-24027" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Tools" version="4.0.1" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Runtime" version="4.1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/abstractions/xunit.abstractions.nuspec
+++ b/src/abstractions/xunit.abstractions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>xunit.abstractions</id>
-    <version>2.0.1-rc2</version>
+    <version>99.99.99-dev</version>
     <title>xUnit.net [Abstractions]</title>
     <authors>James Newkirk,Brad Wilson</authors>
     <owners>James Newkirk,Brad Wilson</owners>

--- a/src/abstractions/xunit.abstractions/project.json
+++ b/src/abstractions/xunit.abstractions/project.json
@@ -4,10 +4,10 @@
         "net35": { },
         "netstandard1.0": {
             "dependencies": {
-                "System.Collections": "4.0.11-rc2-24027",
-                "System.Diagnostics.Tools": "4.0.1-rc2-24027",
-                "System.Reflection": "4.1.0-rc2-24027",
-                "System.Runtime": "4.1.0-rc2-24027"
+                "System.Collections": "4.0.11",
+                "System.Diagnostics.Tools": "4.0.1",
+                "System.Reflection": "4.1.0",
+                "System.Runtime": "4.1.0"
             }
         }
     }

--- a/src/xunit.core/project.json
+++ b/src/xunit.core/project.json
@@ -29,6 +29,6 @@
         }
     },
     "dependencies": {
-        "xunit.abstractions": "2.0.1-rc2"
+        "xunit.abstractions": "99.99.99-dev"
     }
 }

--- a/src/xunit.extensibility.core.nuspec
+++ b/src/xunit.extensibility.core.nuspec
@@ -18,10 +18,10 @@
     <dependencies>
       <group targetFramework="netstandard1.0">
         <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="xunit.abstractions" version="2.0.1-rc2" />
+        <dependency id="xunit.abstractions" version="[99.99.99-dev]" />
       </group>
       <group targetFramework="portable-net45+win8+wp8+wpa81">
-        <dependency id="xunit.abstractions" version="2.0.1-rc2" />
+        <dependency id="xunit.abstractions" version="[99.99.99-dev]" />
       </group>
     </dependencies>
   </metadata>

--- a/src/xunit.runner.utility.nuspec
+++ b/src/xunit.runner.utility.nuspec
@@ -15,13 +15,13 @@
     <dependencies>
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="xunit.abstractions" version="2.0.1-rc2" />
+        <dependency id="xunit.abstractions" version="[99.99.99-dev]" />
       </group>
       <group targetFramework="portable-net45+win8+wpa81">
-        <dependency id="xunit.abstractions" version="2.0.1-rc2" />
+        <dependency id="xunit.abstractions" version="[99.99.99-dev]" />
       </group>
       <group targetFramework="net35">
-        <dependency id="xunit.abstractions" version="2.0.1-rc2" />
+        <dependency id="xunit.abstractions" version="[99.99.99-dev]" />
       </group>
     </dependencies>
   </metadata>

--- a/src/xunit.runner.utility/project.json
+++ b/src/xunit.runner.utility/project.json
@@ -61,6 +61,6 @@
         }
     },
     "dependencies": {
-        "xunit.abstractions": "2.0.1-rc2"
+        "xunit.abstractions": "99.99.99-dev"
     }
 }


### PR DESCRIPTION
Though not sure if the buildsystem applies a proper version to xunit.abstractions. Please let me know if I need to modify some more lines to get rid of RC2 packages. This pull request should resolve https://github.com/xunit/xunit/issues/920.