### PR TITLE
Implement ToString on DiagnosticMessage

### DIFF
--- a/src/messages/DiagnosticMessage.cs
+++ b/src/messages/DiagnosticMessage.cs
@@ -61,5 +61,8 @@ namespace Xunit
 
 		/// <inheritdoc/>
 		public string Message { get; }
+
+		/// <inheritdoc />
+		public override string ToString() => Message;
 	}
 }


### PR DESCRIPTION
My hope is that the diagnostics will become available in JetBrains Rider unit test logs. Currently, we can see messages like this: `TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage`. My intuition is that the Rider test runner is calling `ToString()` on `Xunit.Sdk.DiagnosticMessage` and that implementing `ToString()` will get the actual diagnostic messages in the Rider logs.

Anyway, implementing `ToString()` in a class that wraps a message string can't hurt.

```
09:14:44.304 |I| TestRunner: XUnitRunner Execution started 
09:14:44.310 |I| TestRunner: Discoverer Discovering tests from ~/Projects/MyApp/MyApp.Tests/bin/Debug/netcoreapp3.1/MyApp.Tests.dll 
09:14:44.550 |V| TestRunner: Discoverer Sending discovery results to server... 
09:14:44.602 |V| Run: 9aabab47-d5ae-4b6a-b5c5-d137ae8c521f - Discovery result processing started
09:14:44.602 |I| TestRunner: Discoverer Discovery completed 
09:14:44.615 |V| Run: 9aabab47-d5ae-4b6a-b5c5-d137ae8c521f - Discovery result processing finished (+0 -0 ~11)
09:14:44.785 |V| TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage 
09:14:45.483 |V| TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage 
09:14:45.490 |V| TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage 
09:14:45.570 |V| TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage 
09:14:45.578 |V| TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage 
09:14:51.787 |V| TestRunner: XUnitRunner Xunit.Sdk.DiagnosticMessage 
09:14:51.810 |I| TestRunner: XUnitRunner Execution completed
```