### PR TITLE
Fix typo in visual-studio.html

### DIFF
--- a/docs/getting-started/netcore/visual-studio.html
+++ b/docs/getting-started/netcore/visual-studio.html
@@ -37,7 +37,7 @@ breadcrumb: Documentation
 <p><img class="border" src="/images/getting-started/netcore/new-project-step1-vs2019.png" width="1024" /></p>
 
 <p>
-  In the drop down boxes, chooses your language (C#), your platform (All platforms), and your
+  In the drop down boxes, choose your language (C#), your platform (All platforms), and your
   project type (Test). Scroll through the list if necessary until you find the item titled
   "xUnit Test Project (.NET Core)". Select it, then click "Next".
 </p>


### PR DESCRIPTION
The sentence:

> In the drop down boxes, chooses your language (C#)...

Should read:

> In the drop down boxes, **choose** your language (C#)...