### PR TITLE
Fix typo in running-tests-in-parallel.html

### DIFF
--- a/docs/running-tests-in-parallel.html
+++ b/docs/running-tests-in-parallel.html
@@ -224,7 +224,7 @@ public class TestClass2
 <h3>Changing Default Behavior</h3>
 
 <p>
-  There are several default pieces of behavior that be configured by the
+  There are several default pieces of behavior that can be configured by the
   developer as relates to running tests in parallel. These are all changed
   by applying an assembly level attribute:
 </p>


### PR DESCRIPTION
The following sentence:

> There are several default pieces of behavior that be configured by the...

Should read:

> There are several default pieces of behavior that **can** be configured by the...