### PR TITLE
Add missing flowId on TeamCity testStdOut message

### DIFF
--- a/src/xunit.v3.runner.common/Reporters/TeamCityReporterMessageHandler.cs
+++ b/src/xunit.v3.runner.common/Reporters/TeamCityReporterMessageHandler.cs
@@ -176,11 +176,12 @@ namespace Xunit
         void LogFinish(ITestResultMessage testResult)
         {
             var formattedName = Escape(displayNameFormatter.DisplayName(testResult.Test));
+            var flowId = ToFlowId(testResult.TestCollection.DisplayName);
 
             if (!string.IsNullOrWhiteSpace(testResult.Output))
-                logger.LogImportantMessage($"##teamcity[testStdOut name='{formattedName}' out='{Escape(testResult.Output)}']");
+                logger.LogImportantMessage($"##teamcity[testStdOut name='{formattedName}' out='{Escape(testResult.Output)}' flowId='{flowId}']");
 
-            logger.LogImportantMessage($"##teamcity[testFinished name='{formattedName}' duration='{(int)(testResult.ExecutionTime * 1000M)}' flowId='{ToFlowId(testResult.TestCollection.DisplayName)}']");
+            logger.LogImportantMessage($"##teamcity[testFinished name='{formattedName}' duration='{(int)(testResult.ExecutionTime * 1000M)}' flowId='{flowId}']");
         }
 
         static bool IsAscii(char ch) => ch <= '\x007f';

--- a/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
@@ -119,7 +119,7 @@ public class TeamCityReporterMessageHandlerTests
 
             Assert.Collection(handler.Messages,
                 msg => Assert.Equal("[Imp] => ##teamcity[testFailed name='FORMATTED:This is my display name \t|r|n' details='ExceptionType : This is my message \t|r|n|r|nLine 1|r|nLine 2|r|nLine 3' flowId='myFlowId']", msg),
-                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput']", msg),
+                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput' flowId='myFlowId']", msg),
                 msg => Assert.Equal("[Imp] => ##teamcity[testFinished name='FORMATTED:This is my display name \t|r|n' duration='1234' flowId='myFlowId']", msg)
             );
         }
@@ -136,7 +136,7 @@ public class TeamCityReporterMessageHandlerTests
             handler.OnMessageWithTypes(message, null);
 
             Assert.Collection(handler.Messages,
-                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput']", msg),
+                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput' flowId='myFlowId']", msg),
                 msg => Assert.Equal("[Imp] => ##teamcity[testFinished name='FORMATTED:This is my display name \t|r|n' duration='1234' flowId='myFlowId']", msg)
             );
         }


### PR DESCRIPTION
This adds the missing ``flowId`` parameter to the ``testStdOut`` service message for TeamCity.