### PR TITLE
Delete useless null checks in testCases

### DIFF
--- a/src/xunit.v2.tests/Sdk/Frameworks/Runners/XunitTestAssemblyRunnerTests.cs
+++ b/src/xunit.v2.tests/Sdk/Frameworks/Runners/XunitTestAssemblyRunnerTests.cs
@@ -360,7 +360,7 @@ public class XunitTestAssemblyRunnerTests
 
 			return new TestableXunitTestAssemblyRunner(
 				assembly ?? testCases.First().TestMethod.TestClass.TestCollection.TestAssembly,
-				testCases ?? new IXunitTestCase[0],
+				testCases,
 				new List<IMessageSinkMessage>(),
 				SpyMessageSink.Create(),
 				executionOptions ?? TestFrameworkOptions.ForExecution()

--- a/src/xunit.v3.core.tests/Sdk/v3/Runners/XunitTestAssemblyRunnerTests.cs
+++ b/src/xunit.v3.core.tests/Sdk/v3/Runners/XunitTestAssemblyRunnerTests.cs
@@ -84,7 +84,7 @@ public class XunitTestAssemblyRunnerTests
 
 			return new TestableXunitTestAssemblyRunner(
 				assembly ?? testCases.First().TestCollection.TestAssembly,
-				testCases ?? new IXunitTestCase[0],
+				testCases,
 				SpyMessageSink.Create(),
 				executionOptions ?? _TestFrameworkOptions.ForExecution()
 			);


### PR DESCRIPTION
Hi! I love xunit, and I want to help you :)

This commit clean your code, because this code not used, above this code we already have a null check:
``` cs
if (testCases == null)
    testCases = new[] { Mocks.XunitTestCase<ClassUnderTest>("Passing") };
```
and this code - not used:
``` cs
testCases ?? new IXunitTestCase[0]
```
I hope it's helpful!