### PR TITLE
Dispose of test class when cancellation requested

### DIFF
--- a/src/xunit.v3.core/Extensions/ReflectionAbstractionExtensions.cs
+++ b/src/xunit.v3.core/Extensions/ReflectionAbstractionExtensions.cs
@@ -71,17 +71,16 @@ public static class ReflectionAbstractionExtensions
 
         if (!messageBus.QueueMessage(new TestClassDisposeStarting(test)))
             cancellationTokenSource.Cancel();
-        else
+
+        // Let test class disposal run even if cancellation has been requested
+        try
         {
-            try
-            {
-                timer.Aggregate(disposable.Dispose);
-            }
-            finally
-            {
-                if (!messageBus.QueueMessage(new TestClassDisposeFinished(test)))
-                    cancellationTokenSource.Cancel();
-            }
+            timer.Aggregate(disposable.Dispose);
+        }
+        finally
+        {
+            if (!messageBus.QueueMessage(new TestClassDisposeFinished(test)))
+                cancellationTokenSource.Cancel();
         }
     }
 


### PR DESCRIPTION
Allows test class to be disposed of even if messageBus.QueueMessage
returns false when sending the TestClassDisposeStarting message.

Fixes #2008