### PR TITLE
Exclude byreflike types from type conversion

### DIFF
--- a/src/xunit.execution/Sdk/TypeUtility.cs
+++ b/src/xunit.execution/Sdk/TypeUtility.cs
@@ -158,16 +158,41 @@ namespace Xunit.Sdk
 
             // Check if we can implicitly convert the argument type to the parameter type
             var implicitMethod = conversionDeclaringType.GetRuntimeMethod("op_Implicit", methodTypes);
+#if FEATURE_REFLECTION
+            if (implicitMethod != null && implicitMethod.IsStatic && !IsByRefLikeType(implicitMethod.ReturnType))
+#else
             if (implicitMethod != null && implicitMethod.IsStatic)
+#endif
                 return implicitMethod.Invoke(null, methodArguments);
 
             // Check if we can explicitly convert the argument type to the parameter type
             var explicitMethod = conversionDeclaringType.GetRuntimeMethod("op_Explicit", methodTypes);
+#if FEATURE_REFLECTION
+            if (explicitMethod != null && explicitMethod.IsStatic && !IsByRefLikeType(explicitMethod.ReturnType))
+#else
             if (explicitMethod != null && explicitMethod.IsStatic)
+#endif
                 return explicitMethod.Invoke(null, methodArguments);
 
             return null;
         }
+
+#if FEATURE_REFLECTION
+        private static bool IsByRefLikeType(Type type)
+        {
+            object val = type.GetType()
+                .GetProperty("IsByRefLike", BindingFlags.Instance | BindingFlags.Public)
+                ?.GetValue(type);
+
+            if (val is bool isByRefLike)
+            {
+                return isByRefLike;
+            }
+
+            // The type can't be a byreflike type if the property doesn't exist.
+            return false;
+        }
+#endif
 
         /// <summary>
         /// Formulates the extended portion of the display name for a test method. For tests with no arguments, this will

--- a/src/xunit.execution/xunit.execution.csproj
+++ b/src/xunit.execution/xunit.execution.csproj
@@ -5,6 +5,7 @@
     <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard1.1' ">xunit.execution.dotnet</AssemblyName>
     <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard2.0' ">xunit.execution.dotnet</AssemblyName>
     <DefineConstants>$(DefineConstants);XUNIT_FRAMEWORK</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.1'">$(DefineConstants);FEATURE_REFLECTION</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Xunit.Sdk</RootNamespace>
     <TargetFrameworks>net452;netstandard1.1;netstandard2.0</TargetFrameworks>


### PR DESCRIPTION
Fixes https://github.com/xunit/xunit/issues/1781
Fixes https://github.com/xunit/xunit/issues/1788

With netcoreapp2.1 we added implicit conversions between string and `ReadOnlySpan<char>` which are picked here and tried to be invoked. The execution fails as ByRefLike Types aren't currently supported to be invoked by `MethodInfo.Invoke`. The error currently doesn't happen on .NET Framework as we haven't yet added these implicit conversions there.

This approach uses reflection as the `Type.ByRefLike` property isn't exposed in .NET Standard. It will probably be included with .NET Standard vNext.

cc @jkotas @bradwilson @onovotny 