### PR TITLE
Use ConcurrentDictionary in DependencyContextAssemblyCache

### DIFF
--- a/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs
+++ b/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs
@@ -1,6 +1,7 @@
 ﻿#if NETCOREAPP
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -27,11 +28,11 @@ namespace Xunit
         readonly Lazy<string> fallbackRuntimeIdentifier;
         readonly IFileSystem fileSystem;
         readonly IMessageSink internalDiagnosticsMessageSink;
-        readonly Dictionary<string, Assembly> managedAssemblyCache;
+        readonly ConcurrentDictionary<string, Assembly> managedAssemblyCache;
         readonly Dictionary<string, Tuple<RuntimeLibrary, RuntimeAssetGroup>> managedAssemblyMap;
         readonly Platform operatingSystemPlatform;
         readonly string[] unmanagedDllFormats;
-        readonly Dictionary<string, string> unmanagedAssemblyCache;
+        readonly ConcurrentDictionary<string, string> unmanagedAssemblyCache;
         readonly Dictionary<string, Tuple<RuntimeLibrary, RuntimeAssetGroup>> unmanagedAssemblyMap;
 
         public DependencyContextAssemblyCache(string assemblyFolder,
@@ -59,7 +60,7 @@ namespace Xunit
             if (internalDiagnosticsMessageSink != null)
                 internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache..ctor] Compatible runtimes: [{string.Join(",", compatibleRuntimes.Select(x => $"'{x}'"))}]"));
 
-            managedAssemblyCache = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+            managedAssemblyCache = new ConcurrentDictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
             managedAssemblyMap =
                 dependencyContext.RuntimeLibraries
                                  .Where(lib => lib.RuntimeAssemblyGroups?.Count > 0)
@@ -74,7 +75,7 @@ namespace Xunit
                 internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache..ctor] Managed assembly map: [{string.Join(",", managedAssemblyMap.Keys.Select(k => $"'{k}'").OrderBy(k => k, StringComparer.OrdinalIgnoreCase))}]"));
 
             unmanagedDllFormats = GetUnmanagedDllFormats().ToArray();
-            unmanagedAssemblyCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            unmanagedAssemblyCache = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             unmanagedAssemblyMap =
                 dependencyContext.RuntimeLibraries
                                  .Select(lib => compatibleRuntimes.Select(runtime => Tuple.Create(lib, lib.NativeLibraryGroups.FirstOrDefault(libGroup => string.Equals(libGroup.Runtime, runtime))))


### PR DESCRIPTION
`AssemblyHelper.OnResolving` https://github.com/xunit/xunit/blob/c54cc52ffb275c81afed022521870193bbca6c39/src/common/AssemblyResolution/AssemblyHelper_NetCoreApp.cs#L84

can be called from multiple threads. This can cause hard to reproduce race conditions in `DependencyContextAssemblyCache.LoadManagedDll` modifying underlying `managedAssemblyCache`
https://github.com/xunit/xunit/blob/c54cc52ffb275c81afed022521870193bbca6c39/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs#L156
 For some reason it happens more often on Linux/arm Linux/arm64 (see https://github.com/dotnet/coreclr/issues/20594 and https://github.com/xunit/xunit/issues/1842) but also we also saw this happening on OSX/x64. This problem manifests themselves as `InvalidOperationException` *"Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct."*

This PR switches to using `ConcurrentDictionary` instead of `Dictionary` for `managedAssemblyCache` and `unmanagedAssemblyMap` in `DependencyContextAssemblyCache` to mitigate issue https://github.com/xunit/xunit/issues/1842.