### PR TITLE
Remove deleted build.sh from VS solution

### DIFF
--- a/xunit.vs2017.sln
+++ b/xunit.vs2017.sln
@@ -59,7 +59,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{EB403884-D335-40D1-AD83-BD6F92AC1744}"
 	ProjectSection(SolutionItems) = preProject
 		build.ps1 = build.ps1
-		build.sh = build.sh
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xunit.core", "src\xunit.core\xunit.core.csproj", "{05CC6B6D-5A70-4B82-8118-49A89A70C425}"


### PR DESCRIPTION
`build.sh` was removed in 914e97d57e388b5c8c2bf5c4381b5c232ed64b5a:

```
commit 914e97d57e388b5c8c2bf5c4381b5c232ed64b5a
Author: Brad Wilson <dotnetguy@gmail.com>
Date:   Tue Mar 14 00:03:09 2017 -0700

    Update build to Powershell, add support for AppVeyor

 .gitignore    |  42 ++++++------
 appveyor.yml  |  41 ++++++++++++
 build.ps1     | 204 ++++++++++++++++++++++++++++++++++++++++++++++++++++------
 build.sh      |  66 -------------------
 xunit.msbuild | 187 -----------------------------------------------------
 5 files changed, 248 insertions(+), 292 deletions(-)
```

However, the Visual Studio solution still contained a reference and which is what this PR removes.