### PR TITLE
Adding transformation for JUnit XML output, as documented in #1200.

### DIFF
--- a/src/dotnet-xunit/Program.cs
+++ b/src/dotnet-xunit/Program.cs
@@ -10,7 +10,7 @@ using Xunit;
 class Program
 {
     static HashSet<string> HelpArgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "-?", "/?", "-h", "--help" };
-    static HashSet<string> OutputFileArgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "-xml", "-xmlv1", "-nunit", "-html" };
+    static HashSet<string> OutputFileArgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "-xml", "-xmlv1", "-nunit", "-html", "-junit" };
     static Version Version452 = new Version("4.5.2");
 
     string BuildStdProps;
@@ -268,6 +268,7 @@ class Program
         Console.WriteLine("  -xmlv1 <filename>      : output results to xUnit.net v1 XML file");
         Console.WriteLine("  -nunit <filename>      : output results to NUnit v2.5 XML file");
         Console.WriteLine("  -html <filename>       : output results to HTML file");
+        Console.WriteLine("  -junit <filename>      : output results to JUnit XML file");
     }
 
     int RunTargetFramework(string testProject, string targetFramework, bool amendOutputFileNames)

--- a/src/xunit.console/JUnitXml.xslt
+++ b/src/xunit.console/JUnitXml.xslt
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output cdata-section-elements="message stack-trace"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="assemblies">
+    <testsuites name="Test results">
+      <xsl:attribute name="time">
+        <xsl:value-of select="sum(assembly/@time)"/>
+      </xsl:attribute>
+      <xsl:attribute name="tests">
+        <xsl:value-of select="sum(assembly/@total)"/>
+      </xsl:attribute>
+      <xsl:attribute name="failures">
+        <xsl:value-of select="sum(assembly/@failed)"/>
+      </xsl:attribute>
+      <properties>
+        <property name="skipped">
+          <xsl:attribute name="value">
+            <xsl:value-of select="sum(assembly/@skipped)"/>
+          </xsl:attribute>
+        </property>
+        <property name="date">
+          <xsl:attribute name="value">
+            <xsl:value-of select="assembly[1]/@run-date"/>
+          </xsl:attribute>
+        </property>
+        <property name="nunit-version">
+          <xsl:attribute name="value">
+            <xsl:value-of select="assembly[1]/@test-framework"/>
+          </xsl:attribute>
+        </property>
+        <property name="clr-version">
+          <xsl:attribute name="value">
+            <xsl:value-of select="assembly[1]/@environment"/>
+          </xsl:attribute>
+        </property>
+        <property name="date">
+          <xsl:attribute name="value">
+            <xsl:value-of select="assembly[1]/@run-date"/>
+          </xsl:attribute>
+        </property>
+        <xsl:if test="sum(assembly/@failed) > 0">
+          <property name="result" value="Failure" />
+        </xsl:if>
+        <xsl:if test="sum(assembly/@failed) = 0">
+          <property name="result" value="Success" />
+        </xsl:if>
+      </properties>
+      <xsl:apply-templates select="assembly/collection"/>
+    </testsuites>
+  </xsl:template>
+
+  <xsl:template match="collection">
+    <testsuite>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <xsl:attribute name="tests">
+        <xsl:value-of select="@total"/>
+      </xsl:attribute>
+      <xsl:attribute name="failures">
+        <xsl:value-of select="@failed"/>
+      </xsl:attribute>
+      <xsl:apply-templates select="test"/>
+    </testsuite>
+  </xsl:template>
+
+  <xsl:template match="test">
+    <testcase>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:if test="@time">
+        <xsl:attribute name="time">
+          <xsl:value-of select="@time"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="failure"/>
+    </testcase>
+  </xsl:template>
+
+  <xsl:template match="failure">
+    <failure>
+      <xsl:attribute name="type">
+        <xsl:value-of select="@exception-type"/>
+      </xsl:attribute>
+      <xsl:if test="message">
+        <xsl:attribute name="message">
+          <xsl:value-of select="message"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="stack-trace">
+        <xsl:value-of select="stack-trace"/>
+      </xsl:if>
+    </failure>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/xunit.console/Utility/TransformFactory.cs
+++ b/src/xunit.console/Utility/TransformFactory.cs
@@ -40,6 +40,12 @@ namespace Xunit.ConsoleClient
                 Description = "output results to NUnit v2.5 XML file",
                 OutputHandler = (xml, outputFileName) => Handler_XslTransform("nunit", "NUnitXml.xslt", xml, outputFileName)
             });
+            availableTransforms.Add("junit", new Transform
+            {
+                CommandLine = "junit",
+                Description = "output results to JUnit XML file",
+                OutputHandler = (xml, outputFileName) => Handler_XslTransform("junit", "JUnitXml.xslt", xml, outputFileName)
+            });
         }
 
         public static List<Transform> AvailableTransforms

--- a/src/xunit.console/xunit.console.csproj
+++ b/src/xunit.console/xunit.console.csproj
@@ -20,6 +20,7 @@
     <EmbeddedResource Include="HTML.xslt" />
     <EmbeddedResource Include="NUnitXml.xslt" />
     <EmbeddedResource Include="xUnit1.xslt" />
+    <EmbeddedResource Include="JUnitXml.xslt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/xunit.runner.msbuild/xunit.cs
+++ b/src/xunit.runner.msbuild/xunit.cs
@@ -67,7 +67,7 @@ namespace Xunit.Runner.MSBuild
         public string MaxParallelThreads { get; set; }
 
         protected bool NeedsXml
-            => Xml != null || XmlV1 != null || Html != null || NUnit != null;
+            => Xml != null || XmlV1 != null || Html != null || NUnit != null || JUnit != null;
 
         public bool NoAutoReporters { get; set; }
 
@@ -93,6 +93,8 @@ namespace Xunit.Runner.MSBuild
         public ITaskItem Xml { get; set; }
 
         public ITaskItem XmlV1 { get; set; }
+
+        public ITaskItem JUnit { get; set; }
 
         public void Cancel()
         {
@@ -239,6 +241,9 @@ namespace Xunit.Runner.MSBuild
 
                 if (NUnit != null)
                     CrossPlatform.Transform(logger, "NUnit", "NUnitXml.xslt", assembliesElement, NUnit);
+
+                if (JUnit != null)
+                    CrossPlatform.Transform(logger, "JUnit", "JUnitXml.xslt", assembliesElement, NUnit);
             }
 
             // ExitCode is set to 1 for test failures and -1 for Exceptions.


### PR DESCRIPTION
In #1200 XSL-T support was added. One feature request mentioned was support for generating JUnit XML files. This PR adds just that, following the instructions mentioned in that issue.

The transformation is largely based on https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_14.1.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html and http://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd 

This should help support certain CI systems, in my case with BitBucket Pipelines which only accepts test files in this particular format.