### PR TITLE
Refactor VsTestRunner to support multiple reporters

### DIFF
--- a/src/xunit.runner.visualstudio/Sinks/VsExecutionSink.cs
+++ b/src/xunit.runner.visualstudio/Sinks/VsExecutionSink.cs
@@ -15,18 +15,18 @@ namespace Xunit.Runner.VisualStudio
         readonly Func<bool> cancelledThunk;
         readonly ITestFrameworkExecutionOptions executionOptions;
         readonly LoggerHelper logger;
-        readonly IMessageSinkWithTypes innerSink;
+        readonly IEnumerable<IMessageSinkWithTypes> innerSinks;
         readonly ITestExecutionRecorder recorder;
         readonly Dictionary<string, TestCase> testCasesMap;
 
-        public VsExecutionSink(IMessageSinkWithTypes innerSink,
+        public VsExecutionSink(IEnumerable<IMessageSinkWithTypes> innerSinks,
                                ITestExecutionRecorder recorder,
                                LoggerHelper logger,
                                Dictionary<string, TestCase> testCasesMap,
                                ITestFrameworkExecutionOptions executionOptions,
                                Func<bool> cancelledThunk)
         {
-            this.innerSink = innerSink;
+            this.innerSinks = innerSinks;
             this.recorder = recorder;
             this.logger = logger;
             this.testCasesMap = testCasesMap;
@@ -299,7 +299,8 @@ namespace Xunit.Runner.VisualStudio
 
         public override bool OnMessageWithTypes(IMessageSinkMessage message, HashSet<string> messageTypes)
         {
-            var result = innerSink.OnMessageWithTypes(message, messageTypes);
+            var result = true;
+            innerSinks.ForEach(s => result = result && s.OnMessageWithTypes(message, messageTypes));
             return base.OnMessageWithTypes(message, messageTypes) && result;
         }
     }

--- a/test/test.xunit.runner.visualstudio/RunnerReporterTests.cs
+++ b/test/test.xunit.runner.visualstudio/RunnerReporterTests.cs
@@ -39,9 +39,9 @@ public class RunnerReporterTests
     {
         var settings = new RunSettings { NoAutoReporters = true };
 
-        var runnerReporter = VsTestRunner.GetRunnerReporter(null, settings, new[] { Assembly.GetExecutingAssembly().Location });
+        var runnerReporters = VsTestRunner.GetRunnerReporters(null, settings, new[] { Assembly.GetExecutingAssembly().Location });
 
-        Assert.Equal(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporter.GetType().AssemblyQualifiedName);
+        Assert.Equal(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporters[0].GetType().AssemblyQualifiedName);
     }
 
     [Fact]
@@ -49,12 +49,12 @@ public class RunnerReporterTests
     {
         var settings = new RunSettings { NoAutoReporters = false };
 
-        var runnerReporter = VsTestRunner.GetRunnerReporter(null, settings, new[] { Assembly.GetExecutingAssembly().Location });
+        var runnerReporters = VsTestRunner.GetRunnerReporters(null, settings, new[] { Assembly.GetExecutingAssembly().Location });
 
         // We just make sure _an_ auto-reporter was chosen, but we can't rely on which one because this code
         // wil run when we're in CI, and therefore will choose the CI reporter sometimes. It's good enough
         // that we've provide an option above so that the default never gets chosen.
-        Assert.NotEqual(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporter.GetType().AssemblyQualifiedName);
+        Assert.NotEqual(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporters[0].GetType().AssemblyQualifiedName);
     }
 
     [Fact]
@@ -62,9 +62,9 @@ public class RunnerReporterTests
     {
         var settings = new RunSettings { NoAutoReporters = true, ReporterSwitch = "notautoenabled" };
 
-        var runnerReporter = VsTestRunner.GetRunnerReporter(null, settings, new[] { Assembly.GetExecutingAssembly().Location });
+        var runnerReporters = VsTestRunner.GetRunnerReporters(null, settings, new[] { Assembly.GetExecutingAssembly().Location });
 
-        Assert.Equal(typeof(TestRunnerReporterNotEnabled).AssemblyQualifiedName, runnerReporter.GetType().AssemblyQualifiedName);
+        Assert.Equal(typeof(TestRunnerReporterNotEnabled).AssemblyQualifiedName, runnerReporters[0].GetType().AssemblyQualifiedName);
     }
 
     [Fact]
@@ -74,9 +74,9 @@ public class RunnerReporterTests
         var logger = Substitute.For<IMessageLogger>();
         var loggerHelper = new LoggerHelper(logger, new Stopwatch());
 
-        var runnerReporter = VsTestRunner.GetRunnerReporter(loggerHelper, settings, new[] { Assembly.GetExecutingAssembly().Location });
+        var runnerReporters = VsTestRunner.GetRunnerReporters(loggerHelper, settings, new[] { Assembly.GetExecutingAssembly().Location });
 
-        Assert.Equal(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporter.GetType().AssemblyQualifiedName);
+        Assert.Equal(typeof(DefaultRunnerReporterWithTypes).AssemblyQualifiedName, runnerReporters[0].GetType().AssemblyQualifiedName);
         logger.Received(1).SendMessage(TestMessageLevel.Warning, "[xUnit.net 00:00:00.00] Could not find requested reporter 'thisnotavalidreporter'");
     }
 


### PR DESCRIPTION
Currently VsTestAdapter uses only single reporter to report results. It is not clear which exactly. So this PR tries to use all available reporters.

If we use `dotnet vstest folderA\Tests.dll`, VsTestAdapter tries to use all available reporters in `folderA`. 

It provides a way to put custom reporters near test assembly, so custom reporters can be installed via NuGet.