### PR TITLE
Add async-await to the suggested fix in xUnit2014 analyzer rule documentation

### DIFF
--- a/xunit.analyzers/_rules/xUnit2014.md
+++ b/xunit.analyzers/_rules/xUnit2014.md
@@ -56,9 +56,9 @@ public class xUnit2014
     }
 
     [Fact]
-    public void TestMethod()
+    public async void TestMethod()
     {
-        Assert.ThrowsAsync<DivideByZeroException>(() => MyMath.Divide(1, 0));
+        await Assert.ThrowsAsync<DivideByZeroException>(() => MyMath.Divide(1, 0));
     }
 }
 ```


### PR DESCRIPTION
While the suggested fix is correct (it replaces `Assert.Throws` with `Assert.ThrowsAsync` to fix the violation), it also renders this assert useless (the suggested test will give false positives if the type of the actual exception doesn't match the type of the expected exception).