### PR TITLE
Allow to inject IMessageSink into ClassFixture/CollectionFixture (#565)

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestClassRunner.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestClassRunner.cs
@@ -75,6 +75,9 @@ namespace Xunit.Sdk
             var ctorArgs = ctor.GetParameters().Select(p =>
             {
                 object arg;
+                if (p.ParameterType == typeof(IMessageSink))
+                    arg = DiagnosticMessageSink;
+                else 
                 if (!collectionFixtureMappings.TryGetValue(p.ParameterType, out arg))
                     missingParameters.Add(p);
                 return arg;


### PR DESCRIPTION
Added possibility to use DiagnosticMessageSink in ClassFixture.

I also changed a little bit current implementation of CollectionFixture creation to meet more or less ClassFixtures mechanism