### PR TITLE
Optimize using Span<T> Assert.Equal for T[] where T is unmanaged

### DIFF
--- a/src/xunit.v3.assert.tests/Asserts/EqualityAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/EqualityAssertsTests.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿#if XUNIT_SPAN
+using System.Diagnostics;
+using System.Linq;
+#endif
+
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -6,10 +11,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
 using Xunit.Sdk;
-#if XUNIT_ASSERT_ARRAY_AS_SPAN
-using System.Diagnostics;
-using System.Linq;
-#endif
 
 public class EqualityAssertsTests
 {
@@ -1099,7 +1100,7 @@ public class EqualityAssertsTests
 		}
 	}
 
-#if XUNIT_ASSERT_ARRAY_AS_SPAN
+#if XUNIT_SPAN
 	public abstract class Equal_ArrayOfUnmanagedT_AsSpan<T>
 		where T : unmanaged, IEquatable<T>
 	{

--- a/src/xunit.v3.assert/xunit.v3.assert.csproj
+++ b/src/xunit.v3.assert/xunit.v3.assert.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
   <ItemGroup Condition="$(DefineConstants.Contains('XUNIT_ASSERT_ARRAY_AS_SPAN'))">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>

--- a/src/xunit.v3.assert/xunit.v3.assert.csproj
+++ b/src/xunit.v3.assert/xunit.v3.assert.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  <ItemGroup Condition="$(DefineConstants.Contains('XUNIT_ASSERT_ARRAY_AS_SPAN'))">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
 </Project>

--- a/src/xunit.v3.assert/xunit.v3.assert.csproj
+++ b/src/xunit.v3.assert/xunit.v3.assert.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(DefineConstants.Contains('XUNIT_ASSERT_ARRAY_AS_SPAN'))">
+  <ItemGroup Condition="$(DefineConstants.Contains('XUNIT_SPAN'))">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #1907 

- Needs https://github.com/xunit/assert.xunit/pull/39 to be merged
- Enable optimization by
  - Updating the `xunit/assert.xunit` submodule reference accordingly
  - Adding `XUNIT_SPAN` definition to [Directory.Build.props' `<DefineConstants>`](https://github.com/xunit/xunit/blob/f4be18e8bf926b3ec0ead036fca5df7fb2114116/src/Directory.Build.props#L11)