### PR TITLE
Fix Console colors concurrency handling

### DIFF
--- a/src/xunit.v3.runner.common/Loggers/ConsoleRunnerLogger.cs
+++ b/src/xunit.v3.runner.common/Loggers/ConsoleRunnerLogger.cs
@@ -44,8 +44,8 @@ namespace Xunit.Runner.Common
 			StackFrameInfo stackFrame,
 			string message)
 		{
-			using (SetColor(ConsoleColor.Red))
-				lock (LockObject)
+			lock (LockObject)
+				using (SetColor(ConsoleColor.Red))
 					Console.Error.WriteLine(message);
 		}
 
@@ -54,8 +54,8 @@ namespace Xunit.Runner.Common
 			StackFrameInfo stackFrame,
 			string message)
 		{
-			using (SetColor(ConsoleColor.Gray))
-				lock (LockObject)
+			lock (LockObject)
+				using (SetColor(ConsoleColor.Gray))
 					Console.WriteLine(message);
 		}
 
@@ -64,8 +64,8 @@ namespace Xunit.Runner.Common
 			StackFrameInfo stackFrame,
 			string message)
 		{
-			using (SetColor(ConsoleColor.DarkGray))
-				lock (LockObject)
+			lock (LockObject)
+				using (SetColor(ConsoleColor.DarkGray))
 					Console.WriteLine(message);
 		}
 
@@ -74,8 +74,8 @@ namespace Xunit.Runner.Common
 			StackFrameInfo stackFrame,
 			string message)
 		{
-			using (SetColor(ConsoleColor.Yellow))
-				lock (LockObject)
+			lock (LockObject)
+				using (SetColor(ConsoleColor.Yellow))
 					Console.WriteLine(message);
 		}
 


### PR DESCRIPTION
Hello,
While I was looking for a cause of https://github.com/xunit/xunit/issues/2227, I've noticed that the console colors changes are not part of the lock, which will cause the colors to be mixed together.

I believe this would also potentially cause invalid escape codes to be emitted, but I am not sure if it could generate codes that can cause a previous character (the newline) to be lost).
I thought it was worth it to raise this small PR even if it has not been discussed yet in the issue.

There are currently not test and would not be easy to write one for this problem, so I haven't added one.

Please let me know what do you think.

Thank you,
 Alessio
