### PR TITLE
Use TotalMilliseconds instead of Milliseconds

### DIFF
--- a/test/test.xunit1/xunit.extensions/FreezeClock/ClockFacts.cs
+++ b/test/test.xunit1/xunit.extensions/FreezeClock/ClockFacts.cs
@@ -66,7 +66,7 @@ namespace Xunit1.Extensions
 
                 DateTime result = Clock.Now;
 
-                Assert.True((result - now).Milliseconds < 1000);
+                Assert.True((result - now).TotalMilliseconds < 1000);
             }
 
             [Fact]
@@ -139,7 +139,7 @@ namespace Xunit1.Extensions
 
                 DateTime result = Clock.UtcNow;
 
-                Assert.True((result - now).Milliseconds < 1000);
+                Assert.True((result - now).TotalMilliseconds < 1000);
             }
 
             [Fact]

--- a/test/test.xunit1/xunit.extensions/FreezeClock/FreezeClockAttributeAcceptanceTests.cs
+++ b/test/test.xunit1/xunit.extensions/FreezeClock/FreezeClockAttributeAcceptanceTests.cs
@@ -17,7 +17,7 @@ namespace Xunit1.Extensions
             DateTime result2 = Clock.Now;
 
             Assert.Equal(result1, result2);
-            Assert.True((reference - result1).Milliseconds < 1000);
+            Assert.True((reference - result1).TotalMilliseconds < 1000);
         }
 
         [Fact, FreezeClock(2006, 12, 31)]

--- a/test/test.xunit1/xunit.extensions/FreezeClock/FreezeClockAttributeFacts.cs
+++ b/test/test.xunit1/xunit.extensions/FreezeClock/FreezeClockAttributeFacts.cs
@@ -22,7 +22,7 @@ namespace Xunit1.Extensions
                 DateTime result2 = Clock.Now;
 
                 Assert.Equal(result1, result2);
-                Assert.True((result1 - reference).Milliseconds < 1000);
+                Assert.True((result1 - reference).TotalMilliseconds < 1000);
             }
             finally
             {


### PR DESCRIPTION
[`Milliseconds`](https://msdn.microsoft.com/en-us/library/system.timespan.milliseconds(v=vs.110).aspx) ranges from -999 to 999, so checking for `Milliseconds < 1000` is always true,
I believe these should be `TotalMilliseconds` instead?