### PR TITLE
Remove duplicate reference from build.csproj

### DIFF
--- a/tools/builder/build.csproj
+++ b/tools/builder/build.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SimpleExec" Version="6.2.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SimpleExec" Version="6.1.0+build.148" />
   </ItemGroup>


### PR DESCRIPTION
Subj.
PackageReference `McMaster.Extensions.CommandLineUtils` is duplicated.

