### PR TITLE
WIP: attempt to reproduce issue #1932

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 # Looking for something to work on?
 
-Documentation is always in need of help. Look at our ["help wanted" issues for the documentation site](https://github.com/xunit/xunit/issues?q=is%3Aopen+label%3A%22help+wanted%22+label%3A%22%5Ba%5D+xunit.github.io%22) to find something to contribute!
+Documentation is always in need of help. Look at our ["help wanted" issues for the documentation site](https://github.com/xunit/xunit/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) to find something to contribute!

--- a/test/test.xunit.assert/Asserts/NullAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/NullAssertsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 
 public class NullAssertsTests
@@ -24,6 +25,12 @@ public class NullAssertsTests
 
     public class Null
     {
+        private readonly ITestOutputHelper Output;
+        public Null(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
         [Fact]
         public void Success()
         {
@@ -40,6 +47,23 @@ public class NullAssertsTests
             Assert.Equal("Assert.Null() Failure" + Environment.NewLine +
                          "Expected: (null)" + Environment.NewLine +
                          "Actual:   Object { }", ex.Message);
+        }
+
+        /// <summary>
+        /// Test case specific to the issue #1932
+        /// </summary>
+        [Fact]
+        public void PrintControlCharactersSuccess()
+        {
+            var ex = Record.Exception(
+                () => Assert.Null("\0*.*\0"));
+            
+            Assert.IsType<NullException>(ex);
+            Assert.Equal("Assert.Null() Failure" + Environment.NewLine +
+                         "Expected: (null)" + Environment.NewLine +
+                         "Actual:   \0*.*\0", ex.Message);
+
+            Output.WriteLine(ex.Message);
         }
     }
 }


### PR DESCRIPTION
A test was added in an attempt to reproduce issue #1932. However, the _ITestOutputHelper_ seems to print the output properly on my environment 👍 

> ------ Test started: Assembly: test.xunit.assert.dll ------
> 
> Output from NullAssertsTests+Null.PrintControlCharactersSuccess:
>   Assert.Null() Failure
>   Expected: (null)
>   Actual:   \0*.*\0
> 
> 1 passed, 0 failed, 0 skipped, took 0.51 seconds (Custom).


Debugging the code, it appears that control characters are left untouched in the exception message. If the control characters appear to have disappeared in the console, it must be due to the _ITestOutputHelper_ implementation (the runner?).