### PR TITLE
Extending build script for working with preview .NET versions.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ if ($null -eq (Get-Command "dotnet" -ErrorAction Ignore)) {
     throw "Could not find 'dotnet'; please install the  .NET Core SDK"
 }
 
-$version = [Version]$(& dotnet --version)
+$version = [Version]$([regex]::matches((&dotnet --version), '^(\d+\.)?(\d+\.)?(\*|\d+)').value)
 if ($version.Major -lt 7) {
     throw ".NET SDK version ($version) is too low; please install version 7.0 or later"
 }


### PR DESCRIPTION
Some time ago I started [this discussion](https://github.com/dotnet/runtime/discussions/84764). Current PR fixes problem with invalid parsing .NET preview version format in AutoMapper build script.