### PR TITLE
Feature: Add CollectionDefinition.DisableParallelization

### DIFF
--- a/src/xunit.core/CollectionAttribute.cs
+++ b/src/xunit.core/CollectionAttribute.cs
@@ -13,5 +13,10 @@ namespace Xunit
         /// </summary>
         /// <param name="name">The test collection name.</param>
         public CollectionAttribute(string name) { }
+
+        /// <summary>
+        /// Determines whether tests in this collection runs in parallel with any other collections.
+        /// </summary>
+        public bool DisableParallelization { get; set; }
     }
 }

--- a/src/xunit.core/CollectionAttribute.cs
+++ b/src/xunit.core/CollectionAttribute.cs
@@ -13,10 +13,5 @@ namespace Xunit
         /// </summary>
         /// <param name="name">The test collection name.</param>
         public CollectionAttribute(string name) { }
-
-        /// <summary>
-        /// Determines whether tests in this collection runs in parallel with any other collections.
-        /// </summary>
-        public bool DisableParallelization { get; set; }
     }
 }

--- a/src/xunit.core/CollectionDefinitionAttribute.cs
+++ b/src/xunit.core/CollectionDefinitionAttribute.cs
@@ -16,5 +16,10 @@ namespace Xunit
         /// </summary>
         /// <param name="name">The test collection name.</param>
         public CollectionDefinitionAttribute(string name) { }
+
+        /// <summary>
+        /// Determines whether tests in this collection runs in parallel with any other collections.
+        /// </summary>
+        public bool DisableParallelization { get; set; }
     }
 }

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs
@@ -175,19 +175,51 @@ namespace Xunit.Sdk
             else
                 taskRunner = code => Task.Run(code, cancellationTokenSource.Token);
 
-            var tasks = OrderTestCollections().Select(
-                collection => taskRunner(() => RunTestCollectionAsync(messageBus, collection.Item1, collection.Item2, cancellationTokenSource))
-            ).ToArray();
-
+            List<Task<RunSummary>> parallel = null;
+            List<Func<Task<RunSummary>>> nonParallel = null;
             var summaries = new List<RunSummary>();
 
-            foreach (var task in tasks)
+            foreach (var collection in OrderTestCollections())
             {
-                try
+                Func<Task<RunSummary>> task = () => RunTestCollectionAsync(messageBus, collection.Item1, collection.Item2, cancellationTokenSource);
+                
+                // attr is null here from our new unit test, but I'm not sure if that's expected or there's a cheaper approach here
+                // Current approach is trying to avoid any changes to the abstractions at all
+                var attr = collection.Item1.CollectionDefinition?.GetCustomAttributes(typeof(CollectionAttribute)).SingleOrDefault();
+                if (attr != null && attr.GetNamedArgument<bool>(nameof(CollectionAttribute.DisableParallelization)))
                 {
-                    summaries.Add(await task);
+                    (nonParallel ?? (nonParallel = new List<Func<Task<RunSummary>>>())).Add(task);
                 }
-                catch (TaskCanceledException) { }
+                else
+                {
+                    (parallel ?? (parallel = new List<Task<RunSummary>>())).Add(taskRunner(task));
+                }
+            }
+            
+            if (parallel?.Count > 0)
+            {
+                foreach (var task in parallel)
+                {
+                    try
+                    {
+                        summaries.Add(await task);
+                    }
+                    catch (TaskCanceledException) { }
+                }
+            }
+
+            if (nonParallel?.Count > 0)
+            {
+                foreach (var task in nonParallel)
+                {
+                    try
+                    {
+                        summaries.Add(await taskRunner(task));
+                        if (cancellationTokenSource.IsCancellationRequested)
+                            break;
+                    }
+                    catch (TaskCanceledException) { }
+                }
             }
 
             return new RunSummary()

--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestAssemblyRunner.cs
@@ -185,8 +185,8 @@ namespace Xunit.Sdk
                 
                 // attr is null here from our new unit test, but I'm not sure if that's expected or there's a cheaper approach here
                 // Current approach is trying to avoid any changes to the abstractions at all
-                var attr = collection.Item1.CollectionDefinition?.GetCustomAttributes(typeof(CollectionAttribute)).SingleOrDefault();
-                if (attr != null && attr.GetNamedArgument<bool>(nameof(CollectionAttribute.DisableParallelization)))
+                var attr = collection.Item1.CollectionDefinition?.GetCustomAttributes(typeof(CollectionDefinitionAttribute)).SingleOrDefault();
+                if (attr?.GetNamedArgument<bool>(nameof(CollectionDefinitionAttribute.DisableParallelization)) == true)
                 {
                     (nonParallel ?? (nonParallel = new List<Func<Task<RunSummary>>>())).Add(task);
                 }

--- a/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
@@ -356,7 +356,7 @@ public class Xunit2AcceptanceTests
         }
     }
 
-    public class TestNonParellelOrdering : AcceptanceTestV2
+    public class TestNonParallelOrdering : AcceptanceTestV2
     {
         [Fact]
         public void NonParallelCollectionsRunLast()
@@ -369,11 +369,16 @@ public class Xunit2AcceptanceTests
             Assert.Collection(testMessages,
                 message => Assert.Equal("Test1", message.TestCase.TestMethod.Method.Name),
                 message => Assert.Equal("Test2", message.TestCase.TestMethod.Method.Name),
-                message => Assert.Equal("IShouldBeLast", message.TestCase.TestMethod.Method.Name)
+                message => Assert.Equal("IShouldBeLast1", message.TestCase.TestMethod.Method.Name),
+                message => Assert.Equal("IShouldBeLast2", message.TestCase.TestMethod.Method.Name)
             );
         }
 
-        [Collection("Ordered Collection")]
+        [CollectionDefinition("Parallel Ordered Collection")]
+        [TestCaseOrderer("Xunit2AcceptanceTests+TestOrdering+AlphabeticalOrderer", "test.xunit.execution")]
+        public class CollectionClass { }
+
+        [Collection("Parallel Ordered Collection")]
         class TestClassParallelCollection
         {
             [Fact]
@@ -383,11 +388,17 @@ public class Xunit2AcceptanceTests
             public void Test2() { }
         }
 
-        [Collection("Non-Parallel Collection", DisableParallelization = true)]
+        [CollectionDefinition("Non-Parallel Collection", DisableParallelization = true)]
+        [TestCaseOrderer("Xunit2AcceptanceTests+TestOrdering+AlphabeticalOrderer", "test.xunit.execution")]
+        public class TestClassNonParallelCollectionDefinition { }
+
+        [Collection("Non-Parallel Collection")]
         class TestClassNonParallelCollection
         {
             [Fact]
-            public void IShouldBeLast() { }
+            public void IShouldBeLast2() { }
+            [Fact]
+            public void IShouldBeLast1() { }
         }
     }
 

--- a/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
+++ b/test/test.xunit.execution/Acceptance/Xunit2AcceptanceTests.cs
@@ -356,6 +356,41 @@ public class Xunit2AcceptanceTests
         }
     }
 
+    public class TestNonParellelOrdering : AcceptanceTestV2
+    {
+        [Fact]
+        public void NonParallelCollectionsRunLast()
+        {
+            var testMessages = Run<ITestPassed>(new[] {
+                typeof(TestClassNonParallelCollection),
+                typeof(TestClassParallelCollection)
+            });
+
+            Assert.Collection(testMessages,
+                message => Assert.Equal("Test1", message.TestCase.TestMethod.Method.Name),
+                message => Assert.Equal("Test2", message.TestCase.TestMethod.Method.Name),
+                message => Assert.Equal("IShouldBeLast", message.TestCase.TestMethod.Method.Name)
+            );
+        }
+
+        [Collection("Ordered Collection")]
+        class TestClassParallelCollection
+        {
+            [Fact]
+            public void Test1() { }
+
+            [Fact]
+            public void Test2() { }
+        }
+
+        [Collection("Non-Parallel Collection", DisableParallelization = true)]
+        class TestClassNonParallelCollection
+        {
+            [Fact]
+            public void IShouldBeLast() { }
+        }
+    }
+
     public class CustomFacts : AcceptanceTestV2
     {
         [Fact]


### PR DESCRIPTION
This spawned [from a Twitter discussion here](https://twitter.com/Nick_Craver/status/897515667259359234).

In every one of our libraries, especially with settings, event handlers, etc. some tests just aren't friendly with parallelization. We want parallel testing in the vast majority of cases (that can in itself reveal issues), but specific tests (or collections) we want to run non-parallel separately from everything else.

This change allows a `CollectionDefinition` to specify `DisableParallelization = true` to support this. The behavior is: all parallel collections (any not specifying this new constructor argument specifically) run first and in parallel (no behavior change from today). Then any collections specifying `DisableParallelization = true` are run, each is awaited in order. This means that one 1 `DisableParallelization` collection is running at a time.

Note the code is a bit more complicated to reduce allocations, but if we want to allocate and simplify I can take that route.

The alternatives to this sort of change is: override `[Fact]` everywhere and handle semaphores externally. Something that's pretty pervasive for a base level change. Or, split all tests into another assembly with 1 thread (disabling parallelization). This (from my experience) would result in a lot of code duplication and complication.

With this change, a user can specify:

```c#
[CollectionDefinition("Event Handler Tests", DisableParallelization = true)]
public class EventHandlerTestDefinition { }

[Collection("Event Handler Tests")]
public class EventHandlerTests
{
    [Fact]
    public void EventHandlerAddRemove() { }
}
```
...and those tests which have global impact (causing many other tests or themselves to fail) can run at the end, safely testing everything and avoiding many of the race conditions and inconsistencies otherwise present when they interact with all tests.

Questions: Is there a better property name for this behavior?

Side notes: it'd be handle to switch to `nameof()` in other places attribute constructors are fetched for seeing where they're used in VS 2017. If that's wanted, I'll open another PR specifically for that.

cc @bradwilson @onovotny 