### PR TITLE
Add classname attribute to testcase in JUnit XSLT

### DIFF
--- a/src/xunit.console/JUnitXml.xslt
+++ b/src/xunit.console/JUnitXml.xslt
@@ -77,6 +77,9 @@
       <xsl:attribute name="name">
         <xsl:value-of select="@name"/>
       </xsl:attribute>
+      <xsl:attribute name="classname">
+        <xsl:value-of select="@type"/>
+      </xsl:attribute>
       <xsl:if test="@time">
         <xsl:attribute name="time">
           <xsl:value-of select="@time"/>


### PR DESCRIPTION
According to [schema](https://github.com/junit-team/junit5/blob/3804182b1c26cb724aab86ccde155cc61cffc9b1/platform-tests/src/test/resources/jenkins-junit.xsd#L76).

This is needed for tests to show correctly in GitLab CI: https://gitlab.com/gitlab-org/gitlab-ce/issues/50964.