### PR TITLE
Update MyGet links to use HTTPS instead of HTTP

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="myget.org/F/xunit" value="http://www.myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
-    <add key="myget.org/F/b4ff5f6" value="http://www.myget.org/F/b4ff5f68eccf4f6bbfed74f055f88d8f/api/v3/index.json" protocolVersion="3" />
+    <add key="myget.org/F/xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
+    <add key="myget.org/F/b4ff5f6" value="https://www.myget.org/F/b4ff5f68eccf4f6bbfed74f055f88d8f/api/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fixes the following message in Visual Studio 15.8 Preview 2:

> Error occurred while restoring NuGet packages: Unable to get repository signature information for source https://www.myget.org/F/xunit/api/v3/repository-signatures/index.json.

📝 If accepted, please do not rebase or squash this pull request during the merge.