### PR TITLE
Support runtimes where ReflectedType exists such as NetStandard2.0 compatible runtimes

### DIFF
--- a/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
+++ b/src/xunit.execution/Sdk/Reflection/ReflectionMethodInfo.cs
@@ -68,7 +68,19 @@ namespace Xunit.Sdk
         public ITypeInfo Type
         {
 #if NETSTANDARD1_1
-            get { throw new NotSupportedException(); }
+            get
+            {
+                var reflectedTypeProperty = MethodInfo.GetType().GetRuntimeProperty("ReflectedType");
+                if (reflectedTypeProperty != null)
+                {
+                    var methodInfoReflectedType = (Type)reflectedTypeProperty.GetValue(MethodInfo, null);
+                    return Reflector.Wrap(methodInfoReflectedType);
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
+            }
 #else
             get { return Reflector.Wrap(MethodInfo.ReflectedType); }
 #endif


### PR DESCRIPTION
This relates to issue #1983

The calling code that fails is this particular call in DataDiscoverer:
https://github.com/xunit/xunit/blob/4db2e39c72e70a3d1ffd308a3131a397e39ecffc/src/xunit.core/Sdk/DataDiscoverer.cs#L32

This change should restore the functionality that worked on NetStandard 2.0 compatible runtimes with v2.4.0 that breaks when upgrading to 2.4.1 (where NetStandard2.0 target was removed breaking this particular call.

I think the missing unit tests are possible but still working out where they go into this file. Potentially alongside this test case?
https://github.com/xunit/xunit/blob/4db2e39c72e70a3d1ffd308a3131a397e39ecffc/test/test.xunit.execution/Acceptance/Xunit2TheoryAcceptanceTests.cs#L869-L888
EDIT: After some playing around I've realised none of these theory tests light up for non .Net Full Framework anyway.

I've tried to do this as low impact as possible.

I investigated just using DeclaringType but there is a subtle difference, which is exactly what the DataDiscoverer is using it for.
(DeclaringType would resolve to the base class while ReflectedType will correctly use the derived test class type, [according to Stack Overflow](https://stackoverflow.com/a/21884304))

Thanks in Advance. All feedback appreciated
