### PR TITLE
Add reporter flag

### DIFF
--- a/src/xunit.console/CommandLine.cs
+++ b/src/xunit.console/CommandLine.cs
@@ -55,7 +55,9 @@ namespace Xunit.ConsoleClient
 
         public bool Wait { get; protected set; }
 
-        public IRunnerReporter ChooseReporter(IReadOnlyList<IRunnerReporter> reporters)
+        public string Reporter { get; protected set; }
+
+        public IRunnerReporter ChooseReporter(IEnumerable<IRunnerReporter> reporters)
         {
             var result = default(IRunnerReporter);
 
@@ -180,6 +182,13 @@ namespace Xunit.ConsoleClient
                 {
                     GuardNoOptionValue(option);
                     NoAutoReporters = true;
+                }
+                else if (optionName == "reporter")
+                {
+                    if (option.Value == null)
+                        throw new ArgumentException("missing argument for -reporter");
+
+                    Reporter = option.Value;
                 }
 #if DEBUG
                 else if (optionName == "pause")


### PR DESCRIPTION
Adds a reporter flag to xunit.console to only load a specified reporting assembly. This avoids loading all assemblies from the current working directory into memory which can cause a) huge memory consumption depending on the number of assemblies in the same directory and b) FileLoadExceptions if the assembly wasn't meant to be loaded by the runner.

cc @bradwilson 