### PR TITLE
Added EqualityAssert.Equal method taking two enumerables and a delegate to compare their items

### DIFF
--- a/src/xunit.v3.assert.tests/Asserts/EqualityAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/EqualityAssertsTests.cs
@@ -760,6 +760,150 @@ public class EqualityAssertsTests
 		}
 	}
 
+	public class Equal_WithEnumerablesAndDelegate
+	{
+		[Fact]
+		public void Success_SameType()
+		{
+			var expected = new int[] { 1, 2, 3 };
+			var actual = new int[] { 2, 3, 4 };
+
+			Assert.Equal(expected, actual,
+				(e, a) =>
+				{
+					Assert.Equal(e, a - 1);
+				});
+		}
+
+		[Fact]
+		public void Success_DifferentType()
+		{
+			var expected = new int[] { 1, 2, 3 };
+			var actual = new string[] { "1", "2", "3" };
+
+			Assert.Equal(expected, actual,
+				(e, a) =>
+				{
+					Assert.Equal(e, int.Parse(a));
+				});
+		}
+
+		[Fact]
+		public void Success_Null()
+		{
+			int[]? expected = null;
+			int[]? actual = null;
+
+			Assert.Equal(expected, actual,
+				(e, a) =>
+				{
+					Assert.Equal(e, a - 1);
+				});
+		}
+
+		[Fact]
+		public void Failure_ExpectedNullActualNotNull()
+		{
+			int[]? expected = null;
+			var actual = new int[] { 2, 3 };
+
+			var ex = Assert.Throws<NullException>(() =>
+			{
+				Assert.Equal(expected, actual,
+					(e, a) =>
+					{
+						Assert.Equal(e, a - 1);
+					});
+			});
+		}
+
+		[Fact]
+		public void Failure_ActualNullExpectedNotNull()
+		{
+			int[] expected = new int[] { 2, 3 };
+			int[]? actual = null;
+
+			var ex = Assert.Throws<NotNullException>(() =>
+			{
+				Assert.Equal(expected, actual,
+					(e, a) =>
+					{
+						Assert.Equal(e, a - 1);
+					});
+			});
+		}
+
+		[Fact]
+		public void Failure_MoreExpectedThanActual()
+		{
+			var expected = new int[] { 1, 2, 3 };
+			var actual = new int[] { 2, 3 };
+
+			var ex = Assert.Throws<EqualException>(() =>
+			{
+				Assert.Equal(expected, actual,
+					(e, a) =>
+					{
+						Assert.Equal(e, a - 1);
+					});
+			});
+
+			Assert.Equal("3", ex.Expected);
+			Assert.Equal("2", ex.Actual);
+		}
+
+		[Fact]
+		public void Failure_MoreActualThanExpected()
+		{
+			var expected = new int[] { 1, 2 };
+			var actual = new int[] { 2, 3, 4 };
+
+			var ex = Assert.Throws<EqualException>(() =>
+			{
+				Assert.Equal(expected, actual,
+					(e, a) =>
+					{
+						Assert.Equal(e, a - 1);
+					});
+			});
+
+			Assert.Equal("2", ex.Expected);
+			Assert.Equal("3", ex.Actual);
+		}
+
+		[Fact]
+		public void Failure_DelegateException()
+		{
+			var expected = new int[] { 1, 2, 3 };
+			var actual = new int[] { 2, 3, 4 };
+
+			var ex = Assert.Throws<EqualException>(() =>
+			{
+				Assert.Equal(expected, actual,
+					(e, a) =>
+					{
+						Assert.Equal(e, a);
+					});
+			});
+
+			Assert.Equal("1", ex.Expected);
+			Assert.Equal("2", ex.Actual);
+		}
+
+#if !XUNIT_NULLABLE
+		[Fact]
+		public void Failure_NullDelegate()
+		{
+			var expected = new int[] { 1, 2, 3 };
+			var actual = new int[] { 2, 3, 4 };
+
+			var ex = Assert.Throws<ArgumentNullException>(() => Assert.Equal(expected, actual, comparer: null));
+
+			Assert.Equal("comparer", ex.ParamName);
+		}
+#endif
+	}
+
 	public class Equal_DateTime
 	{
 		public class WithoutPrecision


### PR DESCRIPTION
This PR follows [this discussion](https://github.com/xunit/xunit/discussions/2683) which lead to the creation of [this issue](https://github.com/xunit/xunit/issues/2692).

It basically consists in adding a new method to `Assert`, taking in parameter 2 enumerables and a delegate responsible for comparing the items from each enumerable 1 pair at a time.

Code sample (from the unit tests):

```csharp
var expected = new int[] { 1, 2, 3 };
var actual = new int[] { 2, 3, 4 };

Assert.Equal(expected, actual,
    (e, a) =>
    {
    	Assert.Equal(e, a - 1);
    });
```

Note that the enumerables do not need to be associated to the same item type:

```csharp
var expected = new int[] { 1, 2, 3 };
var actual = new string[] { "1", "2", "3" };

Assert.Equal(expected, actual,
    (e, a) =>
    {
        Assert.Equal(e, int.Parse(a));
    });
```

The code is C#6 compatible but would benefit from several improvements available in more recent C# releases (pattern matching, nullable reference types, short `using` syntax...)

* Did you ensure this is an accepted ['help wanted' issue](
  https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
Not a 'help wanted' issue.

* Did you read the project governance @ https://xunit.net/governance ?
Yes.

* Does the code follow existing coding styles? (tabs, comments, no regions, etc.)
Yes, I tried to stick to the same standards as the edited files.

* Did you write unit tests?
Yes, also included in the PR.
