### PR TITLE
dotnet-xunit: add -usemsbuild flag 

### DIFF
--- a/src/dotnet-xunit/MsBuild.cs
+++ b/src/dotnet-xunit/MsBuild.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.InteropServices;
+
+internal static class MsBuild
+{
+    public static string MsBuildName { get; }
+
+    static MsBuild()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            MsBuildName = "MSBuild.exe";
+        else
+            MsBuildName = "msbuild";
+    }
+}


### PR DESCRIPTION
`dotnet xunit` needs to run an msbuild build in order to discover project information. Right now this uses `dotnet msbuild`, which can't build all project types. With this PR, a flag can be used by people with a full-framework msbuild on their `%PATH%` to support, for example, using dotnet xunit to test a UWP class library.