### PR TITLE
Use cast instead of as for IReflectionTypeInfo

### DIFF
--- a/src/xunit.core/Sdk/DataDiscoverer.cs
+++ b/src/xunit.core/Sdk/DataDiscoverer.cs
@@ -27,7 +27,7 @@ namespace Xunit.Sdk
                     // If we couldn't find the data on the base type, check if it is in current type.
                     // This allows base classes to specify data that exists on a sub type, but not on the base type.
                     var memberDataAttribute = attribute as MemberDataAttribute;
-                    var reflectionTestMethodType = reflectionTestMethod.Type as IReflectionTypeInfo;
+                    var reflectionTestMethodType = (IReflectionTypeInfo)reflectionTestMethod.Type;
                     if (memberDataAttribute != null && memberDataAttribute.MemberType == null)
                     {
                         memberDataAttribute.MemberType = reflectionTestMethodType.Type;


### PR DESCRIPTION
since reflectionTestMethodType is always used. I would assume "non IReflectionTypeInfo" is not allowed since it would result in null ref. A cast is better since if it is incorrect an invalid cast will be easier to debug than a null ref