### PR TITLE
poc for fix issue 1985

### DIFF
--- a/src/xunit.v3.runner.common.tests/Issue1985Tests.cs
+++ b/src/xunit.v3.runner.common.tests/Issue1985Tests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace System.Diagnostics.CodeAnalysis;
+
+public class Issue1985Tests
+{
+
+	public static IEnumerable<object[]> MyTestCases(string name, int maxSzenarios = 444)
+	{
+		for (int i = 1; i <= maxSzenarios; i++)
+		{
+			yield return new object[] { name, i };
+		}
+	}
+
+	public static IEnumerable<object[]> MyTestCases(string name, string maxSzenarios = "444")
+	{
+		yield return new object[] { name + name, int.Parse(maxSzenarios) };
+	}
+
+	// Uncomment the method below for the test to pass
+	
+	// public static IEnumerable<object[]> MyTestCases(string name)
+	// {
+	// 	yield return new object[] { name + name, 2 };
+	// }
+	
+	[Theory]
+	[MemberData(nameof(MyTestCases), "MyFirst")]
+	[MemberData(nameof(MyTestCases), "MySecond")]
+	public void MyTestMethod(string name, int szenario)
+	{
+		Assert.True(name.Length > 0);
+		Assert.True(szenario > 0);
+	}
+}


### PR DESCRIPTION
Before you submit a PR...

* Did you ensure this is an accepted ['help wanted' issue](
  https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
* Did you read the project governance @ https://xunit.net/governance ?
* Does the code follow existing coding styles? (tabs, comments, no regions, etc.)
* Did you write unit tests?

I've checked the issue 1985 and thought about two approaches:
- provide support for methods with optional parameters
- provide only more detailed exception message, as reporter mentioned.

I realized that there may be a lot of cases:
- method with multiple optional parameters
- method with multiple optional parameters, and only some of them are called
- multiple methods with similar set of parameters, some of them may be optional...
- etc.
And this may lead to very complicated algorithm, which will try to make the best guess what method to use, and in many cases this decision can be impossible to be done.

So I decided it is not worth the effort to write a lot of code, instead - as reporter suggested - it should be enough to mention that such methods (with optional parameter) are not supported.

So - I put the exception if no method with exactly corresponding singature was found.

In attached "test class" - there are 2 methods, none of them is proper (both contain optional parameters), so when you run the project (randomly selected), this test will fail.
However, if you uncomment the "proper" member data method, it will pass, as the corresponding method has been found.

P.S. As a side note: I've found that `FirstOrDefault` in line 182 could be Single, as we expect only Single method with given parameters set. However, 11 unit tests failed when changing it to Single, so it may be eventually another small PR.
