### PR TITLE
AssemblyCache locking

### DIFF
--- a/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs
+++ b/src/common/AssemblyResolution/DependencyContextAssemblyCache.cs
@@ -167,9 +167,13 @@ namespace Xunit
                     if (internalDiagnosticsMessageSink != null)
                     {
                         if (result == null)
+                        {
                             internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache.LoadManagedDll] Resolution for '{assemblyName}' failed, passed down to next resolver"));
+                        }
                         else
+                        {
                             internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache.LoadManagedDll] Resolved '{assemblyName}' to '{resolvedAssemblyPath}'"));
+                        }
                     }
                 }
 
@@ -195,8 +199,11 @@ namespace Xunit
                     result = unmanagedAssemblyLoader(resolvedAssemblyPath);
 
                 if (needDiagnostics && internalDiagnosticsMessageSink != null)
+                {
                     if (result != default)
+                    {
                         internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache.LoadUnmanagedLibrary] Resolved '{unmanagedLibraryName}' to '{resolvedAssemblyPath}'"));
+                    }
                     else
                     {
                         if (resolvedAssemblyPath != null)
@@ -204,6 +211,7 @@ namespace Xunit
 
                         internalDiagnosticsMessageSink.OnMessage(new _DiagnosticMessage($"[DependencyContextAssemblyCache.LoadUnmanagedLibrary] Resolution for '{unmanagedLibraryName}' failed, passed down to next resolver"));
                     }
+                }
 
                 return result;
             }


### PR DESCRIPTION
On highly parallelized xUnit runs using .NetCoreApp with numerous unmanaged p-invokes within the test classes, the cache dictionaries in `DependencyContextAssemblyCache` can cause InvalidOperationExceptions due to concurrent reads/writes.

```
xUnit.net Console Runner v2.4.1 (64-bit .NET Core 3.0.0-preview5-27626-15)
  Discovering: Testing
  Discovered:  Testing
  Starting:    Testing
Unhandled Exception: System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Xunit.DependencyContextAssemblyCache.LoadUnmanagedLibrary(String unmanagedLibraryName, Func`2 unmanagedAssemblyLoader) in C:\Dev\xunit\xunit\src\common\AssemblyResolution\DependencyContextAssemblyCache.cs:line 180
   at Xunit.AssemblyHelper.LoadUnmanagedDll(String unmanagedDllName) in C:\Dev\xunit\xunit\src\common\AssemblyResolution\AssemblyHelper_NetCoreApp.cs:line 76
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDll(String unmanagedDllName, IntPtr gchManagedAssemblyLoadContext)
```