### PR TITLE
xunit.vs.runner to support managed sources only

### DIFF
--- a/src/xunit.runner.visualstudio/VsTestRunner.cs
+++ b/src/xunit.runner.visualstudio/VsTestRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -23,6 +24,9 @@ namespace Xunit.Runner.VisualStudio
     [FileExtension(".exe")]
     [DefaultExecutorUri(Constants.ExecutorUri)]
     [ExtensionUri(Constants.ExecutorUri)]
+#if !WINDOWS_UAP
+    [Category("managed")]
+#endif
     public class VsTestRunner : ITestDiscoverer, ITestExecutor
     {
         static IRunnerReporter[] NoReporters = new IRunnerReporter[0];

--- a/test/test.xunit.runner.visualstudio/RunnerReporterTests.cs
+++ b/test/test.xunit.runner.visualstudio/RunnerReporterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -77,5 +78,13 @@ public class RunnerReporterTests
 
         Assert.Equal(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporter.GetType().AssemblyQualifiedName);
         logger.Received(1).SendMessage(TestMessageLevel.Warning, "[xUnit.net 00:00:00] Could not find requested reporter 'thisnotavalidreporter'");
+    }
+
+    [Fact]
+    public void VSTestRunnerShouldHaveCategoryAttribute_WithValueManaged()
+    {
+        var attribute = typeof(VsTestRunner).GetCustomAttribute(typeof(CategoryAttribute));
+        Assert.NotNull(attribute);
+        Assert.Equal("managed", (attribute as CategoryAttribute)?.Category);
     }
 }


### PR DESCRIPTION
Following RFC: https://github.com/Microsoft/vstest-docs/blob/master/RFCs/0020-Improving-Logic-To-Pass-Sources-To-Adapters.md