### PR TITLE
Traverse multiple levels in hierarchy to find base method info

### DIFF
--- a/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
@@ -128,19 +128,24 @@ namespace Xunit.Sdk
             if (!method.IsVirtual)
                 return null;
 
-            var baseType = method.DeclaringType.GetTypeInfo().BaseType;
-            if (baseType == null)
-                return null;
-
             var methodParameters = method.GetParameters();
             var methodGenericArgCount = method.GetGenericArguments().Length;
 
-            foreach (MethodInfo m in baseType.GetMatchingMethods(method))
+            var currentType = method.DeclaringType;
+
+            while (currentType != typeof(object))
             {
-                if (m.Name == method.Name &&
-                    m.GetGenericArguments().Length == methodGenericArgCount &&
-                    ParametersHaveSameTypes(methodParameters, m.GetParameters()))
-                    return m;
+                currentType = currentType.GetTypeInfo().BaseType;
+                if (currentType == null)
+                    return null;
+
+                foreach (MethodInfo m in currentType.GetMatchingMethods(method))
+                {
+                    if (m.Name == method.Name &&
+                        m.GetGenericArguments().Length == methodGenericArgCount &&
+                        ParametersHaveSameTypes(methodParameters, m.GetParameters()))
+                        return m;
+                }
             }
 
             return null;

--- a/test/test.xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscovererTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/XunitTestFrameworkDiscovererTests.cs
@@ -321,6 +321,39 @@ public class XunitTestFrameworkDiscovererTests
             Assert.Single(framework.Sink.TestCases, testCase => testCase.DisplayName == "XunitTestFrameworkDiscovererTests+FindImpl+TheoryWithPropertyData.TheoryMethod(value: 42)");
             Assert.Single(framework.Sink.TestCases, testCase => testCase.DisplayName == "XunitTestFrameworkDiscovererTests+FindImpl+TheoryWithPropertyData.TheoryMethod(value: 2112)");
         }
+
+        [Fact]
+        public static void AssemblyWithMultiLevelHierarchyWithFactOverridenInNonImmediateDerivedClass_ReturnsOneTestCase()
+        {
+            var framework = TestableXunitTestFrameworkDiscoverer.Create();
+            var testClass = Mocks.TestClass(typeof(Child));
+
+            framework.FindTestsForClass(testClass);
+
+            Assert.Equal(1, framework.Sink.TestCases.Count);
+            Assert.Equal("XunitTestFrameworkDiscovererTests+FindImpl+Child.FactOverridenInNonImmediateDerivedClass", framework.Sink.TestCases[0].DisplayName);
+        }
+
+        public abstract class GrandParent
+        {
+            [Fact]
+            public virtual void FactOverridenInNonImmediateDerivedClass()
+            {
+                Assert.True(true);
+            }
+        }
+
+        public abstract class Parent : GrandParent { }
+
+        public class Child : Parent
+        {
+            public override void FactOverridenInNonImmediateDerivedClass()
+            {
+                base.FactOverridenInNonImmediateDerivedClass();
+
+                Assert.False(false);
+            }
+        }
     }
 
     public class CreateTestClass


### PR DESCRIPTION
Resolves #1068 

Issue: When trying to find base method for `CustomAttributeData`, we checked base type of method's declaring type to find matching base method but if the base type did not define the method, we returned null. In multiple level of hierarchy (`GrandParent` -> `Parent` -> `Child`), if the method is overridden in `Child` class without `FactAttribute` on it (assuming it would be carried from the base method), we would try to find base method on `Parent` Class. But if the method is defined on `GrandParent` and not overridden in `Parent` class then we will not be able to locate the base method hence associated `CustomAttributeData` is not found which causes test to be ignored.

Fix is to go multiple levels towards base till we find base method.