### PR TITLE
Remove UWP test platform v1 wokarounds. 

### DIFF
--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -20,9 +20,6 @@
   <files>
     <file src="xunit.core\build\xunit.core.props"                                             target="build\" />
     <file src="xunit.core\build\xunit.core.targets"                                           target="build\" />
-    <file src="xunit.execution\bin\$Configuration$\net452\xunit.execution.desktop.dll"        target="build\" />
-    <file src="xunit.execution\bin\$Configuration$\netstandard1.1\xunit.execution.dotnet.dll" target="build\" />
-
     <file src="xunit.core\build\xunit.core.props"   target="buildMultiTargeting\" />
     <file src="xunit.core\build\xunit.core.targets" target="buildMultiTargeting\" />
   </files>

--- a/src/xunit.core/build/xunit.core.targets
+++ b/src/xunit.core/build/xunit.core.targets
@@ -15,35 +15,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <UnitTestPlatformVersion Condition=" '$(UnitTestPlatformVersion)' == '' ">$(VisualStudioVersion)</UnitTestPlatformVersion>
-  </PropertyGroup>
-
-  <Choose>
-    <When Condition=" '$(UnitTestPlatformVersion)' &gt;= '15.5' ">
-      <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'UAP' ">
-        <None Include="$(MSBuildThisFileDirectory)xunit.execution.dotnet.dll">
-          <Link>xunit.execution.dotnet.dll</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Visible>False</Visible>
-        </None>
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <!-- UWP in TPv1 does discovery in desktop CLR, so needs desktop execution library (and full PDBs) -->
-      <PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == 'UAP' ">
-        <DebugType Condition=" '$(DebugType)' == '' ">full</DebugType>
-      </PropertyGroup>
-      <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'UAP' ">
-        <None Include="$(MSBuildThisFileDirectory)xunit.execution.desktop.dll">
-          <Link>xunit.execution.desktop.dll</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-          <Visible>False</Visible>
-        </None>
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
   <!-- Support for importing targets via the runner -->
   <Import Condition=" '$(_Xunit_ImportTargetsFile)' != '' " Project="$(_Xunit_ImportTargetsFile)" />
 


### PR DESCRIPTION
This removes the hacks needed for UWP test platform v1 with the desktop adapter.

Also fixes 

```
/Users/.../.nuget/packages/xunit.core/2.4.0-beta.1.build3958/buildMultiTargeting/xunit.core.targets(23,11): error MSB4086: A numeric comparison was attempted on "$(UnitTestPlatformVersion)" that evaluates to "" instead of a number, in condition " '$(UnitTestPlatformVersion)' >= '15.5' ". [/Users/…/Git/…/src/Testing.Common/Testing.Common.csproj]
Build failed!
```

Since the current logic was assuming `VisualStudioVersion` being set
