### PR TITLE
Fix build of the v2 branch.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "1.6.55"
+    "MSBuild.Sdk.Extras": "1.6.61"
   }
 }


### PR DESCRIPTION
MSBuild.Sdk.Extras 1.6.55 had this bug:
https://github.com/novotnyllc/MSBuildSdkExtras/issues/127

1.6.61 fixes it.

This fixes:
https://github.com/xunit/xunit/issues/1972
https://github.com/xunit/xunit/issues/1819