### PR TITLE
Dispose ClassData class if disposable

### DIFF
--- a/src/xunit.v3.core/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunner.cs
+++ b/src/xunit.v3.core/Sdk/Frameworks/Runners/XunitTheoryTestCaseRunner.cs
@@ -106,6 +106,8 @@ namespace Xunit.Sdk
 					foreach (var dataRow in data)
 					{
 						toDispose.AddRange(dataRow.OfType<IDisposable>());
+						if (data is IDisposable)
+							toDispose.Add((IDisposable)data);
 
 						ITypeInfo[]? resolvedTypes = null;
 						var methodToRun = TestMethod;


### PR DESCRIPTION
I am attempting to fix the fact that ClassData attributed classes that are IDisposable are not disposed.
