### PR TITLE
#2534 Fix: "ArgumentFormatter doesn't pretty-print rank-1 variable-bound arrays correctly"

### DIFF
--- a/src/xunit.v3.assert.tests/Asserts/Sdk/ArgumentFormatterTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/Sdk/ArgumentFormatterTests.cs
@@ -178,6 +178,8 @@ public class ArgumentFormatterTests
 			{ typeof(string), "typeof(string)" },
 			{ typeof(int[]), "typeof(int[])" },
 			{ typeof(int).MakeArrayType(1), "typeof(int[*])" },
+			{ typeof(int).MakeArrayType(2), "typeof(int[,])" },
+			{ typeof(int).MakeArrayType(3), "typeof(int[,,])" },
 			{ typeof(DateTime[,]), "typeof(System.DateTime[,])" },
 			{ typeof(decimal[][,]), "typeof(decimal[][,])" },
 			{ typeof(IEnumerable<>), "typeof(System.Collections.Generic.IEnumerable<>)" },

--- a/src/xunit.v3.assert.tests/Asserts/Sdk/ArgumentFormatterTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/Sdk/ArgumentFormatterTests.cs
@@ -177,6 +177,7 @@ public class ArgumentFormatterTests
 		{
 			{ typeof(string), "typeof(string)" },
 			{ typeof(int[]), "typeof(int[])" },
+			{ typeof(int).MakeArrayType(1), "typeof(int[*])" },
 			{ typeof(DateTime[,]), "typeof(System.DateTime[,])" },
 			{ typeof(decimal[][,]), "typeof(decimal[][,])" },
 			{ typeof(IEnumerable<>), "typeof(System.Collections.Generic.IEnumerable<>)" },


### PR DESCRIPTION
Fix for https://github.com/xunit/xunit/issues/2534

Is this issue still open? Saw there was a pull request a while aga.
I tested it and it works, however it doesn't have a call to IsSZArray as requested in Sample Fix and isn't implemented as an extension method to work downlevel.

Anyway I made a fix for the issue that makes a call to IsSZArray and also works downlevel incase IsSZArray is not available due to .NET Version

Let me know what you think of the fix. And if any further improvements are required.

PS: there was a separate pull request for the submodule 