### PR TITLE
Fix NullReferenceException if IDataDiscoverer.GetData returns null

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunner.cs
@@ -61,7 +61,13 @@ namespace Xunit.Sdk
                     var discovererType = SerializationHelper.GetType(args[1], args[0]);
                     var discoverer = ExtensibilityPointFactory.GetDataDiscoverer(diagnosticMessageSink, discovererType);
 
-                    foreach (var dataRow in discoverer.GetData(dataAttribute, TestCase.TestMethod.Method))
+                    IEnumerable<object[]> data = discoverer.GetData(dataAttribute, TestCase.TestMethod.Method);
+                    if (data == null)
+                    {
+                        Aggregator.Add(new InvalidOperationException($"Test data returned null for {TestCase.TestMethod.TestClass.Class.Name}.{TestCase.TestMethod.Method.Name}. Make sure it is statically initialized before this test method is called."));
+                        continue;
+                    }
+                    foreach (var dataRow in data)
                     {
                         toDispose.AddRange(dataRow.OfType<IDisposable>());
 

--- a/test/test.xunit.execution/Sdk/Frameworks/TheoryDiscovererTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/TheoryDiscovererTests.cs
@@ -28,6 +28,33 @@ public class TheoryDiscovererTests : AcceptanceTestV2
     }
 
     [Fact]
+    public void NullMemberData_ThrowsInvalidOperationException()
+    {
+        var results = Run<ITestFailed>(typeof(NullDataClass));
+
+        var failure = Assert.Single(results);
+        Assert.Equal("System.InvalidOperationException", failure.ExceptionTypes.Single());
+        Assert.Equal("Test data returned null for TheoryDiscovererTests+NullDataClass.NullMemberData. Make sure it is statically initialized before this test method is called.", failure.Messages.Single());
+    }
+
+    public class NullDataClass
+    {
+        public static IEnumerable<object[]> InitializedInConstructor;
+
+        public NullDataClass()
+        {
+            InitializedInConstructor = new List<object[]>
+            {
+                new object[] { "1", "2"}
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(InitializedInConstructor))]
+        public void NullMemberData(string str1, string str2) { }
+    }
+
+    [Fact]
     public void EmptyTheoryData()
     {
         var failures = Run<ITestFailed>(typeof(EmptyTheoryDataClass));


### PR DESCRIPTION
Fixes #928

/cc @bradwilson
@yahor-stalnik FYI
