### PR TITLE
Fixed "Help wanted" link in the Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 # Looking for something to work on?
 
-Documentation is always in need of help. Look at our ["help wanted" issues for the documentation site](https://github.com/xunit/xunit/issues?q=is%3Aopen+label%3A%22help+wanted%22+label%3A%22%5Ba%5D+xunit.github.io%22) to find something to contribute!
+Documentation is always in need of help. Look at our ["help wanted" issues for the documentation site](https://github.com/xunit/xunit/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) to find something to contribute!


### PR DESCRIPTION
The link was pointing to an empty list of issues. The new link now shows all "Help Wanted" tagged issues.