### PR TITLE
Add release notes link to nuspec files

### DIFF
--- a/src/xunit.assert.nuspec
+++ b/src/xunit.assert.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes the assertion library from xUnit.net (xunit.assert.dll). Supports .NET Standard 1.1.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.assert.source.nuspec
+++ b/src/xunit.assert.source.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes the current assertion library from xUnit.net, as source into your project. Supports any platform(s) compatible with .NET Standard 1.1.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.console.nuspec
+++ b/src/xunit.console.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>.NET Core console runner, as a linkable library, for runner authors. For running tests, please use xunit.runner.console instead.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.core.nuspec
+++ b/src/xunit.core.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes the libraries for writing unit tests with xUnit.net.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.extensibility.core.nuspec
+++ b/src/xunit.extensibility.core.nuspec
@@ -9,6 +9,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes xunit.core.dll for extensibility purposes. Supports .NET 4.5.2 or later, and .NET Standard 1.1.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.extensibility.execution.nuspec
+++ b/src/xunit.extensibility.execution.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes xunit.execution.*.dll for extensibility purposes. Supports .NET 4.5.2 or later, and .NET Standard 1.1.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.nuspec
+++ b/src/xunit.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>xUnit.net is a developer testing framework, built to support Test Driven Development, with a design goal of extreme simplicity and alignment with framework features.
 
 Installing this package installs xunit.core, xunit.assert, and xunit.analyzers.</description>

--- a/src/xunit.runner.console.nuspec
+++ b/src/xunit.runner.console.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Console runner for the xUnit.net framework. Capable of running xUnit.net v1.9.2 and v2.0+ tests. Supports .NET 4.5.2 or later, .NET Core 1.x, and .NET Core 2.x.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.runner.msbuild.nuspec
+++ b/src/xunit.runner.msbuild.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>MSBuild runner for the xUnit.net framework. Capable of running xUnit.net v1.9.2 and v2.0+ tests. Supports .NET 4.5.2 or later.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.runner.reporters.nuspec
+++ b/src/xunit.runner.reporters.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes runner reporters for TeamCity, AppVeyor, Verbose and Quiet output for test runners. Supports .NET 4.5.2 or later, .NET Standard 1.1, .NET Standard 1.5, and .NET Core 1.0 or later.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />

--- a/src/xunit.runner.utility.nuspec
+++ b/src/xunit.runner.utility.nuspec
@@ -10,6 +10,7 @@
     <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <icon>_content/logo-128-transparent.png</icon>
     <readme>_content/README.md</readme>
+    <releaseNotes>https://xunit.net/releases/$PackageVersion$</releaseNotes>
     <description>Includes the version-independent runner for xUnit.net to run both v1.9.2 and v2.0+ tests (xunit.runner.utility.*.dll). Supports .NET 3.5, .NET 4.5.2 or later, .NET Standard 1.1, .NET Standard 1.5, and .NET Core 1.0 or later.</description>
     <copyright>Copyright (C) .NET Foundation</copyright>
     <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />


### PR DESCRIPTION
Fixes #2742

Added `releaseNotes` to nuspec files for projects mentioned on https://xunit.net/releases/2.5.0:

* xunit
* core
* assert
* extensibility
* runners

One downside (mostly for pre-release packages) is that this will generate a link in NuGet to a page that may not ever exist, e.g., https://xunit.net/releases/2.5.1-pre.2.