### PR TITLE
Provide source information for referenced assemblies, fixing test categorisation

### DIFF
--- a/src/xunit.runner.utility/Utility/DiaSession.cs
+++ b/src/xunit.runner.utility/Utility/DiaSession.cs
@@ -13,7 +13,7 @@ namespace Xunit
         static readonly Type typeDiaSession;
         static readonly Type typeDiaNavigationData;
 
-        readonly string assemblyFileName;
+        public readonly string AssemblyFileName;
         bool sessionHasErrors;
         IDisposable wrappedSession;
 
@@ -32,7 +32,7 @@ namespace Xunit
 
         public DiaSession(string assemblyFileName)
         {
-            this.assemblyFileName = assemblyFileName;
+            this.AssemblyFileName = assemblyFileName;
             sessionHasErrors |= (typeDiaSession == null || Environment.GetEnvironmentVariable("XUNIT_SKIP_DIA") != null);
         }
 
@@ -42,13 +42,13 @@ namespace Xunit
                 wrappedSession.Dispose();
         }
 
-        public DiaNavigationData GetNavigationData(string typeName, string methodName)
+        public DiaNavigationData GetNavigationData(string typeName, string methodName, string owningAssemblyFilename)
         {
             if (!sessionHasErrors)
                 try
                 {
                     if (wrappedSession == null)
-                        wrappedSession = (IDisposable)Activator.CreateInstance(typeDiaSession, assemblyFileName);
+                        wrappedSession = (IDisposable)Activator.CreateInstance(typeDiaSession, owningAssemblyFilename);
 
                     var data = methodGetNavigationData.Invoke(wrappedSession, new[] { typeName, methodName });
                     if (data == null)

--- a/src/xunit.runner.utility/Utility/DiaSessionWrapper.cs
+++ b/src/xunit.runner.utility/Utility/DiaSessionWrapper.cs
@@ -24,8 +24,9 @@ namespace Xunit
 
         public DiaNavigationData GetNavigationData(string typeName, string methodName)
         {
-            helper.Normalize(ref typeName, ref methodName);
-            return session.GetNavigationData(typeName, methodName);
+            var owningAssemblyFilename = session.AssemblyFileName;
+            helper.Normalize(ref typeName, ref methodName, ref owningAssemblyFilename);
+            return session.GetNavigationData(typeName, methodName, owningAssemblyFilename);
         }
 
         public void Dispose()

--- a/src/xunit.runner.utility/Utility/DiaSessionWrapperHelper.cs
+++ b/src/xunit.runner.utility/Utility/DiaSessionWrapperHelper.cs
@@ -148,7 +148,7 @@ namespace Xunit
             return Expression.Lambda<Func<MethodInfo, Type>>(conditional, methodParam).Compile();
         }
 
-        public void Normalize(ref string typeName, ref string methodName)
+        public void Normalize(ref string typeName, ref string methodName, ref string assemblyPath)
         {
             try
             {
@@ -163,6 +163,7 @@ namespace Xunit
                     {
                         // DiaSession only ever wants you to ask for the declaring type
                         typeName = method.DeclaringType.FullName;
+                        assemblyPath = method.DeclaringType.Assembly.Location;
 
                         // See if this is an async method by looking for [AsyncStateMachine] on the method,
                         // which means we need to pass the state machine's "MoveNext" method.


### PR DESCRIPTION
In the Visual Studio runner, test source information is provided using `VisualStudioSourceInformationProvider`. VS uses this information to group tests by project, to jump to the source of tests and to run tests from a context menu. However, the provider is returning null for inherited test cases in referenced projects. These tests show up as category External" and IDE features don't work for them. The problem can be seen in the following solution:
https://github.com/gulbanana/xunit-repro

This PR updates the DiaSession wrapper to inspect the assembly associated with individual test class types instead of assuming all test cases are in the same assembly. It shouldn't have performance implications as it will only produce one extra session wrapper per assembly that contains discovered tests.

It wasn't possible to write unit tests for this change, here's a companion PR with integration testing: [#6](https://github.com/xunit/xunit.integration/pull/6).