### PR TITLE
Added lock around TestOutputHelper getter.

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/TestOutputHelper.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestOutputHelper.cs
@@ -22,8 +22,12 @@ namespace Xunit.Sdk
         {
             get
             {
-                GuardInitialized();
-                return buffer.ToString();
+                lock (lockObject)
+                {
+                    GuardInitialized();
+
+                    return buffer.ToString();
+                }
             }
         }
 


### PR DESCRIPTION
Tests with async logging can cause a IndexOutOfBoundsException because the TestOutputHelper.Output getter does not lock the internal StringBuilder. This commit locks the getter with the pre-existing lockObject.