### PR TITLE
Fix another typo in running-tests-in-parallel.html

### DIFF
--- a/docs/running-tests-in-parallel.html
+++ b/docs/running-tests-in-parallel.html
@@ -285,7 +285,7 @@ public class TestClass2
 <p>
   The console runner in xUnit.net v2 is capable of running unit tests from both
   xUnit.net v1 and v2. It can run multiple assemblies at the same time, and
-  command line options can be used to configuration the parallelism options
+  command line options can be used to configure the parallelism options
   used when running the tests.
 </p>
 


### PR DESCRIPTION
The following sentence:

> ...and command line options can be used to configuration the parallelism options...

Should read:

> ...and command line options can be used to **configure** the parallelism options...