### PR TITLE
Add support for optional parameters in a test method

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCaseRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestCaseRunner.cs
@@ -48,6 +48,7 @@ namespace Xunit.Sdk
             for (int i = 0; i < parameters.Length; i++)
                 parameterTypes[i] = parameters[i].ParameterType;
 
+            testMethodArguments = TypeUtility.ResolveMethodArguments(Reflector.Wrap(TestMethod), testMethodArguments);
             TestMethodArguments = Reflector.ConvertArguments(testMethodArguments, parameterTypes);
 
             IEnumerable<Attribute> beforeAfterTestCollectionAttributes;

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunner.cs
@@ -67,15 +67,17 @@ namespace Xunit.Sdk
 
                         ITypeInfo[] resolvedTypes = null;
                         var methodToRun = TestMethod;
+                        var convertedDataRow = TypeUtility.ResolveMethodArguments(Reflector.Wrap(methodToRun), dataRow);
 
                         if (methodToRun.IsGenericMethodDefinition)
                         {
-                            resolvedTypes = TestCase.TestMethod.Method.ResolveGenericTypes(dataRow);
+                            resolvedTypes = TestCase.TestMethod.Method.ResolveGenericTypes(convertedDataRow);
                             methodToRun = methodToRun.MakeGenericMethod(resolvedTypes.Select(t => ((IReflectionTypeInfo)t).Type).ToArray());
                         }
 
                         var parameterTypes = methodToRun.GetParameters().Select(p => p.ParameterType).ToArray();
-                        var convertedDataRow = Reflector.ConvertArguments(dataRow, parameterTypes);
+                        convertedDataRow = Reflector.ConvertArguments(convertedDataRow, parameterTypes);
+
                         var theoryDisplayName = TestCase.TestMethod.Method.GetDisplayNameWithArguments(DisplayName, convertedDataRow, resolvedTypes);
                         var test = new XunitTest(TestCase, theoryDisplayName);
                         var skipReason = SkipReason ?? dataAttribute.GetNamedArgument<string>("Skip");

--- a/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -13,6 +12,102 @@ public class Xunit2TheoryAcceptanceTests
 {
     public class TheoryTests : AcceptanceTestV2
     {
+        [Fact]
+        public void OptionalParameters_Valid()
+        {
+            var results = Run<ITestResultMessage>(typeof(ClassWithOptionalParameters));
+
+            Assert.Collection(results.Cast<ITestPassed>().OrderBy(r => r.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_OneNullParameter_NonePassed(s: null)", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_OneNullParameter_OneNonNullPassed(s: ""abc"")", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_OneNullParameter_OneNullPassed(s: null)", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_OneParameter_NonePassed(s: ""abc"")", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_OneParameter_OnePassed(s: ""def"")", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_TwoParameters_OnePassed(s: ""abc"", i: 5)", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.OneOptional_TwoParameters_TwoPassed(s: ""abc"", i: 6)", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.TwoOptional_TwoParameters_FirstOnePassed(s: ""def"", i: 5)", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.TwoOptional_TwoParameters_NonePassed(s: ""abc"", i: 5)", result.Test.DisplayName),
+                result => Assert.Equal(@"Xunit2TheoryAcceptanceTests+TheoryTests+ClassWithOptionalParameters.TwoOptional_TwoParameters_TwoPassedInOrder(s: ""def"", i: 6)", result.Test.DisplayName));
+        }
+
+        public class ClassWithOptionalParameters
+        {
+            [Theory]
+            [InlineData]
+            public void OneOptional_OneParameter_NonePassed(string s = "abc")
+            {
+                Assert.Equal("abc", s);
+            }
+
+            [Theory]
+            [InlineData("def")]
+            public void OneOptional_OneParameter_OnePassed(string s = "abc")
+            {
+                Assert.Equal("def", s);
+            }
+
+            [Theory]
+            [InlineData]
+            public void OneOptional_OneNullParameter_NonePassed(string s = null)
+            {
+                Assert.Null(s);
+            }
+
+            [Theory]
+            [InlineData("abc")]
+            public void OneOptional_OneNullParameter_OneNonNullPassed(string s = null)
+            {
+                Assert.Equal("abc", s);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            public void OneOptional_OneNullParameter_OneNullPassed(string s = null)
+            {
+                Assert.Null(s);
+            }
+
+            [Theory]
+            [InlineData("abc")]
+            public void OneOptional_TwoParameters_OnePassed(string s, int i = 5)
+            {
+                Assert.Equal("abc", s);
+                Assert.Equal(5, i);
+            }
+
+            [Theory]
+            [InlineData("abc", 6)]
+            public void OneOptional_TwoParameters_TwoPassed(string s, int i = 5)
+            {
+                Assert.Equal("abc", s);
+                Assert.Equal(6, i);
+            }
+
+            [Theory]
+            [InlineData()]
+            public void TwoOptional_TwoParameters_NonePassed(string s = "abc", int i = 5)
+            {
+                Assert.Equal("abc", s);
+                Assert.Equal(5, i);
+            }
+
+            [Theory]
+            [InlineData("def")]
+            public void TwoOptional_TwoParameters_FirstOnePassed(string s = "abc", int i = 5)
+            {
+                Assert.Equal("def", s);
+                Assert.Equal(5, i);
+            }
+
+            [Theory]
+            [InlineData("def", 6)]
+            public void TwoOptional_TwoParameters_TwoPassedInOrder(string s = "abc", int i = 5)
+            {
+                Assert.Equal("def", s);
+                Assert.Equal(6, i);
+            }
+        }
+
         [Fact]
         public void Skipped()
         {


### PR DESCRIPTION
I seem to remember seeing an issue in the repo requesting something like this but can't find it now!

Also: http://stackoverflow.com/questions/14818439/xunit-test-engines-inlinedataattribute-optional-method-parameters

/cc @bradwilson