### PR TITLE
Initial support for netstandard1.5 in xunit.runner.msbuild

### DIFF
--- a/src/common/AssemblyExtensions.cs
+++ b/src/common/AssemblyExtensions.cs
@@ -1,4 +1,4 @@
-#if NET35 || NET40 || NET452
+#if NET35 || NET40 || NET452 || NETSTANDARD1_5
 
 using System;
 using System.IO;

--- a/src/xunit.runner.msbuild/Utility/CrossPlatform.cs
+++ b/src/xunit.runner.msbuild/Utility/CrossPlatform.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace Xunit.Runner.MSBuild.Xslt
+{
+    public class CrossPlatform
+    {
+#if NET452
+        public static void Transform(string resourceName, XNode xml, ITaskItem outputFile)
+        {
+            var xmlTransform = new System.Xml.Xsl.XslCompiledTransform();
+
+            using (var writer = XmlWriter.Create(outputFile.GetMetadata("FullPath"), new XmlWriterSettings { Indent = true }))
+            using (var xsltReader = XmlReader.Create(typeof(xunit).Assembly.GetManifestResourceStream("xunit.runner.msbuild." + resourceName)))
+            using (var xmlReader = xml.CreateReader())
+            {
+                xmlTransform.Load(xsltReader);
+                xmlTransform.Transform(xmlReader, writer);
+            }
+        }
+
+        public static Assembly LoadAssembly(string dllFile)
+        {
+            return Assembly.LoadFile(dllFile);
+        }
+
+        public static string Version => Environment.Version.ToString();
+#endif
+
+#if NETSTANDARD1_5
+        public static void Transform(string resourceName, XNode xml, ITaskItem outputFile)
+        {
+            throw new Exception("Only xunit v2 is supported output type");
+        }
+
+        public static Assembly LoadAssembly(string dllFile)
+        {
+            return System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(dllFile);
+        }
+        public static string Version => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+#endif
+    }
+}

--- a/src/xunit.runner.msbuild/xunit.cs
+++ b/src/xunit.runner.msbuild/xunit.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
-using System.Xml.Xsl;
 using Microsoft.Build.Framework;
+using Xunit.Runner.MSBuild.Xslt;
 using MSBuildTask = Microsoft.Build.Utilities.Task;
 
 namespace Xunit.Runner.MSBuild
@@ -110,7 +110,7 @@ namespace Xunit.Runner.MSBuild
             RemotingUtility.CleanUpRegisteredChannels();
 
             XElement assembliesElement = null;
-            var environment = $"{IntPtr.Size * 8}-bit .NET {Environment.Version}";
+            var environment = $"{IntPtr.Size * 8}-bit .NET {CrossPlatform.Version}";
 
             if (NeedsXml)
                 assembliesElement = new XElement("assemblies");
@@ -205,16 +205,16 @@ namespace Xunit.Runner.MSBuild
             if (NeedsXml)
             {
                 if (Xml != null)
-                    assembliesElement.Save(Xml.GetMetadata("FullPath"));
+                    assembliesElement.Save(new FileStream(Xml.GetMetadata("FullPath"), FileMode.OpenOrCreate));
 
                 if (XmlV1 != null)
-                    Transform("xUnit1.xslt", assembliesElement, XmlV1);
+                    CrossPlatform.Transform("xUnit1.xslt", assembliesElement, XmlV1);
 
                 if (Html != null)
-                    Transform("HTML.xslt", assembliesElement, Html);
+                    CrossPlatform.Transform("HTML.xslt", assembliesElement, Html);
 
                 if (NUnit != null)
-                    Transform("NUnitXml.xslt", assembliesElement, NUnit);
+                    CrossPlatform.Transform("NUnitXml.xslt", assembliesElement, NUnit);
             }
 
             // ExitCode is set to 1 for test failures and -1 for Exceptions.
@@ -236,7 +236,7 @@ namespace Xunit.Runner.MSBuild
                 assembly.Configuration.InternalDiagnosticMessages |= InternalDiagnosticMessages;
 
                 if (appDomains.HasValue)
-                    assembly.Configuration.AppDomain = appDomains.GetValueOrDefault() ? AppDomainSupport.Required : AppDomainSupport.Denied;
+                    assembly.Configuration.AppDomain = appDomains.GetValueOrDefault() ? AppDomainSupport.IfAvailable : AppDomainSupport.Denied;
 
                 // Setup discovery and execution options with command-line overrides
                 var discoveryOptions = TestFrameworkOptions.ForDiscovery(assembly.Configuration);
@@ -318,7 +318,7 @@ namespace Xunit.Runner.MSBuild
         protected virtual List<IRunnerReporter> GetAvailableRunnerReporters()
         {
             var result = new List<IRunnerReporter>();
-            var runnerPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetLocalCodeBase());
+            var runnerPath = Path.GetDirectoryName(Assembly.GetEntryAssembly().GetLocalCodeBase());
 
             foreach (var dllFile in Directory.GetFiles(runnerPath, "*.dll").Select(f => Path.Combine(runnerPath, f)))
             {
@@ -326,7 +326,7 @@ namespace Xunit.Runner.MSBuild
 
                 try
                 {
-                    var assembly = Assembly.LoadFile(dllFile);
+                    var assembly = CrossPlatform.LoadAssembly(dllFile);
                     types = assembly.GetTypes();
                 }
                 catch (ReflectionTypeLoadException ex)
@@ -341,7 +341,7 @@ namespace Xunit.Runner.MSBuild
                 foreach (var type in types)
                 {
 #pragma warning disable CS0618
-                    if (type == null || type.IsAbstract || type == typeof(DefaultRunnerReporter) || type == typeof(DefaultRunnerReporterWithTypes) || !type.GetInterfaces().Any(t => t == typeof(IRunnerReporter)))
+                    if (type == null || type.GetTypeInfo().IsAbstract || type == typeof(DefaultRunnerReporter) || type == typeof(DefaultRunnerReporterWithTypes) || !type.GetInterfaces().Any(t => t == typeof(IRunnerReporter)))
                         continue;
 #pragma warning restore CS0618
 
@@ -382,19 +382,6 @@ namespace Xunit.Runner.MSBuild
             }
 
             return reporter ?? new DefaultRunnerReporterWithTypes();
-        }
-
-        static void Transform(string resourceName, XNode xml, ITaskItem outputFile)
-        {
-            var xmlTransform = new XslCompiledTransform();
-
-            using (var writer = XmlWriter.Create(outputFile.GetMetadata("FullPath"), new XmlWriterSettings { Indent = true }))
-            using (var xsltReader = XmlReader.Create(typeof(xunit).Assembly.GetManifestResourceStream("xunit.runner.msbuild." + resourceName)))
-            using (var xmlReader = xml.CreateReader())
-            {
-                xmlTransform.Load(xsltReader);
-                xmlTransform.Transform(xmlReader, writer);
-            }
         }
     }
 }

--- a/src/xunit.runner.msbuild/xunit.runner.msbuild.csproj
+++ b/src/xunit.runner.msbuild/xunit.runner.msbuild.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\common\AssemblyExtensions.cs" />
@@ -10,7 +10,7 @@
     <Compile Include="..\common\Guard.cs" />
     <EmbeddedResource Include="..\xunit.console\*.xslt" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />
@@ -18,6 +18,13 @@
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\xunit.runner.reporters\xunit.runner.reporters.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The msbuild runner of xUnit should support netstandard1.5.

Consider this a starting point and a RFC. It compiles, but that's about it. 