### PR TITLE
Fix Processor Architecture in Path of Build.ps1

### DIFF
--- a/xunit.msbuild
+++ b/xunit.msbuild
@@ -78,7 +78,7 @@
     <RegexReplace
         Pattern="type=&quot;Xunit.ConsoleClient.XunitConsoleConfigurationSection, xunit.console&quot;"
         Replacement="type=&quot;Xunit.ConsoleClient.XunitConsoleConfigurationSection, xunit.console.x86&quot;"
-        Files="src\xunit.console\bin\$(Configuration)_x86\net452\win7-x64\xunit.console.x86.exe.config" />
+        Files="src\xunit.console\bin\$(Configuration)_x86\net452\win7-x86\xunit.console.x86.exe.config" />
   </Target>
 
   <Target Name="_Test32" DependsOnTargets="Build">


### PR DESCRIPTION
I just pulled the latest and a clean build via **Build.ps1** fails because the path in the **RegexReplace** task is incorrect. Since the build configuration uses **x86**, the path should reflect that rather than **x64**.

Instead of submitting a new issue, I figured it would be easier and faster to just submit a PR. The CLA is already signed.