### PR TITLE
Fix incorrect JSON encoding

### DIFF
--- a/src/xunit.runner.reporters/JsonExtentions.cs
+++ b/src/xunit.runner.reporters/JsonExtentions.cs
@@ -41,7 +41,7 @@ namespace Xunit.Runner.Reporters
                 switch (c)
                 {
                     case '\\': sb.Append("\\\\"); break;
-                    case '"': sb.Append(@"\\"""); break;
+                    case '"': sb.Append(@"\"""); break;
                     case '\t': sb.Append("\\t"); break;
                     case '\r': sb.Append("\\r"); break;
                     case '\n': sb.Append("\\n"); break;

--- a/test/test.xunit.runner.reporters/JsonExtensionsTests.cs
+++ b/test/test.xunit.runner.reporters/JsonExtensionsTests.cs
@@ -36,6 +36,6 @@ public class JsonExtensionsTests
 
         var result = JsonExtentions.ToJson(data);
 
-        Assert.Equal(@"{""foo"":""\u0000 \u001F \t \r \n \\ \\""Hello!\\""""}", result);
+        Assert.Equal(@"{""foo"":""\u0000 \u001F \t \r \n \\ \""Hello!\""""}", result);
     }
 }

--- a/test/test.xunit.runner.reporters/JsonExtensionsTests.cs
+++ b/test/test.xunit.runner.reporters/JsonExtensionsTests.cs
@@ -18,11 +18,12 @@ public class JsonExtensionsTests
             { "decimal", 21.12M },
             { "boolean", true },
             { "guid", Guid.Empty },
+            { "stringWithQuote", "\"bar\"" },
         };
 
         var result = JsonExtentions.ToJson(data);
 
-        Assert.Equal(@"{""string"":""bar"",""int32"":42,""int64"":42,""single"":21.12,""double"":21.12,""decimal"":21.12,""boolean"":true,""guid"":""00000000-0000-0000-0000-000000000000""}", result);
+        Assert.Equal(@"{""string"":""bar"",""int32"":42,""int64"":42,""single"":21.12,""double"":21.12,""decimal"":21.12,""boolean"":true,""guid"":""00000000-0000-0000-0000-000000000000"",""stringWithQuote"":""\""bar\""""}", result);
     }
 
     [Fact]


### PR DESCRIPTION
Fix incorrect escaping of quotes for encoding strings as JSON due to one too many slashes being added.

Resolves #1116.