### PR TITLE
Adding IsPackable to xunit.core.props to allow consuming projects to be packable

### DIFF
--- a/src/xunit.core/build/xunit.core.props
+++ b/src/xunit.core/build/xunit.core.props
@@ -7,7 +7,8 @@
 
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
-    <IsTestProject>true</IsTestProject>
+    <IsTestProject>true</IsTestProject>    
+    <IsPackable>true</IsPackable> <!-- Setting IsTestProject prevents consuming projects from being packed unless IsPackable is set.-->
   </PropertyGroup>
 
   <!-- Support for importing props via the runner -->


### PR DESCRIPTION
Fixes: https://github.com/xunit/xunit/issues/1624

Setting `<IsTestProject>true</IsTestProject>` prevents consuming projects to be packed based on NuGet pack [logic](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L33).

This PR adds a new property - `<IsPackable>true</IsPackable>`. This property will aloow the package consumers to be able to pack their projects.