### PR TITLE
Print full exception details in error message

### DIFF
--- a/src/xunit.v3.common/v3/Abstractions/_IErrorMetadata.cs
+++ b/src/xunit.v3.common/v3/Abstractions/_IErrorMetadata.cs
@@ -22,6 +22,11 @@ namespace Xunit.v3
 		string[] Messages { get; }
 
 		/// <summary>
+		/// Gets the details of the exception(s).
+		/// </summary>
+		string? Details { get; }
+
+		/// <summary>
 		/// Gets the stack trace(s) of the exception(s).
 		/// </summary>
 		string?[] StackTraces { get; }

--- a/src/xunit.v3.common/v3/Messages/_ErrorMessage.cs
+++ b/src/xunit.v3.common/v3/Messages/_ErrorMessage.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -36,6 +37,13 @@ namespace Xunit.v3
 		}
 
 		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
+		}
+
+		/// <inheritdoc/>
 		public string?[] StackTraces
 		{
 			get => stackTraces ?? throw new InvalidOperationException($"Attempted to get {nameof(StackTraces)} on an uninitialized '{GetType().FullName}' object");
@@ -56,6 +64,7 @@ namespace Xunit.v3
 			{
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestAssemblyCleanupFailure.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestAssemblyCleanupFailure.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -33,6 +34,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -61,6 +69,7 @@ namespace Xunit.v3
 				AssemblyUniqueID = assemblyUniqueID,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestCaseCleanupFailure.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestCaseCleanupFailure.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -33,6 +34,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -75,6 +83,7 @@ namespace Xunit.v3
 				TestCaseUniqueID = testCaseUniqueID,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestClassCleanupFailure.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestClassCleanupFailure.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -33,6 +34,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -68,6 +76,7 @@ namespace Xunit.v3
 				TestClassUniqueID = testClassUniqueID,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestCleanupFailure.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestCleanupFailure.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -33,6 +34,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -79,6 +87,7 @@ namespace Xunit.v3
 				TestUniqueID = testUniqueID,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestCollectionCleanupFailure.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestCollectionCleanupFailure.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -33,6 +34,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -65,6 +73,7 @@ namespace Xunit.v3
 				TestCollectionUniqueID = testCollectionUniqueID,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestFailed.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestFailed.cs
@@ -13,6 +13,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <summary>
@@ -47,6 +48,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -101,6 +109,7 @@ namespace Xunit.v3
 				Output = output ?? string.Empty,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.common/v3/Messages/_TestMethodCleanupFailure.cs
+++ b/src/xunit.v3.common/v3/Messages/_TestMethodCleanupFailure.cs
@@ -12,6 +12,7 @@ namespace Xunit.v3
 		int[]? exceptionParentIndices;
 		string?[]? exceptionTypes;
 		string[]? messages;
+		string? details;
 		string?[]? stackTraces;
 
 		/// <inheritdoc/>
@@ -33,6 +34,13 @@ namespace Xunit.v3
 		{
 			get => messages ?? throw new InvalidOperationException($"Attempted to get {nameof(Messages)} on an uninitialized '{GetType().FullName}' object");
 			set => messages = Guard.ArgumentNotNullOrEmpty(nameof(Messages), value);
+		}
+
+		/// <inheritdoc/>
+		public string? Details
+		{
+			get => details ?? throw new InvalidOperationException($"Attempted to get {nameof(Details)} on an uninitialized '{GetType().FullName} object");
+			set => details = Guard.ArgumentNotNull(nameof(Details), value);
 		}
 
 		/// <inheritdoc/>
@@ -71,6 +79,7 @@ namespace Xunit.v3
 				TestMethodUniqueID = testMethodUniqueID,
 				ExceptionTypes = errorMetadata.ExceptionTypes,
 				Messages = errorMetadata.Messages,
+				Details = ex.ToString(),
 				StackTraces = errorMetadata.StackTraces,
 				ExceptionParentIndices = errorMetadata.ExceptionParentIndices,
 			};

--- a/src/xunit.v3.runner.common/Reporters/DefaultRunnerReporterMessageHandler.cs
+++ b/src/xunit.v3.runner.common/Reporters/DefaultRunnerReporterMessageHandler.cs
@@ -147,8 +147,24 @@ namespace Xunit.Runner.Common
 				foreach (var messageLine in ExceptionUtility.CombineMessages(errorMetadata).Split(new[] { Environment.NewLine }, StringSplitOptions.None))
 					Logger.LogImportantMessage(frameInfo, $"      {messageLine}");
 
-				LogStackTrace(frameInfo, ExceptionUtility.CombineStackTraces(errorMetadata));
+				LogDetails(frameInfo, errorMetadata.Details);
 			}
+		}
+
+		/// <summary>
+		/// Logs the exception details to the logger.
+		/// </summary>
+		protected virtual void LogDetails(
+			StackFrameInfo frameInfo,
+			string? details)
+		{
+			if (string.IsNullOrEmpty(details))
+				return;
+
+			Logger.LogMessage(frameInfo, "      Details:");
+
+			foreach (var messageLine in details.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
+				Logger.LogImportantMessage(frameInfo, $"        {messageLine}");
 		}
 
 		/// <summary>
@@ -492,7 +508,7 @@ namespace Xunit.Runner.Common
 				foreach (var messageLine in ExceptionUtility.CombineMessages(testFailed).Split(new[] { Environment.NewLine }, StringSplitOptions.None))
 					Logger.LogImportantMessage(frameInfo, $"      {messageLine}");
 
-				LogStackTrace(frameInfo, ExceptionUtility.CombineStackTraces(testFailed));
+				LogDetails(frameInfo, testFailed.Details);
 				LogOutput(frameInfo, testFailed.Output);
 			}
 		}

--- a/src/xunit.v3.runner.utility.tests/Utility/ExceptionUtilityTests.cs
+++ b/src/xunit.v3.runner.utility.tests/Utility/ExceptionUtilityTests.cs
@@ -12,11 +12,14 @@ public class ExceptionUtilityTests
 		readonly List<int> exceptionParentIndices = new List<int>();
 		readonly List<string?> exceptionTypes = new List<string?>();
 		readonly List<string> messages = new List<string>();
+		string? details = null;
 		readonly List<string?> stackTraces = new List<string?>();
 
 		public string?[] ExceptionTypes => exceptionTypes.ToArray();
 
 		public string[] Messages => messages.ToArray();
+
+		public string? Details => details;
 
 		public string?[] StackTraces => stackTraces.ToArray();
 
@@ -26,6 +29,7 @@ public class ExceptionUtilityTests
 			Exception ex,
 			int index = -1)
 		{
+			details ??= ex.ToString();
 			Add(ex.GetType(), ex.Message, ex.StackTrace, index);
 		}
 

--- a/src/xunit.v3.runner.utility/Runners/AssemblyRunner.cs
+++ b/src/xunit.v3.runner.utility/Runners/AssemblyRunner.cs
@@ -394,19 +394,19 @@ namespace Xunit.Runners
 
 			if (OnErrorMessage != null)
 			{
-				if (DispatchMessage<_ErrorMessage>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.CatastrophicError, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_ErrorMessage>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.CatastrophicError, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
-				if (DispatchMessage<_TestAssemblyCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestAssemblyCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_TestAssemblyCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestAssemblyCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
-				if (DispatchMessage<_TestCaseCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestCaseCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_TestCaseCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestCaseCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
-				if (DispatchMessage<_TestClassCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestClassCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_TestClassCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestClassCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
-				if (DispatchMessage<_TestCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_TestCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
-				if (DispatchMessage<_TestCollectionCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestCollectionCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_TestCollectionCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestCollectionCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
-				if (DispatchMessage<_TestMethodCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestMethodCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.StackTraces.FirstOrDefault()))))
+				if (DispatchMessage<_TestMethodCleanupFailure>(message, messageTypes, m => OnErrorMessage(new ErrorMessageInfo(ErrorMessageType.TestMethodCleanupFailure, m.ExceptionTypes.FirstOrDefault(), m.Messages.FirstOrDefault(), m.Details, m.StackTraces.FirstOrDefault()))))
 					return !cancelled;
 			}
 

--- a/src/xunit.v3.runner.utility/Runners/ErrorMessageInfo.cs
+++ b/src/xunit.v3.runner.utility/Runners/ErrorMessageInfo.cs
@@ -10,11 +10,13 @@
 			ErrorMessageType messageType,
 			string? exceptionType,
 			string? exceptionMessage,
+			string? exceptionDetails,
 			string? exceptionStackTrace)
 		{
 			MesssageType = messageType;
 			ExceptionType = exceptionType;
 			ExceptionMessage = exceptionMessage;
+			ExceptionDetails = exceptionDetails;
 			ExceptionStackTrace = exceptionStackTrace;
 		}
 
@@ -32,6 +34,11 @@
 		/// The message from the exception that caused the test failure.
 		/// </summary>
 		public string? ExceptionMessage { get; }
+
+		/// <summary>
+		/// The full details from the exception that caused the test failure.
+		/// </summary>
+		public string? ExceptionDetails { get; }
 
 		/// <summary>
 		/// The stack trace from the exception that caused the test failure.


### PR DESCRIPTION
When a test fails, print full exception details.

This provides a crucial stop-gap for many developers needing good log messages from CI test runs (in our case an important service within Microsoft).

* Fixes active issue https://github.com/xunit/xunit/issues/1548
* Relevant tests have been adjusted and all tests pass following this change.
