### PR TITLE
Add lock around DisposalTracker

### DIFF
--- a/src/xunit.execution/Sdk/DisposalTracker.cs
+++ b/src/xunit.execution/Sdk/DisposalTracker.cs
@@ -17,16 +17,20 @@ namespace Xunit.Sdk
         /// <param name="disposable">The object to be disposed.</param>
         public void Add(IDisposable disposable)
         {
-            toDispose.Push(disposable);
+            lock (toDispose)
+                toDispose.Push(disposable);
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            foreach (var disposable in toDispose)
-                disposable.Dispose();
+            lock (toDispose)
+            {
+                foreach (var disposable in toDispose)
+                    disposable.Dispose();
 
-            toDispose.Clear();
+                toDispose.Clear();
+            }
         }
     }
 }


### PR DESCRIPTION
#### About this PR:

Proposed fix for (v2 branch): https://github.com/xunit/xunit/issues/1855
Fixes: https://github.com/dotnet/runtime/issues/11063 (this fix would help improve the test pass rate in dontet/runtime infra.)
Opened in lieu of initial PR: https://github.com/xunit/xunit/pull/2375.

---

#### Details of this change:

* Cherry pick from v3 of eacf435.

A couple notes:

- I applied a cherry pick to preserve history of where the fix is coming from even though the v3 change is on a different file.
- The original commit that was cherry picked is nullable annotated but the v2 version is not.
- The original commit had the `isDisposed` flag and v2 doesn't have that flag.
- The original commit does not have a call to `toDispose.Clear()` in `Dispose()` but v2 has.


#### About testing:

We left the test (linked [here](https://github.com/xunit/xunit/pull/2375#issuecomment-918334991)) out of this PR since it wouldn't always fail. It was helpful for validating our fix initially, but doesn't provide enough value as a regression test to be submit as part of this PR.

@bradwilson @ericstj