### PR TITLE
Add environment variable to override AppDomain.Unload

### DIFF
--- a/src/xunit.runner.utility/AppDomain/AppDomainManager_AppDomain.cs
+++ b/src/xunit.runner.utility/AppDomain/AppDomainManager_AppDomain.cs
@@ -36,6 +36,8 @@ namespace Xunit
 
         public bool HasAppDomain => true;
 
+        private bool SkipAppDomainUnload => string.Equals(Environment.GetEnvironmentVariable("XUNIT_SKIP_APPDOMAIN_UNLOAD"), "true", StringComparison.OrdinalIgnoreCase);
+
         static AppDomain CreateAppDomain(string assemblyFilename, string configFilename, bool shadowCopy, string shadowCopyFolder)
         {
             var setup = new AppDomainSetup();
@@ -88,7 +90,7 @@ namespace Xunit
 
         public virtual void Dispose()
         {
-            if (AppDomain != null)
+            if (AppDomain != null && !SkipAppDomainUnload)
             {
                 string cachePath = AppDomain.SetupInformation.CachePath;
 


### PR DESCRIPTION
This pull request provides a mitigation path for dotnet/roslyn#49024.

I considered three approaches:

* A new option `appDomainUnload`, with default value `true`. This is the cleanest option for a user, but is difficult to implement throughout the internals without breaking API changes.
* Changing `AppDomainSupport` to have an enum flag for this. This seemed like a reasonable possibility, but likely unnecessarily complex considering the current maintenance strategy for the v2 branch.
* An environment variable. This is the simplest option, and likely only works for CI scenarios, but at least it mitigates the acute problems we're facing today.

