### PR TITLE
Make available xunit.console pause option also in Release builds.

### DIFF
--- a/src/xunit.console/CommandLine.cs
+++ b/src/xunit.console/CommandLine.cs
@@ -39,9 +39,7 @@ namespace Xunit.ConsoleClient
 
         public bool NoLogo { get; protected set; }
 
-#if DEBUG
         public bool Pause { get; protected set; }
-#endif
 
         public XunitProject Project { get; protected set; }
 
@@ -182,13 +180,11 @@ namespace Xunit.ConsoleClient
                     GuardNoOptionValue(option);
                     NoAutoReporters = true;
                 }
-#if DEBUG
                 else if (optionName == "pause")
                 {
                     GuardNoOptionValue(option);
                     Pause = true;
                 }
-#endif
                 else if (optionName == "debug")
                 {
                     GuardNoOptionValue(option);

--- a/src/xunit.console/ConsoleRunner.cs
+++ b/src/xunit.console/ConsoleRunner.cs
@@ -64,14 +64,12 @@ namespace Xunit.ConsoleClient
 
                 var reporter = commandLine.ChooseReporter(reporters);
 
-#if DEBUG
                 if (commandLine.Pause)
                 {
                     Console.Write("Press any key to start execution...");
                     Console.ReadKey(true);
                     Console.WriteLine();
                 }
-#endif
 
                 if (commandLine.Debug)
                     Debugger.Launch();
@@ -240,9 +238,7 @@ namespace Xunit.ConsoleClient
             Console.WriteLine("  -wait                  : wait for input after completion");
             Console.WriteLine("  -diagnostics           : enable diagnostics messages for all test assemblies");
             Console.WriteLine("  -internaldiagnostics   : enable internal diagnostics messages for all test assemblies");
-#if DEBUG
             Console.WriteLine("  -pause                 : pause before doing any work, to help attach a debugger");
-#endif
             Console.WriteLine("  -debug                 : launch the debugger to debug the tests");
             Console.WriteLine("  -serialize             : serialize all test cases (for diagnostic purposes only)");
             Console.WriteLine("  -trait \"name=value\"    : only run tests with matching name/value traits");


### PR DESCRIPTION
This option makes the console runner wait for the user to press a key at start,
which makes it easy to attach a debugger to the test process.