### PR TITLE
Reintroduce license.txt

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,1 +1,16 @@
-LICENSE
+Unless otherwise noted, the source code here is covered by the following license:
+
+    Copyright (c) .NET Foundation and Contributors
+    All Rights Reserved
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.


### PR DESCRIPTION
This fixes the license-link on Nuget.org for older versions of xUnit. 

This closes #2022.
