### PR TITLE
Add information about console output logging

### DIFF
--- a/docs/capturing-output.html
+++ b/docs/capturing-output.html
@@ -74,6 +74,13 @@ public class MyTestClass
   test runners will surface the output for you as well.
 </p>
 
+<p class="note">
+  If running tests via <code>dotnet test</code>, specify
+  <code>--logger "console;verbosity=detailed"</code> to see console output.
+
+  See the <a href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test">dotnet documentation</a> for more details.
+</p>
+
 <p><img class="border" src="/images/capturing-output/vs-runner-output.png" width="775" /></p>
 
 <h2 id="output-in-extensions">Capturing output in extensibility classes</h2>


### PR DESCRIPTION
Fix #2136 

Change preview when running gh-pages locally: 
<img width="1178" alt="Screen Shot 2021-11-30 at 2 33 15 PM" src="https://user-images.githubusercontent.com/797495/144139497-eaea3b7a-894f-47f6-92e7-cca85e8f5d29.png">

