### PR TITLE
Added functionality to honor CollectSourceInformation flag from RunSettings XML

### DIFF
--- a/src/xunit.runner.visualstudio/Utility/RunSettingsHelper.cs
+++ b/src/xunit.runner.visualstudio/Utility/RunSettingsHelper.cs
@@ -16,11 +16,13 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         /// </summary>
         public static bool DesignMode { get; private set; }
 
+        public static bool CollectSourceInformation { get; private set; }
+
         public static bool NoAutoReporters { get; private set; }
 
-/*
-        public static string ReporterSwitch { get; private set; }
-*/
+        /*
+                public static string ReporterSwitch { get; private set; }
+        */
         /// <summary>
         /// Reads settings for the current run from run settings xml
         /// </summary>
@@ -36,6 +38,8 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             // differentiate between VS or vstest.console.
             DesignMode = true;
 
+            // If runSettings doesnt have CollectSourceInformation tag then by default it should be true
+            CollectSourceInformation = true;
 
 #if !WINDOWS_UAP
             if (!string.IsNullOrEmpty(runSettingsXml))
@@ -66,9 +70,14 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                         if (bool.TryParse(noAutoReportersString, out noAutoReporters))
                             NoAutoReporters = noAutoReporters;
 
-/*
-                        ReporterSwitch = element.Element("ReporterSwitch")?.Value;
-*/
+                        var collectSourceInformationString = element.Element("CollectSourceInformation")?.Value;
+                        bool collectSourceinformation;
+                        if (bool.TryParse(collectSourceInformationString, out collectSourceinformation))
+                            CollectSourceInformation = collectSourceinformation;
+
+                        /*
+                                                ReporterSwitch = element.Element("ReporterSwitch")?.Value;
+                        */
                     }
                 }
                 catch { }

--- a/src/xunit.runner.visualstudio/Utility/RunSettingsHelper.cs
+++ b/src/xunit.runner.visualstudio/Utility/RunSettingsHelper.cs
@@ -6,40 +6,49 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
 {
     public static class RunSettingsHelper
     {
-        public static bool DisableAppDomain { get; private set; }
-
-        public static bool DisableParallelization { get; private set; }
+        /// <summary>
+        /// Gets a value which indicates whether we should attempt to get source line information.
+        /// </summary>
+        public static bool CollectSourceInformation { get; private set; }
 
         /// <summary>
-        /// Design mode indicates the context of a test run. True indicates the test run is invoked from an editor
-        /// or IDE.
+        /// Gets a value which indicates whether we're running in design mode inside the IDE.
         /// </summary>
         public static bool DesignMode { get; private set; }
 
-        public static bool CollectSourceInformation { get; private set; }
+        /// <summary>
+        /// Gets a value which indicates if we should disable app domains.
+        /// </summary>
+        public static bool DisableAppDomain { get; private set; }
 
+        /// <summary>
+        /// Gets a value which indicates if we should disable parallelization.
+        /// </summary>
+        public static bool DisableParallelization { get; private set; }
+
+        /// <summary>
+        /// Gets a value which indiciates if we should disable automatic reporters.
+        /// </summary>
         public static bool NoAutoReporters { get; private set; }
 
-        /*
-                public static string ReporterSwitch { get; private set; }
-        */
+        /// <summary>
+        /// Gets a value which indicates which reporter we should use.
+        /// </summary>
+        public static string ReporterSwitch { get; private set; }
+
         /// <summary>
         /// Reads settings for the current run from run settings xml
         /// </summary>
         /// <param name="runSettingsXml">RunSettingsXml of the run</param>
         public static void ReadRunSettings(string runSettingsXml)
         {
-            // reset first, do not want to propagate earlier settings in cases where execution host is kept alive
+            // Reset to defaults
+            CollectSourceInformation = true;
+            DesignMode = true;
             DisableAppDomain = false;
             DisableParallelization = false;
             NoAutoReporters = false;
-
-            // We're keeping the default value as true since the adapter (prior to VS 2017) shouldn't
-            // differentiate between VS or vstest.console.
-            DesignMode = true;
-
-            // If runSettings doesnt have CollectSourceInformation tag then by default it should be true
-            CollectSourceInformation = true;
+            ReporterSwitch = null;
 
 #if !WINDOWS_UAP
             if (!string.IsNullOrEmpty(runSettingsXml))
@@ -50,34 +59,26 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                     if (element != null)
                     {
                         var disableAppDomainString = element.Element("DisableAppDomain")?.Value;
-                        bool disableAppDomain;
-                        if (bool.TryParse(disableAppDomainString, out disableAppDomain))
+                        if (bool.TryParse(disableAppDomainString, out bool disableAppDomain))
                             DisableAppDomain = disableAppDomain;
 
                         var disableParallelizationString = element.Element("DisableParallelization")?.Value;
-                        bool disableParallelization;
-                        if (bool.TryParse(disableParallelizationString, out disableParallelization))
+                        if (bool.TryParse(disableParallelizationString, out bool disableParallelization))
                             DisableParallelization = disableParallelization;
 
-                        // It is set to True if test is running from an Editor/IDE context.
                         var designModeString = element.Element("DesignMode")?.Value;
-                        bool designMode;
-                        if (bool.TryParse(designModeString, out designMode))
+                        if (bool.TryParse(designModeString, out bool designMode))
                             DesignMode = designMode;
 
                         var noAutoReportersString = element.Element("NoAutoReporters")?.Value;
-                        bool noAutoReporters;
-                        if (bool.TryParse(noAutoReportersString, out noAutoReporters))
+                        if (bool.TryParse(noAutoReportersString, out bool noAutoReporters))
                             NoAutoReporters = noAutoReporters;
 
                         var collectSourceInformationString = element.Element("CollectSourceInformation")?.Value;
-                        bool collectSourceinformation;
-                        if (bool.TryParse(collectSourceInformationString, out collectSourceinformation))
-                            CollectSourceInformation = collectSourceinformation;
+                        if (bool.TryParse(collectSourceInformationString, out bool collectSourceInformation))
+                            CollectSourceInformation = collectSourceInformation;
 
-                        /*
-                                                ReporterSwitch = element.Element("ReporterSwitch")?.Value;
-                        */
+                        ReporterSwitch = element.Element("ReporterSwitch")?.Value;
                     }
                 }
                 catch { }

--- a/src/xunit.runner.visualstudio/VsTestRunner.cs
+++ b/src/xunit.runner.visualstudio/VsTestRunner.cs
@@ -88,7 +88,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                 // Discovery from command line (non designmode) never requires source information
                 // since there is no session or command line runner doesn't send back VSTestCase objects
                 // back to adapter.
-                RequireSourceInformation = RunSettingsHelper.DesignMode,
+                RequireSourceInformation = RunSettingsHelper.CollectSourceInformation,
 
                 // Command line runner could request for Discovery in case of running specific tests. We need
                 // the XunitTestCase serialized in this scenario.
@@ -119,7 +119,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             // serialized xunit test case property
             var testPlatformContext = new TestPlatformContext
             {
-                RequireSourceInformation = RunSettingsHelper.DesignMode,
+                RequireSourceInformation = RunSettingsHelper.CollectSourceInformation,
                 RequireXunitTestProperty = RunSettingsHelper.DesignMode
             };
 
@@ -172,7 +172,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             // serialized xunit test case property
             var testPlatformContext = new TestPlatformContext
             {
-                RequireSourceInformation = RunSettingsHelper.DesignMode,
+                RequireSourceInformation = RunSettingsHelper.CollectSourceInformation,
                 RequireXunitTestProperty = RunSettingsHelper.DesignMode
             };
 

--- a/test/test.xunit.runner.visualstudio/RunSettingsHelperTests.cs
+++ b/test/test.xunit.runner.visualstudio/RunSettingsHelperTests.cs
@@ -27,6 +27,7 @@ public class RunSettingsHelperTests
                         <DisableAppDomain>1234</DisableAppDomain>
                         <DisableParallelization>smfhekhgekr</DisableParallelization>
                         <DesignMode>3245sax</DesignMode>
+                        <CollectSourceInformation>1234blah</CollectSourceInformation>
                         <NoAutoReporters>1x3_5f8g0</NoAutoReporters>
                     </RunConfiguration>
                 </RunSettings>";
@@ -37,6 +38,8 @@ public class RunSettingsHelperTests
         Assert.False(RunSettingsHelper.DisableAppDomain);
         Assert.False(RunSettingsHelper.DisableParallelization);
         Assert.False(RunSettingsHelper.NoAutoReporters);
+        Assert.True(RunSettingsHelper.DesignMode);
+        Assert.True(RunSettingsHelper.CollectSourceInformation);
     }
 
 
@@ -61,6 +64,7 @@ public class RunSettingsHelperTests
         // Default value must be used for disableparallelization, designmode
         Assert.False(RunSettingsHelper.DisableParallelization);
         Assert.True(RunSettingsHelper.DesignMode);
+        Assert.True(RunSettingsHelper.CollectSourceInformation);
     }
 
     [Fact]
@@ -81,16 +85,17 @@ public class RunSettingsHelperTests
         Assert.False(RunSettingsHelper.DisableAppDomain);
         Assert.False(RunSettingsHelper.NoAutoReporters);
         Assert.True(RunSettingsHelper.DesignMode);
+        Assert.True(RunSettingsHelper.CollectSourceInformation);
         // DisableParallelization can be set
         Assert.True(RunSettingsHelper.DisableParallelization);
     }
 
     [Theory]
-    [InlineData(false, false, true)]
-    [InlineData(false, true, true)]
-    [InlineData(true, false, false)]
-    [InlineData(true, true, false)]
-    public void RunSettingsHelperShouldReadValuesCorrectly(bool disableAppDomain, bool disableParallelization, bool noAutoReporters)
+    [InlineData(false, false, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, false, true)]
+    [InlineData(true, true, false, false)]
+    public void RunSettingsHelperShouldReadValuesCorrectly(bool disableAppDomain, bool disableParallelization, bool noAutoReporters, bool collectSourceInformation)
     {
         string settingsXml =
             $@"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -99,6 +104,7 @@ public class RunSettingsHelperTests
                         <DisableAppDomain>{disableAppDomain.ToString().ToLowerInvariant()}</DisableAppDomain>
                         <DisableParallelization>{disableParallelization.ToString().ToLowerInvariant()}</DisableParallelization>
                         <NoAutoReporters>{noAutoReporters.ToString().ToLowerInvariant()}</NoAutoReporters>
+                        <CollectSourceInformation>{collectSourceInformation.ToString().ToLowerInvariant()}</CollectSourceInformation>
                     </RunConfiguration>
                 </RunSettings>";
 
@@ -108,6 +114,7 @@ public class RunSettingsHelperTests
         Assert.Equal(disableAppDomain, RunSettingsHelper.DisableAppDomain);
         Assert.Equal(disableParallelization, RunSettingsHelper.DisableParallelization);
         Assert.Equal(noAutoReporters, RunSettingsHelper.NoAutoReporters);
+        Assert.Equal(collectSourceInformation, RunSettingsHelper.CollectSourceInformation);
     }
 
     [Theory]

--- a/test/test.xunit.runner.visualstudio/RunSettingsHelperTests.cs
+++ b/test/test.xunit.runner.visualstudio/RunSettingsHelperTests.cs
@@ -3,6 +3,15 @@ using Xunit.Runner.VisualStudio.TestAdapter;
 
 public class RunSettingsHelperTests
 {
+    void AssertDefaultValues()
+    {
+        Assert.False(RunSettingsHelper.DisableAppDomain);
+        Assert.False(RunSettingsHelper.DisableParallelization);
+        Assert.False(RunSettingsHelper.NoAutoReporters);
+        Assert.True(RunSettingsHelper.DesignMode);
+        Assert.True(RunSettingsHelper.CollectSourceInformation);
+    }
+
     [Fact]
     public void RunSettingsHelperShouldNotThrowExceptionOnBadXml()
     {
@@ -12,9 +21,7 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Default values must be used
-        Assert.False(RunSettingsHelper.DisableAppDomain);
-        Assert.False(RunSettingsHelper.DisableParallelization);
+        AssertDefaultValues();
     }
 
     [Fact]
@@ -34,14 +41,8 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Default values must be used
-        Assert.False(RunSettingsHelper.DisableAppDomain);
-        Assert.False(RunSettingsHelper.DisableParallelization);
-        Assert.False(RunSettingsHelper.NoAutoReporters);
-        Assert.True(RunSettingsHelper.DesignMode);
-        Assert.True(RunSettingsHelper.CollectSourceInformation);
+        AssertDefaultValues();
     }
-
 
     [Fact]
     public void RunSettingsHelperShouldUseDefaultValuesInCaseOfIncorrectSchemaAndIgnoreAttributes()
@@ -59,12 +60,10 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Attribute must be ignored
+        // Use element value, not attribute value
         Assert.True(RunSettingsHelper.DisableAppDomain);
-        // Default value must be used for disableparallelization, designmode
+        // Ignore value that isn't at the right level
         Assert.False(RunSettingsHelper.DisableParallelization);
-        Assert.True(RunSettingsHelper.DesignMode);
-        Assert.True(RunSettingsHelper.CollectSourceInformation);
     }
 
     [Fact]
@@ -81,64 +80,34 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Default value must be used for DisableAppDomain, DesignMode, NoAutoReporters
-        Assert.False(RunSettingsHelper.DisableAppDomain);
-        Assert.False(RunSettingsHelper.NoAutoReporters);
-        Assert.True(RunSettingsHelper.DesignMode);
-        Assert.True(RunSettingsHelper.CollectSourceInformation);
-        // DisableParallelization can be set
+        // Allow value to be read even after unexpected element body
         Assert.True(RunSettingsHelper.DisableParallelization);
-    }
-
-    [Theory]
-    [InlineData(false, false, true, true)]
-    [InlineData(false, true, true, false)]
-    [InlineData(true, false, false, true)]
-    [InlineData(true, true, false, false)]
-    public void RunSettingsHelperShouldReadValuesCorrectly(bool disableAppDomain, bool disableParallelization, bool noAutoReporters, bool collectSourceInformation)
-    {
-        string settingsXml =
-            $@"<?xml version=""1.0"" encoding=""utf-8""?>
-                <RunSettings>
-                    <RunConfiguration>
-                        <DisableAppDomain>{disableAppDomain.ToString().ToLowerInvariant()}</DisableAppDomain>
-                        <DisableParallelization>{disableParallelization.ToString().ToLowerInvariant()}</DisableParallelization>
-                        <NoAutoReporters>{noAutoReporters.ToString().ToLowerInvariant()}</NoAutoReporters>
-                        <CollectSourceInformation>{collectSourceInformation.ToString().ToLowerInvariant()}</CollectSourceInformation>
-                    </RunConfiguration>
-                </RunSettings>";
-
-        RunSettingsHelper.ReadRunSettings(settingsXml);
-
-        // Correct values must be set
-        Assert.Equal(disableAppDomain, RunSettingsHelper.DisableAppDomain);
-        Assert.Equal(disableParallelization, RunSettingsHelper.DisableParallelization);
-        Assert.Equal(noAutoReporters, RunSettingsHelper.NoAutoReporters);
-        Assert.Equal(collectSourceInformation, RunSettingsHelper.CollectSourceInformation);
     }
 
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void RunSettingsHelperShouldReadDesignModeSettingCorrectly(bool designMode)
+    public void RunSettingsHelperShouldReadValuesCorrectly(bool testValue)
     {
         string settingsXml =
             $@"<?xml version=""1.0"" encoding=""utf-8""?>
                 <RunSettings>
                     <RunConfiguration>
-                        <DisableAppDomain>true</DisableAppDomain>
-                        <DisableParallelization>invalid</DisableParallelization>
-                        <DesignMode>{designMode.ToString().ToLowerInvariant()}</DesignMode>
+                        <CollectSourceInformation>{testValue.ToString().ToLowerInvariant()}</CollectSourceInformation>
+                        <DesignMode>{testValue.ToString().ToLowerInvariant()}</DesignMode>
+                        <DisableAppDomain>{testValue.ToString().ToLowerInvariant()}</DisableAppDomain>
+                        <DisableParallelization>{testValue.ToString().ToLowerInvariant()}</DisableParallelization>
+                        <NoAutoReporters>{testValue.ToString().ToLowerInvariant()}</NoAutoReporters>
                     </RunConfiguration>
                 </RunSettings>";
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Correct values must be set
-        Assert.Equal(designMode, RunSettingsHelper.DesignMode);
-        Assert.True(RunSettingsHelper.DisableAppDomain);
-        // Default value should be set for DisableParallelization
-        Assert.False(RunSettingsHelper.DisableParallelization);
+        Assert.Equal(testValue, RunSettingsHelper.CollectSourceInformation);
+        Assert.Equal(testValue, RunSettingsHelper.DesignMode);
+        Assert.Equal(testValue, RunSettingsHelper.DisableAppDomain);
+        Assert.Equal(testValue, RunSettingsHelper.DisableParallelization);
+        Assert.Equal(testValue, RunSettingsHelper.NoAutoReporters);
     }
 
     [Fact]
@@ -160,7 +129,6 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Correct values must be used
         Assert.True(RunSettingsHelper.DisableAppDomain);
         Assert.True(RunSettingsHelper.DisableParallelization);
         Assert.True(RunSettingsHelper.NoAutoReporters);


### PR DESCRIPTION
Refer RFC: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0010-Source-Information-For-Discovered-Tests.md

Summary:
CollectSourceInformation = True => Test adapter needs to collect source information for the discovered tests
CollectSourceInformation = False => Test adapter doesn't need to collect source information for discovered tests. In case tests are executed from VS IDE, then Test Window will get this information using Roslyn.

By default CollectSourceInformation will be true. It will be false when:
1. VS IDE determines that it can get this information from Roslyn
2. Command line scenario: When tests are executed from vstest.console.exe, this flag will always be false unless user explicitly overrides it in the runsettings XML file.