### PR TITLE
Assert.Equal with ignoreWhiteSpace = true improvements

### DIFF
--- a/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
@@ -102,6 +102,22 @@ public class StringAssertsTests
 		[InlineData(" ", "\t", false, false, true)]
 		[InlineData(" \t", "\t ", false, false, true)]
 		[InlineData("    ", "\t", false, false, true)]
+		[InlineData(" ", " \u180E", false, false, true)]
+		[InlineData(" \u180E", "\u180E ", false, false, true)]
+		[InlineData("    ", "\u180E", false, false, true)]
+		[InlineData(" ", " \u200B", false, false, true)]
+		[InlineData(" \u200B", "\u200B ", false, false, true)]
+		[InlineData("    ", "\u200B", false, false, true)]
+		[InlineData(" ", " \u200B\uFEFF", false, false, true)]
+		[InlineData(" \u180E", "\u200B\u202F\u1680\u180E ", false, false, true)]
+		[InlineData("    ", "\u200B", false, false, true)]
+		[InlineData("\u2001\u2002\u2003\u2006\u2009    ", "\u200B", false, false, true)]
+		[InlineData("\u00A0\u200A\u2009\u2006\u2009    ", "\u200B", false, false, true)]
+		// The ogham space mark (\u1680) kind of looks like a faint dash, but Microsoft has put it
+		// inside the SpaceSeparator unicode category, so we also treat it as a space
+		[InlineData("\u2007\u2008\u1680\t\u0009\u3000   ", " ", false, false, true)]
+		[InlineData("\u1680", "\t", false, false, true)]
+		[InlineData("\u1680", "       ", false, false, true)]
 		public void SuccessCases(string value1, string value2, bool ignoreCase, bool ignoreLineEndingDifferences, bool ignoreWhiteSpaceDifferences)
 		{
 			// Run them in both directions, as the values should be interchangeable when they're equal


### PR DESCRIPTION
Assert.Equal with ignoreWhiteSpace = true will now ignore

```
SPACE (U+0020)
NO-BREAK SPACE (U+00A0)
OGHAM SPACE MARK (U+1680)
MONGOLIAN VOWEL SEPARATOR (U+180E)
EN QUAD (U+2000)
EM QUAD (U+2001)
EN SPACE (U+2002)
EM SPACE (U+2003)
THREE-PER-EM SPACE (U+2004)
FOUR-PER-EM SPACE (U+2005)
SIX-PER-EM SPACE (U+2006)
FIGURE SPACE (U+2007)
PUNCTUATION SPACE (U+2008)
THIN SPACE (U+2009)
HAIR SPACE (U+200A)
ZERO WIDTH SPACE (U+200B)
NARROW NO-BREAK SPACE (U+202F)
MEDIUM MATHEMATICAL SPACE (U+205F)
IDEOGRAPHIC SPACE (U+3000)
ZERO WIDTH NO-BREAK SPACE (U+FEFF)
TABULATION \u0009
```

Includes the tests for [32](https://github.com/xunit/assert.xunit/pull/32).

As per [#1931](https://github.com/xunit/xunit/issues/1931).