### PR TITLE
Checks for target runtime before discovery/execution

### DIFF
--- a/src/xunit.runner.visualstudio/Constants.cs
+++ b/src/xunit.runner.visualstudio/Constants.cs
@@ -2,6 +2,14 @@
 {
     public static class Constants
     {
-        public const string ExecutorUri = "executor://xunit/VsTestRunner2";
+#if NET452
+        public const string ExecutorUri = "executor://xunit/VsTestRunner2/desktop";
+#elif NETCOREAPP1_0
+        public const string ExecutorUri = "executor://xunit/VsTestRunner2/netcoreapp";
+#elif WINDOWS_UAP
+        public const string ExecutorUri = "executor://xunit/VsTestRunner2/uap";
+#else
+#error Unknown target platform
+#endif
     }
 }

--- a/src/xunit.runner.visualstudio/Utility/RunSettingsHelper.cs
+++ b/src/xunit.runner.visualstudio/Utility/RunSettingsHelper.cs
@@ -37,6 +37,11 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         public static string ReporterSwitch { get; private set; }
 
         /// <summary>
+        /// Gets a value which indicates the target framework the tests are being run in.
+        /// </summary>
+        public static string TargetFrameworkVersion { get; private set; }
+
+        /// <summary>
         /// Reads settings for the current run from run settings xml
         /// </summary>
         /// <param name="runSettingsXml">RunSettingsXml of the run</param>
@@ -49,6 +54,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             DisableParallelization = false;
             NoAutoReporters = false;
             ReporterSwitch = null;
+            TargetFrameworkVersion = null;
 
 #if !WINDOWS_UAP
             if (!string.IsNullOrEmpty(runSettingsXml))
@@ -79,6 +85,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                             CollectSourceInformation = collectSourceInformation;
 
                         ReporterSwitch = element.Element("ReporterSwitch")?.Value;
+                        TargetFrameworkVersion = element.Element("TargetFrameworkVersion")?.Value;
                     }
                 }
                 catch { }

--- a/src/xunit.runner.visualstudio/VsTestRunner.cs
+++ b/src/xunit.runner.visualstudio/VsTestRunner.cs
@@ -78,9 +78,9 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             var loggerHelper = new LoggerHelper(logger, stopwatch);
 
 #if NET452 || NETCOREAPP1_0
-            // Reads settings like disabling appdomains, parallel etc.
-            // Do this first before invoking any thing else to ensure correct settings for the run
             RunSettingsHelper.ReadRunSettings(discoveryContext?.RunSettings?.SettingsXml);
+            if (!ValidateRuntimeFramework())
+                return;
 #endif
 
             var testPlatformContext = new TestPlatformContext
@@ -110,9 +110,9 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             var logger = new LoggerHelper(frameworkHandle, stopwatch);
 
 #if NET452 || NETCOREAPP1_0
-            // Reads settings like disabling appdomains, parallel etc.
-            // Do this first before invoking any thing else to ensure correct settings for the run
             RunSettingsHelper.ReadRunSettings(runContext?.RunSettings?.SettingsXml);
+            if (!ValidateRuntimeFramework())
+                return;
 #endif
 
             // In the context of Run All tests, commandline runner doesn't require source information or
@@ -163,8 +163,6 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             var logger = new LoggerHelper(frameworkHandle, stopwatch);
 
 #if NET452 || NETCOREAPP1_0
-            // Reads settings like disabling appdomains, parallel etc.
-            // Do this first before invoking any thing else to ensure correct settings for the run
             RunSettingsHelper.ReadRunSettings(runContext?.RunSettings?.SettingsXml);
 #endif
 
@@ -712,6 +710,22 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
 
             return result;
 #endif
+        }
+
+        /// <summary>
+        /// Validates the runtime target framework from test platform with the current adapter's target.
+        /// </summary>
+        /// <returns>True if the target frameworks match.</returns>
+        static bool ValidateRuntimeFramework()
+        {
+#if NETCOREAPP1_0
+            var targetFrameworkVersion = RunSettingsHelper.TargetFrameworkVersion;
+
+            return targetFrameworkVersion.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) ||
+                   targetFrameworkVersion.StartsWith("FrameworkCore", StringComparison.OrdinalIgnoreCase);
+#endif
+
+            return true;
         }
 
         class AssemblyDiscoveredInfo

--- a/test/test.xunit.runner.visualstudio/RunSettingsHelperTests.cs
+++ b/test/test.xunit.runner.visualstudio/RunSettingsHelperTests.cs
@@ -10,6 +10,7 @@ public class RunSettingsHelperTests
         Assert.False(RunSettingsHelper.NoAutoReporters);
         Assert.True(RunSettingsHelper.DesignMode);
         Assert.True(RunSettingsHelper.CollectSourceInformation);
+        Assert.Null(RunSettingsHelper.TargetFrameworkVersion);
     }
 
     [Fact]
@@ -132,5 +133,6 @@ public class RunSettingsHelperTests
         Assert.True(RunSettingsHelper.DisableAppDomain);
         Assert.True(RunSettingsHelper.DisableParallelization);
         Assert.True(RunSettingsHelper.NoAutoReporters);
+        Assert.Equal("FrameworkCore10", RunSettingsHelper.TargetFrameworkVersion);
     }
 }


### PR DESCRIPTION
This change allows an adapter to bail out if it's loaded in incorrect target runtime. It can happen if .NET core adapter is loaded to run a desktop test for instance (this occurs consistently if user has .NET 4.7 installed).

Provide different executor URI identifiers for the desktop and dotnet core adapters.

Fixes #1348.