### PR TITLE
Same variable checked twice for null

### DIFF
--- a/test/test.utility/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
+++ b/test/test.utility/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
@@ -50,7 +50,7 @@ namespace TestUtility
         {
             if (originalUICulture != null)
                 CurrentUICulture = originalUICulture;
-            if (originalUICulture != null)
+            if (originalCulture != null)
                 CurrentCulture = originalCulture;
 
             return base.BeforeTestCaseFinishedAsync();


### PR DESCRIPTION
`originalUICulture` is checked for null in both if statements making them identical.