### PR TITLE
[=] Fix incorrect json conversion of double/float numbers

### DIFF
--- a/src/xunit.runner.reporters/JsonExtentions.cs
+++ b/src/xunit.runner.reporters/JsonExtentions.cs
@@ -26,7 +26,7 @@ namespace Xunit.Runner.Reporters
                 sb.Append(',');
 
             if (value is int || value is long || value is float || value is double || value is decimal)
-                sb.AppendFormat(@"""{0}"":{1}", name, value);
+                sb.AppendFormat(@"""{0}"":{1}", name, Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture));
             else if (value is bool)
                 sb.AppendFormat(@"""{0}"":{1}", name, value.ToString().ToLower());
             else

--- a/test/test.xunit.runner.reporters/JsonExtensionsTests.cs
+++ b/test/test.xunit.runner.reporters/JsonExtensionsTests.cs
@@ -5,7 +5,7 @@ using Xunit.Runner.Reporters;
 
 public class JsonExtensionsTests
 {
-    [Fact]
+    [CulturedFact]
     public void SimpleValues()
     {
         var data = new Dictionary<string, object>


### PR DESCRIPTION
In Russian language evniropment default converter of double/float numbers uses comma (`,`), instead dot (`.`) and JSON will be incorrect. Example:
```
{
    "message": "testPassed",
    "flowId": "d2e1c4f6508847269e92603003bc8c5c",
    "executionTime": 0,0519754,
    "output": ""
}
```
How to reproduce:
```
> WriteLine(String.Format(@"""{0}"":{1}", "executionTime", 0.0519754.ToString(System.Globalization.CultureInfo.GetCultureInfo("ru-RU"))));
"executionTime":0,0519754
```
Correct code variant:
```
> WriteLine(String.Format(@"""{0}"":{1}", "executionTime", 0.0519754.ToString(System.Globalization.CultureInfo.InvariantCulture)));
"executionTime":0.0519754
```