### PR TITLE
Make sure output file full path exsits

### DIFF
--- a/src/xunit.console/CommandLine.cs
+++ b/src/xunit.console/CommandLine.cs
@@ -325,6 +325,8 @@ namespace Xunit.ConsoleClient
                         if (option.Value == null)
                             throw new ArgumentException($"missing filename for {option.Key}");
 
+                        EnsurePathExists(option.Value);
+
                         project.Output.Add(optionName, option.Value);
                     }
                 }
@@ -342,6 +344,16 @@ namespace Xunit.ConsoleClient
                 value = arguments.Pop();
 
             return new KeyValuePair<string, string>(option, value);
+        }
+
+        static void EnsurePathExists(string path)
+        {
+            var directory = Path.GetDirectoryName(path);
+
+            if(string.IsNullOrEmpty(directory))
+                return;
+
+            Directory.CreateDirectory(directory);
         }
     }
 }

--- a/test/test.xunit.console/CommandLineTests.cs
+++ b/test/test.xunit.console/CommandLineTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.ConsoleClient;
@@ -785,6 +786,20 @@ public class CommandLineTests
             var output = Assert.Single(commandLine.Project.Output);
             Assert.Equal("xml", output.Key);
             Assert.Equal("foo.xml", output.Value);
+        }
+
+        [Fact]
+        public static void OutputWithFolder()
+        {
+            var arguments = new[] {"assemblyName.dll", "-xml", "bar/foo.xml"};
+
+            var commandLine = TestableCommandLine.Parse(arguments);
+
+            var output = Assert.Single(commandLine.Project.Output);
+            Assert.Equal("xml", output.Key);
+            Assert.Equal("bar/foo.xml", output.Value);
+            Assert.True(Directory.Exists("bar"));
+            Directory.Delete("bar");
         }
     }
 


### PR DESCRIPTION
Added a method to make sure the file path exists after the following twitter thread: https://twitter.com/xunit/status/904718357697630213