### PR TITLE
Stacktraces to delight

### DIFF
--- a/src/common/ExceptionUtility.cs
+++ b/src/common/ExceptionUtility.cs
@@ -1,5 +1,15 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+#if NET452 || NET35 || NETSTANDARD2_0
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+#if NET452 || NETSTANDARD2_0
+using System.Runtime.ExceptionServices;
+#endif
+using System.Text;
+#endif
 using Xunit.Abstractions;
 
 #if XUNIT_FRAMEWORK
@@ -169,10 +179,10 @@ namespace Xunit
         static void ConvertExceptionToFailureInformation(Exception ex, int parentIndex, List<string> exceptionTypes, List<string> messages, List<string> stackTraces, List<int> indices)
         {
             var myIndex = exceptionTypes.Count;
-
+            
             exceptionTypes.Add(ex.GetType().FullName);
             messages.Add(ex.Message);
-            stackTraces.Add(ex.StackTrace);
+            stackTraces.Add(ex.GetCleanStackTrace());
             indices.Add(parentIndex);
 
 #if XUNIT_FRAMEWORK
@@ -194,5 +204,384 @@ namespace Xunit
             public int[] ExceptionParentIndices { get; set; }
         }
 
+        static string GetCleanStackTrace(this Exception exception)
+        {
+#if !(NET452 || NETSTANDARD2_0)
+            return exception.StackTrace;
+#else
+            var stackTrace = new System.Diagnostics.StackTrace(exception, true);
+            var stackFrames = stackTrace.GetFrames();
+
+            if (stackFrames == null)
+            {
+                return exception.StackTrace;
+            }
+
+            var isFirst = true;
+            var builder = new StringBuilder();
+            for (var i = 0; i < stackFrames.Length; i++)
+            {
+                var frame = stackFrames[i];
+                var method = frame.GetMethod();
+
+                // Always show last stackFrame
+                if (!ShowInStackTrace(method) && i < stackFrames.Length - 1)
+                {
+                    continue;
+                }
+
+                if (isFirst)
+                {
+                    isFirst = false;
+                }
+                else
+                {
+                    builder.AppendLine();
+                }
+
+                builder.Append("   at ");
+
+                AppendStackLine(builder, frame.GetMethod());
+
+                try
+                {
+                    var fileName = frame.GetFileName();
+                    if (fileName != null)
+                    {
+                        // tack on " in c:\tmp\MyFile.cs:line 5"
+                        builder.AppendFormat(CultureInfo.InvariantCulture, " in {0}:line {1}", fileName, frame.GetFileLineNumber());
+                    } 
+                }
+                catch { }
+            }
+
+            return builder.ToString();
+#endif
+        }
+
+#if NET452 || NETSTANDARD2_0
+        static bool ShowInStackTrace(MethodBase method)
+        {
+            // Don't show any methods marked with the StackTraceHiddenAttribute
+            // https://github.com/dotnet/coreclr/pull/14652
+            foreach (var attibute in method.CustomAttributes)
+            {
+                // internal Attribute, match on name
+                if (attibute.AttributeType.Name == "StackTraceHiddenAttribute")
+                {
+                    return false;
+                }
+            }
+
+            var type = method.DeclaringType;
+            if (type == null)
+            {
+                return true;
+            }
+
+            foreach (var attibute in type.CustomAttributes)
+            {
+                // internal Attribute, match on name
+                if (attibute.AttributeType.Name == "StackTraceHiddenAttribute")
+                {
+                    return false;
+                }
+            }
+
+            // Fallbacks for runtime pre-StackTraceHiddenAttribute
+            if (type == typeof(ExceptionDispatchInfo) && method.Name == "Throw")
+            {
+                return false;
+            }
+
+            if (type == typeof(TaskAwaiter) || 
+                type == typeof(TaskAwaiter<>) ||
+                type == typeof(ConfiguredTaskAwaitable.ConfiguredTaskAwaiter) ||
+                type == typeof(ConfiguredTaskAwaitable<>.ConfiguredTaskAwaiter))
+            {
+                switch (method.Name)
+                {
+                    case "HandleNonSuccessAndDebuggerNotification":
+                    case "ThrowForNonSuccess":
+                    case "ValidateEnd":
+                    case "GetResult":
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static void AppendStackLine(StringBuilder builder, MethodBase method)
+        {
+            // Special case: no method available
+            if (method == null)
+            {
+                return;
+            }
+
+            // Type name
+            var type = method.DeclaringType;
+
+            var methodName = method.Name;
+            var subMethod = String.Empty;
+            if (type != null && type.IsDefined(typeof(CompilerGeneratedAttribute)) &&
+                (typeof(IAsyncStateMachine).IsAssignableFrom(type) || typeof(IEnumerator).IsAssignableFrom(type)))
+            {
+                // Convert StateMachine methods to correct overload +MoveNext()
+                if (TryResolveStateMachineMethod(ref method, out type))
+                {
+                    subMethod = methodName;
+                }
+            }
+
+            // ResolveStateMachineMethod may have set declaringType to null
+            if (type != null)
+            {
+                builder
+                    .Append(TypeNameHelper.GetTypeDisplayName(type))
+                    .Append(".");
+            }
+
+            // Method name
+            builder.Append(method.Name);
+
+            // Generic arguments
+            var isFirst = true;
+            if (method.IsGenericMethod)
+            {
+                builder.Append("<");
+
+                foreach (var genericArgument in method.GetGenericArguments())
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        builder.Append(", ");
+                    }
+
+                    builder.Append(genericArgument);
+                }
+
+                builder.Append(">");
+            }
+
+            // Method parameters
+            isFirst = true;
+            builder.Append("(");
+            foreach (var parameter in method.GetParameters())
+            {
+                if (isFirst)
+                {
+                    isFirst = false;
+                }
+                else
+                {
+                    builder.Append(", ");
+                }
+
+                var parameterType = parameter.ParameterType;
+                if (parameter.IsOut)
+                {
+                    builder.Append("out ");
+                }
+                else if (parameterType != null && parameterType.IsByRef)
+                {
+                    builder.Append("ref");
+                }
+
+                if (parameterType != null)
+                {
+                    if (parameterType.IsByRef)
+                    {
+                        parameterType = parameterType.GetElementType();
+                    }
+
+                    builder.Append(TypeNameHelper.GetTypeDisplayName(parameterType, fullName: false));
+                }
+                else
+                {
+                    builder.Append("?");
+                }
+
+                builder.Append(parameter.Name);
+            }
+            builder.Append(")");
+
+            // Append statemachine submethod
+            if (!string.IsNullOrEmpty(subMethod))
+            {
+                builder.Append("+");
+                builder.Append(subMethod);
+                builder.Append("()");
+            }
+        }
+
+        static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
+        {
+            declaringType = method.DeclaringType;
+
+            var parentType = declaringType.DeclaringType;
+            if (parentType == null)
+            {
+                return false;
+            }
+
+            var methods = parentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            if (methods == null)
+            {
+                return false;
+            }
+
+            foreach (var candidateMethod in methods)
+            {
+                var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>();
+                if (attributes == null)
+                {
+                    continue;
+                }
+
+                foreach (var asma in attributes)
+                {
+                    if (asma.StateMachineType == declaringType)
+                    {
+                        method = candidateMethod;
+                        declaringType = candidateMethod.DeclaringType;
+                        // Mark the iterator as changed; so it gets the + annotation of the original method
+                        // async statemachines resolve directly to their builder methods so aren't marked as changed
+                        return asma is IteratorStateMachineAttribute;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        // From: https://github.com/aspnet/Common Microsoft.Extensions.StackTrace.Sources
+        internal class TypeNameHelper
+        {
+            private static readonly Dictionary<Type, string> _builtInTypeNames = new Dictionary<Type, string>
+            {
+            { typeof(bool), "bool" },
+            { typeof(byte), "byte" },
+            { typeof(char), "char" },
+            { typeof(decimal), "decimal" },
+            { typeof(double), "double" },
+            { typeof(float), "float" },
+            { typeof(int), "int" },
+            { typeof(long), "long" },
+            { typeof(object), "object" },
+            { typeof(sbyte), "sbyte" },
+            { typeof(short), "short" },
+            { typeof(string), "string" },
+            { typeof(uint), "uint" },
+            { typeof(ulong), "ulong" },
+            { typeof(ushort), "ushort" }
+            };
+
+            public static string GetTypeDisplayName(object item, bool fullName = true)
+            {
+                return item == null ? null : GetTypeDisplayName(item.GetType(), fullName);
+            }
+
+            public static string GetTypeDisplayName(Type type, bool fullName = true)
+            {
+                var sb = new StringBuilder();
+                ProcessTypeName(type, sb, fullName);
+                return sb.ToString();
+            }
+
+            static void AppendGenericArguments(Type[] args, int startIndex, int numberOfArgsToAppend, StringBuilder sb, bool fullName)
+            {
+                var totalArgs = args.Length;
+                if (totalArgs >= startIndex + numberOfArgsToAppend)
+                {
+                    sb.Append("<");
+                    for (int i = startIndex; i < startIndex + numberOfArgsToAppend; i++)
+                    {
+                        ProcessTypeName(args[i], sb, fullName);
+                        if (i + 1 < startIndex + numberOfArgsToAppend)
+                        {
+                            sb.Append(", ");
+                        }
+                    }
+                    sb.Append(">");
+                }
+            }
+
+            static void ProcessTypeName(Type t, StringBuilder sb, bool fullName)
+            {
+                if (t.IsGenericType)
+                {
+                    ProcessNestedGenericTypes(t, sb, fullName);
+                    return;
+                }
+                if (_builtInTypeNames.ContainsKey(t))
+                {
+                    sb.Append(_builtInTypeNames[t]);
+                }
+                else
+                {
+                    sb.Append(fullName ? t.FullName : t.Name);
+                }
+            }
+
+            static void ProcessNestedGenericTypes(Type t, StringBuilder sb, bool fullName)
+            {
+                var genericFullName = t.GetGenericTypeDefinition().FullName;
+                var genericSimpleName = t.GetGenericTypeDefinition().Name;
+                var parts = genericFullName.Split('+');
+                var genericArguments = t.GenericTypeArguments;
+                var index = 0;
+                var totalParts = parts.Length;
+                if (totalParts == 1)
+                {
+                    var part = parts[0];
+                    var num = part.IndexOf('`');
+                    if (num == -1) return;
+
+                    var name = part.Substring(0, num);
+                    var numberOfGenericTypeArgs = int.Parse(part.Substring(num + 1));
+                    sb.Append(fullName ? name : genericSimpleName.Substring(0, genericSimpleName.IndexOf('`')));
+                    AppendGenericArguments(genericArguments, index, numberOfGenericTypeArgs, sb, fullName);
+                    return;
+                }
+                for (var i = 0; i < totalParts; i++)
+                {
+                    var part = parts[i];
+                    var num = part.IndexOf('`');
+                    if (num != -1)
+                    {
+                        var name = part.Substring(0, num);
+                        var numberOfGenericTypeArgs = int.Parse(part.Substring(num + 1));
+                        if (fullName || i == totalParts - 1)
+                        {
+                            sb.Append(name);
+                            AppendGenericArguments(genericArguments, index, numberOfGenericTypeArgs, sb, fullName);
+                        }
+                        if (fullName && i != totalParts - 1)
+                        {
+                            sb.Append("+");
+                        }
+                        index += numberOfGenericTypeArgs;
+                    }
+                    else
+                    {
+                        if (fullName || i == totalParts - 1)
+                        {
+                            sb.Append(part);
+                        }
+                        if (fullName && i != totalParts - 1)
+                        {
+                            sb.Append("+");
+                        }
+                    }
+                }
+            }
+        }
+#endif
     }
 }

--- a/src/xunit.execution/Properties/AssemblyInfo.cs
+++ b/src/xunit.execution/Properties/AssemblyInfo.cs
@@ -6,6 +6,8 @@ using Xunit.Sdk;
 [assembly: AssemblyTitle("xUnit.net Execution (desktop)")]
 #elif NETSTANDARD1_1
 [assembly: AssemblyTitle("xUnit.net Execution (dotnet)")]
+#elif NETSTANDARD2_0
+[assembly: AssemblyTitle("xUnit.net Execution (dotnet)")]
 #else
 #error Unknown target platform
 #endif

--- a/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionAssemblyInfo.cs
@@ -42,7 +42,7 @@ namespace Xunit.Sdk
         {
             get
             {
-#if NETSTANDARD1_1
+#if NETSTANDARD1_1 || NETSTANDARD2_0
                 return Assembly.GetName().Name + ".dll";  // Make sure we only use the short form
 #else
                 return Assembly.GetLocalCodeBase();

--- a/src/xunit.execution/xunit.execution.csproj
+++ b/src/xunit.execution/xunit.execution.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.1;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);XUNIT_FRAMEWORK</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Xunit.Sdk</RootNamespace>
@@ -37,6 +37,9 @@
     <AssemblyName>xunit.execution.desktop</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <AssemblyName>xunit.execution.dotnet</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <AssemblyName>xunit.execution.dotnet</AssemblyName>
   </PropertyGroup>
 </Project>

--- a/src/xunit.runner.utility/Frameworks/VisualStudioSourceInformationProvider.cs
+++ b/src/xunit.runner.utility/Frameworks/VisualStudioSourceInformationProvider.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_1
+﻿#if !(NETSTANDARD1_1 || NETSTANDARD2_0)
 
 using Xunit.Abstractions;
 

--- a/src/xunit.runner.utility/Frameworks/XunitFrontController.cs
+++ b/src/xunit.runner.utility/Frameworks/XunitFrontController.cs
@@ -60,7 +60,7 @@ namespace Xunit
 
             if (this.sourceInformationProvider == null)
             {
-#if NETSTANDARD1_1
+#if NETSTANDARD1_1 || NETSTANDARD2_0
                 this.sourceInformationProvider = new NullSourceInformationProvider();
 #else
                 this.sourceInformationProvider = new VisualStudioSourceInformationProvider(assemblyFileName);

--- a/src/xunit.runner.utility/Properties/AssemblyInfo.cs
+++ b/src/xunit.runner.utility/Properties/AssemblyInfo.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 [assembly: AssemblyTitle("xUnit.net Runner Utility (.NET Standard 1.1)")]
 #elif NETSTANDARD1_5
 [assembly: AssemblyTitle("xUnit.net Runner Utility (.NET Standard 1.5)")]
+#elif NETSTANDARD2_0
+[assembly: AssemblyTitle("xUnit.net Runner Utility (.NET Standard 2.0)")]
 #elif NETCOREAPP1_0
 [assembly: AssemblyTitle("xUnit.net Runner Utility (.NET Core 1.0)")]
 #else

--- a/src/xunit.runner.utility/xunit.runner.utility.csproj
+++ b/src/xunit.runner.utility/xunit.runner.utility.csproj
@@ -9,7 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Xunit</RootNamespace>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.0</RuntimeFrameworkVersion>
-    <TargetFrameworks>net35;net452;netstandard1.1;netstandard1.5;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net35;net452;netstandard1.1;netstandard1.5;netcoreapp1.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\common\AssemblyExtensions.cs" LinkBase="Common" />

--- a/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunnerTests.cs
+++ b/test/test.xunit.execution/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunnerTests.cs
@@ -45,7 +45,7 @@ public class XunitTheoryTestCaseRunnerTests
         Assert.Equal("Display Name", failed.Test.DisplayName);
         Assert.Equal("System.DivideByZeroException", failed.ExceptionTypes.Single());
         Assert.Equal("Attempted to divide by zero.", failed.Messages.Single());
-        Assert.Contains("XunitTheoryTestCaseRunnerTests.ClassUnderTest.get_ThrowingData()", failed.StackTraces.Single());
+        Assert.Contains("XunitTheoryTestCaseRunnerTests+ClassUnderTest.get_ThrowingData()", failed.StackTraces.Single());
     }
 
     [Fact]

--- a/test/test.xunit.runner.tdnet/Visitors/ResultVisitorTests.cs
+++ b/test/test.xunit.runner.tdnet/Visitors/ResultVisitorTests.cs
@@ -220,7 +220,8 @@ public class ResultVisitorTests
             Assert.Equal(123.45, testResult.TimeSpan.TotalMilliseconds);
             Assert.Equal(42, testResult.TotalTests);
             Assert.Equal("System.Exception : " + ex.Message, testResult.Message);
-            Assert.Equal(ex.StackTrace, testResult.StackTrace);
+            // Depending on runtime StackTrace may differ by +Method vs .Method so normalize
+            Assert.Equal(ex.StackTrace.Replace("+", "."), testResult.StackTrace.Replace("+", "."));
         }
 
         [Fact]


### PR DESCRIPTION
For `NET452` and `NETSTANDARD2_0` focus on the call stack and methods rather than compiler and task noise

Resolves generics; converts il entries to C#

Drops
```
--- End of stack trace from previous location where exception was thrown ---
--- End of stack trace from previous location where exception was thrown ---
--- End of stack trace from previous location where exception was thrown ---
```
Drops
```
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() in ExceptionServicesCommon.cs
System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) in TaskAwaiter.cs
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) in TaskAwaiter.cs
System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task) in TaskAwaiter.cs
System.Runtime.CompilerServices.TaskAwaiter.GetResult() in TaskAwaiter.cs
```
De-garbles iterators and async

From
```
Program.<Iterator>d__4.MoveNext()
Microsoft.AspNetCore.Mvc.Razor.RazorView+<RenderPageAsync>d__15.MoveNext()
```
To
```
Program.Iterator(long count, int value)+MoveNext()
Microsoft.AspNetCore.Mvc.Razor.RazorView.RenderPageAsync(IRazorPage page, ViewContext context, bool invokeViewStarts)
```

Don't need to merge was an academic exploration :)