### PR TITLE
Add output for skip message in HTML transform

### DIFF
--- a/src/xunit.console/HTML.xslt
+++ b/src/xunit.console/HTML.xslt
@@ -30,6 +30,7 @@
           .indent { margin: 0.25em 0 0.5em 2em; }
           .clickable { cursor: pointer; }
           .testcount { font-size: 85%; }
+          .label { font-weight: bold; }
         </style>
         <script language="javascript">
           function ToggleClass(id) {
@@ -167,6 +168,11 @@
       </xsl:if>
       &#160;<xsl:value-of select="@name"/>
       <br clear="all" />
+      <xsl:if test="reason">
+        <div>
+          <span class="label">Skip message: </span><xsl:value-of select="reason"/>
+        </div>
+      </xsl:if>
       <xsl:if test="child::node()/message">
         <pre><xsl:value-of select="child::node()/message"/></pre>
       </xsl:if>


### PR DESCRIPTION
Fixes #2004 

Adds a new row containing the reason a test was skipped in the HTML output file.