### PR TITLE
Enable C# 8 Nullable Reference Types

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,3 +14,30 @@ Unless otherwise noted, the source code here is covered by the following license
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+The file src/common/Annotations.cs is covered by the following license
+(copied from https://github.com/dotnet/runtime/blob/391dbfa87d8aba2a5bf338b433830de5f5c1cb3b/LICENSE.TXT):
+
+    The MIT License (MIT)
+
+    Copyright (c) .NET Foundation and Contributors
+
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/src/common/Annotations.cs
+++ b/src/common/Annotations.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    { }
+}

--- a/src/xunit.v3.assert/xunit.v3.assert.csproj
+++ b/src/xunit.v3.assert/xunit.v3.assert.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <DefineConstants>$(DefineConstants);XUNIT_NULLABLE</DefineConstants>
     <Description>Includes the assertion library from xUnit.net (xunit.v3.assert.dll). Supports .NET Standard 2.0.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/xunit.v3.core/Record.cs
+++ b/src/xunit.v3.core/Record.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -15,7 +17,7 @@ namespace Xunit
         /// </summary>
         /// <param name="testCode">The code which may throw an exception.</param>
         /// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
-        public static Exception Exception(Action testCode)
+        public static Exception? Exception(Action testCode)
         {
             Guard.ArgumentNotNull(nameof(testCode), testCode);
 
@@ -36,10 +38,10 @@ namespace Xunit
         /// </summary>
         /// <param name="testCode">The code which may throw an exception.</param>
         /// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
-        public static Exception Exception(Func<object> testCode)
+        public static Exception? Exception(Func<object> testCode)
         {
             Guard.ArgumentNotNull(nameof(testCode), testCode);
-            Task task;
+            Task? task;
 
             try
             {
@@ -58,6 +60,7 @@ namespace Xunit
 
         /// <summary/>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DoesNotReturn]
         [Obsolete("You must call Record.ExceptionAsync (and await the result) when testing async code.", true)]
         public static Exception Exception(Func<Task> testCode) { throw new NotImplementedException(); }
 
@@ -66,7 +69,7 @@ namespace Xunit
         /// </summary>
         /// <param name="testCode">The task which may throw an exception.</param>
         /// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
-        public static async Task<Exception> ExceptionAsync(Func<Task> testCode)
+        public static async Task<Exception?> ExceptionAsync(Func<Task> testCode)
         {
             Guard.ArgumentNotNull(nameof(testCode), testCode);
 

--- a/src/xunit.v3.core/xunit.v3.core.csproj
+++ b/src/xunit.v3.core/xunit.v3.core.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\common\Annotations.cs" LinkBase="Common" />
     <Compile Include="..\common\AssemblyExtensions.cs" LinkBase="Common" />
     <Compile Include="..\common\CommonTasks.cs" LinkBase="Common" />
     <Compile Include="..\common\DictionaryExtensions.cs" LinkBase="Common" />


### PR DESCRIPTION
Fixes #2011 and #2033.

There is a parallel PR that annotates `Assert.NotNull` in https://github.com/xunit/assert.xunit/pull/36.

The commit here enables NRT on two projects (`xunit.assert` and `xunit.core`), setting the language version to C# 8 on both. Ultimately it would probably make sense to enable it for all code in the repository, but it's prudent to roll it out in small steps such as this.

This requires Visual Studio 16.3 or later, or a new enough compiler. I expect this to PR to fail in various ways in CI, as this no doubt builds in environments where a new enough compiler is not available. In such cases it is possible to opt-in to a specific version of the compiler via its NuGet package. I'll see what happens in CI first.

I've been dogfooding NRT for a while now so am happy to field any questions about this PR or the feature in general. My goal is to improve the experience of using xUnit in tandem with NRT.

(I read the contribution guidelines and see that the associated issue is not flagged as help-wanted. This PR is meant to demonstrate what's required to get this to work, at least on a single Windows machine with VS2019 16.3 installed.)