### PR TITLE
Add support for optional, default and params parameters in test fixtures

### DIFF
--- a/src/xunit.execution/Sdk/TypeUtility.cs
+++ b/src/xunit.execution/Sdk/TypeUtility.cs
@@ -386,5 +386,15 @@ namespace Xunit.Sdk
 
             return resolvedTypes;
         }
+
+        internal static object GetDefaultValue(this TypeInfo typeInfo)
+        {
+            if (typeInfo.IsValueType)
+            {
+                return Activator.CreateInstance(typeInfo.AsType());
+            }
+
+            return null;
+        }
     }
 }

--- a/test/test.xunit.execution/Acceptance/FixtureAcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/FixtureAcceptanceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -145,6 +146,70 @@ public class FixtureAcceptanceTests
             public FixtureSpy(EmptyFixtureData data)
             {
                 Assert.NotNull(data);
+            }
+
+            [Fact]
+            public void TheTest() { }
+        }
+
+        [Fact]
+        public void TestClassWithDefaultParameter()
+        {
+            var messages = Run<ITestPassed>(typeof(ClassWithDefaultCtorArg));
+
+            var msg = Assert.Single(messages);
+            Assert.Equal("FixtureAcceptanceTests+ClassFixture+ClassWithDefaultCtorArg.TheTest", msg.Test.DisplayName);
+        }
+
+        class ClassWithDefaultCtorArg : IClassFixture<EmptyFixtureData>
+        {
+            public ClassWithDefaultCtorArg(EmptyFixtureData fixture, int x = 0)
+            {
+                Assert.NotNull(fixture);
+                Assert.Equal(0, x);
+            }
+
+            [Fact]
+            public void TheTest() { }
+        }
+
+        [Fact]
+        public void TestClassWithOptionalParameter()
+        {
+            var messages = Run<ITestPassed>(typeof(ClassWithOptionalCtorArg));
+
+            var msg = Assert.Single(messages);
+            Assert.Equal("FixtureAcceptanceTests+ClassFixture+ClassWithOptionalCtorArg.TheTest", msg.Test.DisplayName);
+        }
+
+        class ClassWithOptionalCtorArg : IClassFixture<EmptyFixtureData>
+        {
+            public ClassWithOptionalCtorArg(EmptyFixtureData fixture, [Optional]int x, [Optional]object y)
+            {
+                Assert.NotNull(fixture);
+                Assert.Equal(0, x);
+                Assert.Null(y);
+            }
+
+            [Fact]
+            public void TheTest() { }
+        }
+
+        [Fact]
+        public void TestClassWithParamsParameter()
+        {
+            var messages = Run<ITestPassed>(typeof(ClassWithParamsArg));
+
+            var msg = Assert.Single(messages);
+            Assert.Equal("FixtureAcceptanceTests+ClassFixture+ClassWithParamsArg.TheTest", msg.Test.DisplayName);
+        }
+
+        class ClassWithParamsArg : IClassFixture<EmptyFixtureData>
+        {
+            public ClassWithParamsArg(EmptyFixtureData fixture, params object[] x)
+            {
+                Assert.NotNull(fixture);
+                Assert.Empty(x);
             }
 
             [Fact]


### PR DESCRIPTION
Fixes #985

TypeUtility.GetDefaultValue(this TypeInfo typeInfo) will be used elsewhere in a subsequent PR

