### PR TITLE
Add IClassFixture to 'Capturing output in extensibility classes' list

### DIFF
--- a/docs/capturing-output.html
+++ b/docs/capturing-output.html
@@ -101,6 +101,7 @@ public class MyTestClass
 </p>
 
 <ul>
+  <li><code>IClassFixture&lt;&gt;</code></li>
   <li><code>IDataDiscoverer</code></li>
   <li><code>ITestCaseOrderer</code></li>
   <li><code>ITestCollectionOrderer</code></li>

--- a/docs/capturing-output.html
+++ b/docs/capturing-output.html
@@ -102,6 +102,7 @@ public class MyTestClass
 
 <ul>
   <li><code>IClassFixture&lt;&gt;</code></li>
+  <li><code>ICollectionFixture&lt;&gt;</code></li>
   <li><code>IDataDiscoverer</code></li>
   <li><code>ITestCaseOrderer</code></li>
   <li><code>ITestCollectionOrderer</code></li>


### PR DESCRIPTION
Fixes #2218, added alphabetically.