### PR TITLE
Prevent a first-chance FileNotFoundException.

### DIFF
--- a/src/xunit.runner.utility/Configuration/ConfigReader_Json.cs
+++ b/src/xunit.runner.utility/Configuration/ConfigReader_Json.cs
@@ -138,6 +138,13 @@ namespace Xunit
         {
             try
             {
+                // Prevent a first-chance FileNotFoundException if the file doesn't exist.
+                // Happens twice when debugging a single test with first-chance exceptions on.
+#if !NETSTANDARD1_1
+                if (!File.Exists(configFileName))
+                    return null;
+#endif
+
                 using (var stream = File_OpenRead(configFileName))
                     return Load(stream);
             }


### PR DESCRIPTION
When an xunit test is being debugged with first-chance exceptions on we get two exceptions before the test even starts running. These are benign, but given how it takes time for the debugger to stop, show the exception helper and restart, twice, it takes away anywhere between 10s and 50s for each debugging session.

One can of course turn off breaking on FileNotFoundExceptions, but if the test happens to be testing a file-system related feature where we actually look for FileNotFoundExceptions it quickly becomes really impractical.

NetStandard 1.1 doesn't seem to have File.Exists, but even solving this for 4.5.2 and other platforms would be a huge improvement to the debugging story. Probably not worth using reflection to get this for netstandard 1.1.

Would be nice to fix especially because otherwise xunit is clean in terms of first-chance exceptions (some runners add their own of course, but we can deal with them separately).

You decide whether to take this but I'd be jumping with joy if this makes it in.