### PR TITLE
Emit MethodName as a test-case property in -nunit output

### DIFF
--- a/src/xunit.v3.runner.common/Transforms/templates/NUnitXml.xslt
+++ b/src/xunit.v3.runner.common/Transforms/templates/NUnitXml.xslt
@@ -143,6 +143,12 @@
   <xsl:template match="traits">
     <properties>
       <xsl:apply-templates select="trait"/>
+      <property>
+        <xsl:attribute name="name">MethodName</xsl:attribute>
+        <xsl:attribute name="value">
+          <xsl:value-of select="../@method"/>
+        </xsl:attribute>
+      </property>
     </properties>
   </xsl:template>
 


### PR DESCRIPTION
CI post-processing scripts may need the test method name; many tools use nunit-style output.
When the test is a Theory, the method name has to be parsed from test-case name. Much worse,
when xunit is used with TechTalk.SpecFlow, the test-case name is based on the Scenario name;
the method name is completely lost! Emit method name as property MethodName in nunit output.