### PR TITLE
Performance tweaks for test discovery

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscoverer.cs
@@ -19,6 +19,7 @@ namespace Xunit.Sdk
         public static readonly string DisplayName = string.Format(CultureInfo.InvariantCulture, "xUnit.net {0}", new object[] { typeof(XunitTestFrameworkDiscoverer).GetTypeInfo().Assembly.GetName().Version });
 
         readonly Dictionary<Type, IXunitTestCaseDiscoverer> discovererCache = new Dictionary<Type, IXunitTestCaseDiscoverer>();
+        readonly Dictionary<Type, Type> discovererTypeCache = new Dictionary<Type, Type>(); // key is a Type that is or derives from FactAttribute
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XunitTestFrameworkDiscoverer"/> class.
@@ -79,12 +80,22 @@ namespace Xunit.Sdk
             if (factAttribute == null)
                 return true;
 
-            var testCaseDiscovererAttribute = factAttribute.GetCustomAttributes(typeof(XunitTestCaseDiscovererAttribute)).FirstOrDefault();
-            if (testCaseDiscovererAttribute == null)
-                return true;
+            var factAttributeType = (factAttribute as IReflectionAttributeInfo)?.Attribute.GetType();
 
-            var args = testCaseDiscovererAttribute.GetConstructorArguments().Cast<string>().ToList();
-            var discovererType = SerializationHelper.GetType(args[1], args[0]);
+            Type discovererType = null;
+            if (factAttributeType == null || !discovererTypeCache.TryGetValue(factAttributeType, out discovererType))
+            {
+                var testCaseDiscovererAttribute = factAttribute.GetCustomAttributes(typeof(XunitTestCaseDiscovererAttribute)).FirstOrDefault();
+                if (testCaseDiscovererAttribute != null)
+                {
+                    var args = testCaseDiscovererAttribute.GetConstructorArguments().Cast<string>().ToList();
+                    discovererType = SerializationHelper.GetType(args[1], args[0]);
+                }
+
+                if (factAttributeType != null)
+                    discovererTypeCache[factAttributeType] = discovererType;
+
+            }
             if (discovererType == null)
                 return true;
 

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
@@ -59,7 +59,7 @@ namespace Xunit.Sdk
         /// <inheritdoc/>
         public IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName)
         {
-            var attributeType = SerializationHelper.GetType(assemblyQualifiedAttributeTypeName);
+            var attributeType = ReflectionAttributeNameCache.GetType(assemblyQualifiedAttributeTypeName);
             Guard.ArgumentValid("assemblyQualifiedAttributeTypeName", "Could not locate type name", attributeType != null);
 
             return Assembly.CustomAttributes

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -12,6 +13,7 @@ namespace Xunit.Sdk
     public class ReflectionAttributeInfo : LongLivedMarshalByRefObject, IReflectionAttributeInfo
     {
         static readonly AttributeUsageAttribute DefaultAttributeUsageAttribute = new AttributeUsageAttribute(AttributeTargets.All);
+        static readonly ConcurrentDictionary<Type, AttributeUsageAttribute> attributeUsageCache = new ConcurrentDictionary<Type, AttributeUsageAttribute>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReflectionAttributeInfo"/> class.
@@ -52,8 +54,9 @@ namespace Xunit.Sdk
 
         internal static AttributeUsageAttribute GetAttributeUsage(Type attributeType)
         {
-            return (AttributeUsageAttribute)attributeType.GetTypeInfo().GetCustomAttributes(typeof(AttributeUsageAttribute), true).FirstOrDefault()
-                ?? DefaultAttributeUsageAttribute;
+            return attributeUsageCache.GetOrAdd(attributeType,
+                at => (AttributeUsageAttribute)at.GetTypeInfo().GetCustomAttributes(typeof(AttributeUsageAttribute), true).FirstOrDefault()
+                      ?? DefaultAttributeUsageAttribute);
         }
 
         /// <inheritdoc/>

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAttributeInfo.cs
@@ -70,7 +70,7 @@ namespace Xunit.Sdk
 
         internal static IEnumerable<IAttributeInfo> GetCustomAttributes(Type type, string assemblyQualifiedAttributeTypeName)
         {
-            Type attributeType = SerializationHelper.GetType(assemblyQualifiedAttributeTypeName);
+            Type attributeType = ReflectionAttributeNameCache.GetType(assemblyQualifiedAttributeTypeName);
 
             return GetCustomAttributes(type, attributeType, GetAttributeUsage(attributeType));
         }

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAttributeNameCache.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAttributeNameCache.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Xunit.Sdk
+{
+    class ReflectionAttributeNameCache
+    {
+        static ConcurrentDictionary<string, Type> attributeTypeCache = new ConcurrentDictionary<string, Type>();
+
+        internal static Type GetType(string assemblyQualifiedAttributeTypeName)
+        {
+            return attributeTypeCache.GetOrAdd(assemblyQualifiedAttributeTypeName, name => SerializationHelper.GetType(name));
+        }
+    }
+}

--- a/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
@@ -82,7 +82,7 @@ namespace Xunit.Sdk
 
         static IEnumerable<IAttributeInfo> GetCustomAttributes(MethodInfo method, string assemblyQualifiedAttributeTypeName)
         {
-            var attributeType = SerializationHelper.GetType(assemblyQualifiedAttributeTypeName);
+            var attributeType = ReflectionAttributeNameCache.GetType(assemblyQualifiedAttributeTypeName);
 
             return GetCustomAttributes(method, attributeType, ReflectionAttributeInfo.GetAttributeUsage(attributeType));
         }

--- a/src/xunit.runner.utility/Frameworks/TestFrameworkOptions.cs
+++ b/src/xunit.runner.utility/Frameworks/TestFrameworkOptions.cs
@@ -10,7 +10,10 @@ namespace Xunit
     /// Represents options passed to a test framework for discovery or execution.
     /// </summary>
     [DebuggerDisplay("{ToDebuggerDisplay(),nq}")]
-    public class TestFrameworkOptions : LongLivedMarshalByRefObject, ITestFrameworkDiscoveryOptions, ITestFrameworkExecutionOptions
+#if !PLATFORM_DOTNET
+    [System.Serializable]
+#endif
+    public class TestFrameworkOptions : ITestFrameworkDiscoveryOptions, ITestFrameworkExecutionOptions
     {
         readonly Dictionary<string, object> properties = new Dictionary<string, object>();
 


### PR DESCRIPTION
Using a profiler I found a number of inefficient reflection look-ups which could benefit from some caching.
In addition make `TestFrameworkOptions` serializable to avoid the cost of repeated value lookups across AppDomain boundaries.