### PR TITLE
Make TypeUtility.ResolveMethodArguments use MethodBase instead of MethodInfo

### DIFF
--- a/src/xunit.execution/Sdk/TypeUtility.cs
+++ b/src/xunit.execution/Sdk/TypeUtility.cs
@@ -43,7 +43,7 @@ namespace Xunit.Sdk
         /// <param name="testMethod">The test method to resolve.</param>
         /// <param name="arguments">The user-supplied method arguments.</param>
         /// <returns>The argument values</returns>
-        public static object[] ResolveMethodArguments(this MethodInfo testMethod, object[] arguments)
+        public static object[] ResolveMethodArguments(this MethodBase testMethod, object[] arguments)
         {
             ParameterInfo[] parameters = testMethod.GetParameters();
             bool hasParamsParameter = false;


### PR DESCRIPTION
This is necessary to avoid a breaking change in the future when we release.

This is becasue I'm working on resolving arguments for ConstructorInfos