### PR TITLE
Update NUnitXml.xslt to emit properties element before reason/failure

### DIFF
--- a/src/xunit.console/NUnitXml.xslt
+++ b/src/xunit.console/NUnitXml.xslt
@@ -128,6 +128,7 @@
           <xsl:value-of select="@time"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:apply-templates select="traits"/>
       <xsl:if test="reason">
         <reason>
           <message>
@@ -135,7 +136,6 @@
           </message>
         </reason>
       </xsl:if>
-      <xsl:apply-templates select="traits"/>
       <xsl:apply-templates select="failure"/>
     </test-case>
   </xsl:template>


### PR DESCRIPTION
The NUnit 2.5 schema at http://nunit.org/files/testresult_schema_25.txt specifies
that the test-case element should look like this:

```xml
<xs:complexType name="test-caseType">
    <xs:sequence>
        <xs:element name="categories" type="categoriesType" minOccurs="0" maxOccurs="1" />
        <xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1" />
        <xs:choice>
            <xs:element name="failure" type="failureType" minOccurs="0" />
            <xs:element name="reason" type="reasonType" minOccurs="0" />
        </xs:choice>
    </xs:sequence>
    <xs:attribute name="name" type="xs:string" use="required" />
    ...
```

The usage of xs:sequence means categories, properties and failure/reason elements
need to be emitted in exactly that order.

Currently NUnitXml.xslt however emits the properties _after_ the reason element.

This fixes the xslt to emit properties in the expected order.

---

We noticed this because (for reasons ...) we emit xunit test results in NUnit format and parse it with the popular Jenkins [xunit plugin](https://plugins.jenkins.io/xunit) (name similarity is just coincidence, the plugin supports multiple xml formats). That plugin had an update where it enforced the NUnit schema more stringently than before and this broke the parsing:

```
WARNING: At line 7609 of file:/home/builder/jenkins/workspace/test-mono-mainline-2018-04/label/debian-9-arm64/mcs/class/corlib/TestResult-net_4_x-xunit.xml:
  cvc-complex-type.2.4.d: Invalid content was found starting with element 'properties'. No child element is expected at this point.
```

It'd be nice if this could make the 2.4.1 release.