### PR TITLE
Add ability to disable TeamCity reporter with env variable

### DIFF
--- a/src/xunit.runner.reporters/TeamCityReporter.cs
+++ b/src/xunit.runner.reporters/TeamCityReporter.cs
@@ -8,7 +8,8 @@ namespace Xunit.Runner.Reporters
             => "forces TeamCity mode (normally auto-detected)";
 
         public bool IsEnvironmentallyEnabled
-            => !string.IsNullOrWhiteSpace(EnvironmentHelper.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME"));
+            => !string.IsNullOrWhiteSpace(EnvironmentHelper.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME"))
+               && EnvironmentHelper.GetEnvironmentVariable("DISABLE_TEAMCITY_XUNIT_REPORTER") != "true";
 
         public string RunnerSwitch
             => "teamcity";


### PR DESCRIPTION
I use the TRX reporter on TeamCity and want the ability to suppress the default TC reporter. AFAIK there currently is no way do this with dotnet-test.

Unsetting TEAMCITY_PROJECT_NAME is not a good option since that's required for other build settings. Instead, this adds a check for the environment variable DISABLE_TEAMCITY_XUNIT_REPORTER when determining if TeamCityReporter should be used.

**Btw**, if there is a way to do this already with dotnet-test, please let me know.