### PR TITLE
Add extensibility points

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/FactDiscoverer.cs
+++ b/src/xunit.execution/Sdk/Frameworks/FactDiscoverer.cs
@@ -10,16 +10,19 @@ namespace Xunit.Sdk
     /// </summary>
     public class FactDiscoverer : IXunitTestCaseDiscoverer
     {
-        readonly IMessageSink diagnosticMessageSink;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FactDiscoverer"/> class.
         /// </summary>
         /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
         public FactDiscoverer(IMessageSink diagnosticMessageSink)
         {
-            this.diagnosticMessageSink = diagnosticMessageSink;
+            DiagnosticMessageSink = diagnosticMessageSink;
         }
+
+        /// <summary>
+        /// Gets the message sink used to report <see cref="IDiagnosticMessage"/> messages.
+        /// </summary>
+        protected IMessageSink DiagnosticMessageSink { get; }
 
         /// <summary>
         /// Creates a single <see cref="XunitTestCase"/> for the given test method.
@@ -29,7 +32,7 @@ namespace Xunit.Sdk
         /// <param name="factAttribute">The attribute that decorates the test method.</param>
         /// <returns></returns>
         protected virtual IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
-            => new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
 
         /// <summary>
         /// Discover test cases from a test method. By default, if the method is generic, or
@@ -45,9 +48,9 @@ namespace Xunit.Sdk
             IXunitTestCase testCase;
 
             if (testMethod.Method.GetParameters().Any())
-                testCase = new ExecutionErrorTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[Fact] methods are not allowed to have parameters. Did you mean to use [Theory]?");
+                testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[Fact] methods are not allowed to have parameters. Did you mean to use [Theory]?");
             else if (testMethod.Method.IsGenericMethodDefinition)
-                testCase = new ExecutionErrorTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[Fact] methods are not allowed to be generic.");
+                testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[Fact] methods are not allowed to be generic.");
             else
                 testCase = CreateTestCase(discoveryOptions, testMethod, factAttribute);
 

--- a/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/XunitTestCase.cs
@@ -16,8 +16,6 @@ namespace Xunit.Sdk
     [DebuggerDisplay(@"\{ class = {TestMethod.TestClass.Class.Name}, method = {TestMethod.Method.Name}, display = {DisplayName}, skip = {SkipReason} \}")]
     public class XunitTestCase : TestMethodTestCase, IXunitTestCase
     {
-        readonly IMessageSink diagnosticMessageSink;
-
         /// <summary/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
@@ -25,7 +23,7 @@ namespace Xunit.Sdk
         {
             // No way for us to get access to the message sink on the execution deserialization path, but that should
             // be okay, because we assume all the issues were reported during discovery.
-            diagnosticMessageSink = new NullMessageSink();
+            DiagnosticMessageSink = new NullMessageSink();
         }
 
         /// <summary>
@@ -41,8 +39,13 @@ namespace Xunit.Sdk
                              object[] testMethodArguments = null)
             : base(defaultMethodDisplay, testMethod, testMethodArguments)
         {
-            this.diagnosticMessageSink = diagnosticMessageSink;
+            DiagnosticMessageSink = diagnosticMessageSink;
         }
+
+        /// <summary>
+        /// Gets the message sink used to report <see cref="IDiagnosticMessage"/> messages.
+        /// </summary>
+        protected IMessageSink DiagnosticMessageSink { get; }
 
         /// <summary>
         /// Gets the display name for the test case. Calls <see cref="TypeUtility.GetDisplayNameWithArguments"/>
@@ -80,13 +83,13 @@ namespace Xunit.Sdk
                 var discovererAttribute = traitAttribute.GetCustomAttributes(typeof(TraitDiscovererAttribute)).FirstOrDefault();
                 if (discovererAttribute != null)
                 {
-                    var discoverer = ExtensibilityPointFactory.GetTraitDiscoverer(diagnosticMessageSink, discovererAttribute);
+                    var discoverer = ExtensibilityPointFactory.GetTraitDiscoverer(DiagnosticMessageSink, discovererAttribute);
                     if (discoverer != null)
                         foreach (var keyValuePair in discoverer.GetTraits(traitAttribute))
                             Traits.Add(keyValuePair.Key, keyValuePair.Value);
                 }
                 else
-                    diagnosticMessageSink.OnMessage(new DiagnosticMessage($"Trait attribute on '{DisplayName}' did not have [TraitDiscoverer]"));
+                    DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Trait attribute on '{DisplayName}' did not have [TraitDiscoverer]"));
             }
         }
 


### PR DESCRIPTION
This pull request is a non-functional change to Xunit. It aims to provide fine-grained access to test case creation, test discovery and test runners so that when writing 3rd party libraries, sub-classing can be used to provide additional control over the test execution process.