### PR TITLE
Add NuGet package for xunit.console

### DIFF
--- a/src/xunit.console.nuspec
+++ b/src/xunit.console.nuspec
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>xunit.console</id>
+    <version>99.99.99-dev</version>
+    <title>xUnit.net [Console runner implementation]</title>
+    <authors>James Newkirk,Brad Wilson</authors>
+    <summary>.NET Core console runner, as a linkable library, for runner authors. For running tests, please use xunit.runner.console instead.</summary>
+    <description>.NET Core console runner, as a linkable library, for runner authors. For running tests, please use xunit.runner.console instead.</description>
+    <language>en-US</language>
+    <projectUrl>https://github.com/xunit/xunit</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/xunit/media/master/logo-512-transparent.png</iconUrl>
+    <licenseUrl>https://raw.githubusercontent.com/xunit/xunit/master/license.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+      <dependency id="xunit.runner.reporters" version="[99.99.99-dev]" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="xunit.console\bin\$Configuration$\netcoreapp1.0\xunit.console.dll" target="lib\netcoreapp1.0\" />
+
+    <file src="xunit.console\bin\$Configuration$\netcoreapp2.0\xunit.console.dll" target="lib\netcoreapp2.0\" />
+  </files>
+</package>

--- a/xunit.vs2017.sln
+++ b/xunit.vs2017.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 14.0.22823.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{DAED8494-AC8A-4C67-A8F1-616D95ECC302}"
 	ProjectSection(SolutionItems) = preProject
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{52472A94
 		NuGet.Config = NuGet.Config
 		src\xunit.assert.nuspec = src\xunit.assert.nuspec
 		src\xunit.assert.source.nuspec = src\xunit.assert.source.nuspec
+		src\xunit.console.nuspec = src\xunit.console.nuspec
 		src\xunit.core.nuspec = src\xunit.core.nuspec
 		src\xunit.extensibility.core.nuspec = src\xunit.extensibility.core.nuspec
 		src\xunit.extensibility.execution.nuspec = src\xunit.extensibility.execution.nuspec


### PR DESCRIPTION
This adds a NuGet package for xunit.console.

This would be useful to us in the [dotnet/sdk](https://github.com/dotnet/sdk) and [dotnet/cli](https://github.com/dotnet/cli) repos.  It would allow the test projects to have a main method that calls into xunit.console, so tests could be run via `dotnet run`.  This makes it easier to attach a debugger to tests, since `dotnet test` and `dotnet xunit` both launch separate processes to run the tests.