### PR TITLE
Provide a suitable value for the class fixture mapping if its constru…

### DIFF
--- a/src/xunit.v3.core.tests/Acceptance/FixtureAcceptanceTests.cs
+++ b/src/xunit.v3.core.tests/Acceptance/FixtureAcceptanceTests.cs
@@ -120,6 +120,8 @@ public class FixtureAcceptanceTests
 
 		class ClassWithThrowingFixtureCtor : IClassFixture<ThrowingCtorFixture>
 		{
+			public ClassWithThrowingFixtureCtor(ThrowingCtorFixture _) { }
+
 			[Fact]
 			public void TheTest() { }
 		}

--- a/src/xunit.v3.core/Sdk/v3/Runners/TestClassRunner.cs
+++ b/src/xunit.v3.core/Sdk/v3/Runners/TestClassRunner.cs
@@ -36,7 +36,7 @@ public abstract class TestClassRunner<TContext, TTestCase>
 	protected virtual object?[] CreateTestClassConstructorArguments(TContext ctxt)
 	{
 		var isStaticClass = ctxt.Class.Type.IsAbstract && ctxt.Class.Type.IsSealed;
-		if (!isStaticClass)
+		if (!isStaticClass && !ctxt.Aggregator.HasExceptions)
 		{
 			var ctor = SelectTestClassConstructor(ctxt);
 			if (ctor != null)

--- a/src/xunit.v3.core/Sdk/v3/Runners/XunitTestClassRunner.cs
+++ b/src/xunit.v3.core/Sdk/v3/Runners/XunitTestClassRunner.cs
@@ -170,7 +170,6 @@ public class XunitTestClassRunner : TestClassRunner<XunitTestClassRunnerContext,
 				}
 				catch (Exception ex)
 				{
-					ctxt.ClassFixtureMappings[fixtureType] = new object();
 					throw new TestClassException($"Class fixture type '{fixtureType.FullName}' threw in its constructor", ex.Unwrap());
 				}
 			});

--- a/src/xunit.v3.core/Sdk/v3/Runners/XunitTestClassRunner.cs
+++ b/src/xunit.v3.core/Sdk/v3/Runners/XunitTestClassRunner.cs
@@ -170,6 +170,7 @@ public class XunitTestClassRunner : TestClassRunner<XunitTestClassRunnerContext,
 				}
 				catch (Exception ex)
 				{
+					ctxt.ClassFixtureMappings[fixtureType] = new object();
 					throw new TestClassException($"Class fixture type '{fixtureType.FullName}' threw in its constructor", ex.Unwrap());
 				}
 			});


### PR DESCRIPTION
…ctor throws

It allows the mapping to exist such that we aren't pushing more exceptions due to not detecting the arguments later

This one is rather complex to explain and I am open to review should the fix not be proper, but basically, let's say the fixture class's constructor throws, it prevents the test class's constructor from having an entry in its `ClassFixtureMappings`. This means that later on, during `CreateTestClassConstructorArguments`, it will seem like we didn't provided any arguments needed to the constructor of the test class because it will find the constructor, but not its instance mapping during `TryGetConstructorArgument`. This results in a misleading exception being thrown because it looks like as if the argument was missing when the instance was never in the mappings in the first place.

I am relatively unfamiliar with this project, but I feel fixing this is sort of a catch 22: we would want the mapping to exist so it can proceed without throwing further, but it technically isn't correct because the throw makes the fixture invalid. The only way I found to reliably make it work was to assign the mapping to new object. I fear it might be confusing or not proper so I would at least like someone to review if this would be a proper fix. If not, hopefully I provided enough information to figure out a better way to address this.
