### PR TITLE
Enable ConfigurationManager on .NET 6

### DIFF
--- a/src/xunit.v3.runner.utility/AppDomain/AppDomainManagerFactory.cs
+++ b/src/xunit.v3.runner.utility/AppDomain/AppDomainManagerFactory.cs
@@ -21,7 +21,7 @@ namespace Xunit
 				return new AppDomainManager_AppDomain(assemblyFileName, configFileName, shadowCopy, shadowCopyFolder, diagnosticMessageSink);
 #endif
 
-			return new AppDomainManager_NoAppDomain();
+			return new AppDomainManager_NoAppDomain(assemblyFileName, configFileName);
 		}
 	}
 }

--- a/src/xunit.v3.runner.utility/AppDomain/AppDomainManager_NoAppDomain.cs
+++ b/src/xunit.v3.runner.utility/AppDomain/AppDomainManager_NoAppDomain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Xunit.Internal;
@@ -7,6 +8,24 @@ namespace Xunit
 {
 	class AppDomainManager_NoAppDomain : IAppDomainManager
 	{
+		public AppDomainManager_NoAppDomain(
+			string assemblyFileName,
+			string? configFileName)
+		{
+			Guard.ArgumentNotNullOrEmpty(assemblyFileName);
+
+			assemblyFileName = Path.GetFullPath(assemblyFileName);
+			Guard.FileExists(assemblyFileName);
+
+			if (configFileName == null)
+				configFileName = GetDefaultConfigFile(assemblyFileName);
+
+			if (configFileName != null)
+				configFileName = Path.GetFullPath(configFileName);
+
+			AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", configFileName);
+		}
+
 		public bool HasAppDomain => false;
 
 		public TObject? CreateObject<TObject>(
@@ -65,5 +84,15 @@ namespace Xunit
 
 		public void Dispose()
 		{ }
+
+		static string? GetDefaultConfigFile(string assemblyFile)
+		{
+			var configFilename = assemblyFile + ".config";
+
+			if (File.Exists(configFilename))
+				return configFilename;
+
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
This has finally been unblocked by dotnet/runtime#56748. This will enable testing application code that uses ConfigurationManager. Just like on .NET Framework, it will read from the App.config file of the test project.

Fixes #1653, fixes #1689