### PR TITLE
Fixes issue where traits cannot be inherited from multiple levels of inheritance.

### DIFF
--- a/src/xunit.v3.core/Sdk/Reflection/ReflectionAttributeInfo.cs
+++ b/src/xunit.v3.core/Sdk/Reflection/ReflectionAttributeInfo.cs
@@ -13,7 +13,10 @@ namespace Xunit.Sdk
 	public class ReflectionAttributeInfo : IReflectionAttributeInfo
 	{
 		static readonly AttributeUsageAttribute DefaultAttributeUsageAttribute = new AttributeUsageAttribute(AttributeTargets.All);
-		static readonly ConcurrentDictionary<Type, AttributeUsageAttribute> attributeUsageCache = new ConcurrentDictionary<Type, AttributeUsageAttribute>();
+		static readonly ConcurrentDictionary<Type, AttributeUsageAttribute> attributeUsageCache = new ConcurrentDictionary<Type, AttributeUsageAttribute>
+		{
+			[typeof(ITraitAttribute)] = new AttributeUsageAttribute(AttributeTargets.All) { AllowMultiple = true }
+		};
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ReflectionAttributeInfo"/> class.


### PR DESCRIPTION
Fixes #1397 

The issue was caused due to `ITraitAttribute` using the default `AttributeUsageAttribute` (as it can't have one of its own, not being an actual `Attribute`), which means the `AllowMultiples` property is false.

This change adds a default `AttributeUsageAttribute` instance straight into the cache when it is initialised. `ConcurrentDictionary` does not work with collection initialisers, so I've added an `IEnumerable<KeyValuePair<Type, AttributeUsageAttribute>>` into the constructor. This is far from neat, so perhaps it would be better to add a static constructor to the `ReflectionAttributeInfo` class and seed the cache at that point?

Also, I have added unit tests to prove the fix, but these could do with some improvement too - I'm open to suggestions. The actual method that ought to be tested is `ReflectionAttributeInfo.GetCustomAttributes(Type, string)`, but it is internal.
