### PR TITLE
Fix a test that relies on the TEMP environment variable ending in '/'

### DIFF
--- a/test/test.xunit.runner.msbuild/xunitTests.cs
+++ b/test/test.xunit.runner.msbuild/xunitTests.cs
@@ -20,7 +20,19 @@ public class xunitTests
 
             xunit.Execute();
 
-            Assert.Equal(tempFolder, Directory.GetCurrentDirectory());
+            string actual = Directory.GetCurrentDirectory();
+            string expected = tempFolder;
+
+            if (actual[actual.Length - 1] != Path.DirectorySeparatorChar)
+            {
+                actual += Path.DirectorySeparatorChar;
+            }
+            if (expected[expected.Length - 1] != Path.DirectorySeparatorChar)
+            {
+                expected += Path.DirectorySeparatorChar;
+            }
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes tests running on my laptop vs desktop

@bradwilson