### PR TITLE
Include flowId and parseServiceMessages for stdOut

### DIFF
--- a/src/xunit.runner.reporters/TeamCityReporterMessageHandler.cs
+++ b/src/xunit.runner.reporters/TeamCityReporterMessageHandler.cs
@@ -133,7 +133,7 @@ namespace Xunit.Runner.Reporters
             var formattedName = Escape(displayNameFormatter.DisplayName(testResult.Test));
 
             if (!string.IsNullOrWhiteSpace(testResult.Output))
-                logger.LogImportantMessage($"##teamcity[testStdOut name='{formattedName}' out='{Escape(testResult.Output)}']");
+                logger.LogImportantMessage($"##teamcity[testStdOut name='{formattedName}' out='{Escape(testResult.Output)}' flowId='{ToFlowId(testResult.TestCollection.DisplayName)}' tc:tags='tc:parseServiceMessagesInside']");
 
             logger.LogImportantMessage($"##teamcity[testFinished name='{formattedName}' duration='{(int)(testResult.ExecutionTime * 1000M)}' flowId='{ToFlowId(testResult.TestCollection.DisplayName)}']");
         }

--- a/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
@@ -119,7 +119,7 @@ public class TeamCityReporterMessageHandlerTests
 
             Assert.Collection(handler.Messages,
                 msg => Assert.Equal("[Imp] => ##teamcity[testFailed name='FORMATTED:This is my display name \t|r|n' details='ExceptionType : This is my message \t|r|n|r|nLine 1|r|nLine 2|r|nLine 3' flowId='myFlowId']", msg),
-                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput']", msg),
+                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput' flowId='myFlowId' tc:tags='tc:parseServiceMessagesInside']", msg),
                 msg => Assert.Equal("[Imp] => ##teamcity[testFinished name='FORMATTED:This is my display name \t|r|n' duration='1234' flowId='myFlowId']", msg)
             );
         }
@@ -136,7 +136,7 @@ public class TeamCityReporterMessageHandlerTests
             handler.OnMessageWithTypes(message, null);
 
             Assert.Collection(handler.Messages,
-                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput']", msg),
+                msg => Assert.Equal("[Imp] => ##teamcity[testStdOut name='FORMATTED:This is my display name \t|r|n' out='This is\t|r|noutput' flowId='myFlowId' tc:tags='tc:parseServiceMessagesInside']", msg),
                 msg => Assert.Equal("[Imp] => ##teamcity[testFinished name='FORMATTED:This is my display name \t|r|n' duration='1234' flowId='myFlowId']", msg)
             );
         }


### PR DESCRIPTION
When running tests in parallel, we faced two issues, the output didn't seem to match the test in TeamCity, and we were unable to include extra service messages to add metadata to the test (like a link).

Including these extra parameters allowed us to implement this.
Fixes: https://github.com/xunit/xunit/issues/2397