### PR TITLE
Fix typos in constructor summary for TheoryData

### DIFF
--- a/src/xunit.core/TheoryData.cs
+++ b/src/xunit.core/TheoryData.cs
@@ -90,7 +90,7 @@ namespace Xunit
     }
 
     /// <summary>
-    /// Represents a set of data for a theory with 3 parameters. Data can
+    /// Represents a set of data for a theory with 4 parameters. Data can
     /// be added to the data set using the collection initializer syntax.
     /// </summary>
     /// <typeparam name="T1">The first parameter type.</typeparam>
@@ -113,7 +113,7 @@ namespace Xunit
     }
 
     /// <summary>
-    /// Represents a set of data for a theory with 3 parameters. Data can
+    /// Represents a set of data for a theory with 5 parameters. Data can
     /// be added to the data set using the collection initializer syntax.
     /// </summary>
     /// <typeparam name="T1">The first parameter type.</typeparam>


### PR DESCRIPTION
As mentioned in #1173, there are two typos in the `TheoryData` docs with 4 and 5 types.

Fixes #1173 
