### PR TITLE
2 Modifications to GetUniqueID

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/TestMethodTestCase.cs
+++ b/src/xunit.execution/Sdk/Frameworks/TestMethodTestCase.cs
@@ -182,12 +182,24 @@ namespace Xunit.Sdk
         {
             using (var stream = new MemoryStream())
             {
-                Write(stream, TestMethod.TestClass.TestCollection.TestAssembly.Assembly.Name);
+                var assemblyName = TestMethod.TestClass.TestCollection.TestAssembly.Assembly.Name;
+
+                //Get just the assembly name (without version info) when obtained by reflection
+                IReflectionAssemblyInfo assembly = TestMethod.TestClass.TestCollection.TestAssembly.Assembly as IReflectionAssemblyInfo;
+                if (assembly != null)
+                    assemblyName = assembly.Assembly.GetName().Name;
+
+                Write(stream, assemblyName);
                 Write(stream, TestMethod.TestClass.Class.Name);
                 Write(stream, TestMethod.Method.Name);
 
                 if (TestMethodArguments != null)
                     Write(stream, SerializationHelper.Serialize(TestMethodArguments));
+
+                var genericTypes = MethodGenericTypes;
+                if (genericTypes != null)
+                    for (var idx = 0; idx < genericTypes.Length; idx++)
+                        Write(stream, TypeUtility.ConvertToSimpleTypeName(genericTypes[idx]));
 
                 stream.Position = 0;
 

--- a/src/xunit.execution/Sdk/TypeUtility.cs
+++ b/src/xunit.execution/Sdk/TypeUtility.cs
@@ -12,7 +12,12 @@ namespace Xunit.Sdk
     {
         readonly static ITypeInfo ObjectTypeInfo = Reflector.Wrap(typeof(object));
 
-        static string ConvertToSimpleTypeName(ITypeInfo type)
+        /// <summary>
+        /// Converts a type into a name string.
+        /// </summary>
+        /// <param name="type">The type to convert.</param>
+        /// <returns>Name string of type.</returns>
+        public static string ConvertToSimpleTypeName(ITypeInfo type)
         {
             var baseTypeName = type.Name;
 


### PR DESCRIPTION
1) Adding MethodGenericTypes to the hash, to ensure that distinct UniqueIDs are generated for generic method tests that only differ by a type parameter.
2) Using an assembly name string that does not include version info, to make these UniqueIDs consistent across assembly version bumps.  This makes the UniqueID more useful for correlating results for the same test over time.