### PR TITLE
Test that Equals only enumerates once

### DIFF
--- a/src/xunit.v3.assert.tests/Asserts/CollectionAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/CollectionAssertsTests.cs
@@ -930,9 +930,9 @@ public class CollectionAssertsTests
 		[Fact]
 		public static void EnumeratesOnlyOnce()
 		{
-            var expected = new [] { 1, 2, 3, 4, 5 };
+			var expected = new[] { 1, 2, 3, 4, 5 };
 			var actual = new RunOnceEnumerable<int>(expected);
-            Assert.Equal(expected, actual);
+			Assert.Equal(expected, actual);
 		}
 	}
 
@@ -1358,7 +1358,7 @@ public class CollectionAssertsTests
 			Assert.Equal("The collection was expected to contain a single element matching (filter expression), but it contained 2 matching elements.", ex.Message);
 		}
 	}
-	
+
 	sealed class RunOnceEnumerable<T> : IEnumerable<T>
 	{
 		private readonly IEnumerable<T> _source;

--- a/src/xunit.v3.assert.tests/Asserts/CollectionAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/CollectionAssertsTests.cs
@@ -926,6 +926,14 @@ public class CollectionAssertsTests
 
 			Assert.Equal(expected, actual);
 		}
+
+		[Fact]
+		public static void EnumeratesOnlyOnce()
+		{
+            var expected = new [] { 1, 2, 3, 4, 5 };
+			var actual = new RunOnceEnumerable<int>(expected);
+            Assert.Equal(expected, actual);
+		}
 	}
 
 	public class EqualDictionary
@@ -1349,6 +1357,26 @@ public class CollectionAssertsTests
 			Assert.IsType<SingleException>(ex);
 			Assert.Equal("The collection was expected to contain a single element matching (filter expression), but it contained 2 matching elements.", ex.Message);
 		}
+	}
+	
+	sealed class RunOnceEnumerable<T> : IEnumerable<T>
+	{
+		private readonly IEnumerable<T> _source;
+		private bool _called;
+
+		public RunOnceEnumerable(IEnumerable<T> source)
+		{
+			_source = source;
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			Assert.False(_called, "GetEnumerator() was called more than once");
+			_called = true;
+			return _source.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 
 	sealed class SpyEnumerator<T> : IEnumerable<T>, IEnumerator<T>


### PR DESCRIPTION
Test for https://github.com/xunit/assert.xunit/pull/48

Issue https://github.com/xunit/xunit/issues/2402

Ensure that Assert.Equals on IEnumerables will only enumerate once.