### PR TITLE
Allow for MemberData to not specify arguments for optional parameters

### DIFF
--- a/src/xunit.v3.core.tests/Acceptance/Xunit3TheoryAcceptanceTests.cs
+++ b/src/xunit.v3.core.tests/Acceptance/Xunit3TheoryAcceptanceTests.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 using Xunit.v3;
 
@@ -1962,6 +1963,67 @@ public class Xunit3TheoryAcceptanceTests
 			public static IEnumerable<object?[]> TestData()
 			{
 				yield return new object?[] { 42 };
+			}
+		}
+
+		[Fact]
+		public async Task OptionalParametersSupported()
+		{
+			var testMessages = await RunForResultsAsync(typeof(ClassWithDataMethodsWithOptionalParameters));
+
+			Assert.NotEmpty(testMessages.OfType<TestPassedWithDisplayName>());
+			Assert.Empty(testMessages.OfType<_TestFailed>());
+			Assert.Empty(testMessages.OfType<_TestSkipped>());
+		}
+
+		class ClassWithDataMethodsWithOptionalParameters
+		{
+			public static IEnumerable<object[]> DataMethodWithOptionalParameters(string name, int scenarios = 444)
+			{
+				for (int i = 1; i <= scenarios; i++)
+					yield return new object[] { name, i };
+			}
+
+			[Theory]
+			[MemberData(nameof(DataMethodWithOptionalParameters), "MyFirst")]
+			[MemberData(nameof(DataMethodWithOptionalParameters), "MySecond")]
+			public void TestMethod(string name, int scenario)
+			{
+				Assert.True(name.Length > 0);
+				Assert.True(scenario > 0);
+			}
+		}
+
+		[Fact]
+		public async Task MultipleMethodsButOnlyOneNonOptionalSupported()
+		{
+			var testMessages = await RunForResultsAsync(typeof(ClassWithMultipleMethodsButOneWithoutOptionalParameters));
+
+			Assert.Equal(2, testMessages.OfType<TestPassedWithDisplayName>().Count());
+			Assert.Empty(testMessages.OfType<_TestFailed>());
+			Assert.Empty(testMessages.OfType<_TestSkipped>());
+		}
+
+		class ClassWithMultipleMethodsButOneWithoutOptionalParameters
+		{
+			public static IEnumerable<object[]> OverloadedDataMethod(string name, int scenarios = 444)
+			{
+				for (int i = 1; i <= scenarios; i++)
+					yield return new object[] { name, i };
+			}
+
+			public static IEnumerable<object[]> OverloadedDataMethod(string name)
+			{
+				yield return new object[] { name, -1 };
+			}
+
+			[Theory]
+			[MemberData(nameof(OverloadedDataMethod), "MyFirst")]
+			[MemberData(nameof(OverloadedDataMethod), "MySecond")]
+			public void TestMethod(string name, int scenario)
+			{
+				Assert.True(name.Length > 0);
+				Assert.Equal(-1, scenario);
 			}
 		}
 	}

--- a/src/xunit.v3.core.tests/Acceptance/Xunit3TheoryAcceptanceTests.cs
+++ b/src/xunit.v3.core.tests/Acceptance/Xunit3TheoryAcceptanceTests.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 using Xunit.v3;
 

--- a/src/xunit.v3.core.tests/Acceptance/Xunit3TheoryAcceptanceTests.cs
+++ b/src/xunit.v3.core.tests/Acceptance/Xunit3TheoryAcceptanceTests.cs
@@ -2025,6 +2025,40 @@ public class Xunit3TheoryAcceptanceTests
 				Assert.Equal(-1, scenario);
 			}
 		}
+
+		[Fact]
+		public async Task MultipleMethodsWithAmbiguousOptionalParameters()
+		{
+			var testMessages = await RunForResultsAsync(typeof(ClassWithMultipleMethodsAndAmbiguousOptionalParameters));
+
+			Assert.Empty(testMessages.OfType<_TestPassed>());
+			var failed = Assert.Single(testMessages.OfType<_TestFailed>());
+			Assert.StartsWith(
+				"The call to method 'Xunit3TheoryAcceptanceTests+MethodDataTests+ClassWithMultipleMethodsAndAmbiguousOptionalParameters.OverloadedDataMethod' is ambigous between 2 different options for the given arguments.",
+				failed.Messages.Single()
+			);
+			Assert.Empty(testMessages.OfType<_TestSkipped>());
+		}
+
+		class ClassWithMultipleMethodsAndAmbiguousOptionalParameters
+		{
+			public static IEnumerable<object[]> OverloadedDataMethod(string name, int scenarios = 444)
+			{
+				for (int i = 1; i <= scenarios; i++)
+					yield return new object[] { name, i };
+			}
+
+			public static IEnumerable<object[]> OverloadedDataMethod(string name, string scenariosAsString = "444")
+			{
+				yield return new object[] { name, int.Parse(scenariosAsString) };
+			}
+
+			[Theory]
+			[MemberData(nameof(OverloadedDataMethod), "MyFirst")]
+			[MemberData(nameof(OverloadedDataMethod), "MySecond")]
+			public void TestMethod(string _1, int _2)
+			{ }
+		}
 	}
 
 	public class CustomDataTests : AcceptanceTestV3

--- a/src/xunit.v3.core/MemberDataAttribute.cs
+++ b/src/xunit.v3.core/MemberDataAttribute.cs
@@ -18,10 +18,10 @@ public sealed class MemberDataAttribute : MemberDataAttributeBase
 	/// Initializes a new instance of the <see cref="MemberDataAttribute"/> class.
 	/// </summary>
 	/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
-	/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
+	/// <param name="arguments">The arguments to be passed to the member (only supported for methods; ignored for everything else)</param>
 	public MemberDataAttribute(
 		string memberName,
-		params object?[] parameters)
-			: base(memberName, parameters)
+		params object?[] arguments)
+			: base(memberName, arguments)
 	{ }
 }

--- a/src/xunit.v3.core/MemberDataAttributeBase.cs
+++ b/src/xunit.v3.core/MemberDataAttributeBase.cs
@@ -38,13 +38,13 @@ public abstract class MemberDataAttributeBase : DataAttribute
 	/// Initializes a new instance of the <see cref="MemberDataAttributeBase"/> class.
 	/// </summary>
 	/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
-	/// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
+	/// <param name="arguments">The arguments to be passed to the member (only supported for methods; ignored for everything else)</param>
 	protected MemberDataAttributeBase(
 		string memberName,
-		object?[] parameters)
+		object?[] arguments)
 	{
 		MemberName = Guard.ArgumentNotNull(memberName);
-		Parameters = Guard.ArgumentNotNull(parameters);
+		Arguments = Guard.ArgumentNotNull(arguments);
 	}
 
 	/// <summary>
@@ -66,9 +66,9 @@ public abstract class MemberDataAttributeBase : DataAttribute
 	public Type? MemberType { get; set; }
 
 	/// <summary>
-	/// Gets or sets the parameters passed to the member. Only supported for static methods.
+	/// Gets or sets the arguments passed to the member. Only supported for static methods.
 	/// </summary>
-	public object?[] Parameters { get; }
+	public object?[] Arguments { get; }
 
 	/// <inheritdoc/>
 	protected override ITheoryDataRow ConvertDataRow(
@@ -114,7 +114,7 @@ public abstract class MemberDataAttributeBase : DataAttribute
 					"Could not find public static member (property, field, or method) named '{0}' on {1}{2}",
 					MemberName,
 					type.FullName,
-					Parameters.Length > 0 ? string.Format(CultureInfo.CurrentCulture, " with parameter types: {0}", string.Join(", ", Parameters.Select(p => p?.GetType().FullName ?? "(null)"))) : ""
+					Arguments.Length > 0 ? string.Format(CultureInfo.CurrentCulture, " with parameter types: {0}", string.Join(", ", Arguments.Select(p => p?.GetType().FullName ?? "(null)"))) : ""
 				)
 			);
 
@@ -200,13 +200,13 @@ public abstract class MemberDataAttributeBase : DataAttribute
 	Func<object?>? GetMethodAccessor(Type? type)
 	{
 		MethodInfo? methodInfo = null;
-		var parameterTypes = Parameters is null ? Array.Empty<Type>() : Parameters.Select(p => p?.GetType()).ToArray();
+		var argumentTypes = Arguments is null ? Array.Empty<Type>() : Arguments.Select(p => p?.GetType()).ToArray();
 		for (var reflectionType = type; reflectionType is not null; reflectionType = reflectionType.BaseType)
 		{
 			methodInfo =
 				reflectionType
 					.GetRuntimeMethods()
-					.FirstOrDefault(m => m.Name == MemberName && ParameterTypesCompatible(m.GetParameters(), parameterTypes));
+					.FirstOrDefault(m => m.Name == MemberName && ParameterTypesCompatible(m.GetParameters(), argumentTypes));
 
 			if (methodInfo is not null)
 				break;
@@ -215,7 +215,12 @@ public abstract class MemberDataAttributeBase : DataAttribute
 		if (methodInfo is null || !methodInfo.IsStatic)
 			return null;
 
-		return () => methodInfo.Invoke(null, Parameters);
+		var completedArguments = Arguments ?? Array.Empty<object?>();
+		var finalMethodParameters = methodInfo.GetParameters();
+		completedArguments = completedArguments.Length == finalMethodParameters.Length
+			? completedArguments
+			: completedArguments.Concat(finalMethodParameters.Skip(completedArguments.Length).Select(pi => pi.DefaultValue)).ToArray();
+		return () => methodInfo.Invoke(null, completedArguments);
 	}
 
 	Func<object?>? GetPropertyAccessor(Type? type)
@@ -235,14 +240,19 @@ public abstract class MemberDataAttributeBase : DataAttribute
 	}
 
 	static bool ParameterTypesCompatible(
-		ParameterInfo[]? parameters,
-		Type?[] parameterTypes)
+		ParameterInfo[] parameters,
+		Type?[] argumentTypes)
 	{
-		if (parameters?.Length != parameterTypes.Length)
+		if (parameters.Length < argumentTypes.Length)
 			return false;
 
-		for (var idx = 0; idx < parameters.Length; ++idx)
-			if (parameterTypes[idx] is not null && !parameters[idx].ParameterType.IsAssignableFrom(parameterTypes[idx]!))
+		var idx = 0;
+		for (; idx < argumentTypes.Length; ++idx)
+			if (argumentTypes[idx] is not null && !parameters[idx].ParameterType.IsAssignableFrom(argumentTypes[idx]!))
+				return false;
+
+		for (; idx < parameters.Length; ++idx)
+			if (!parameters[idx].IsOptional)
 				return false;
 
 		return true;

--- a/src/xunit.v3.core/MemberDataAttributeBase.cs
+++ b/src/xunit.v3.core/MemberDataAttributeBase.cs
@@ -219,7 +219,7 @@ public abstract class MemberDataAttributeBase : DataAttribute
 			if (methodInfo is not null)
 				break;
 
-			throw new ArgumentException($"The call to method '{type!.SafeName()}.{MemberName}' is ambigous between {methodInfoArray.Length} different options for the given arguments.");
+			throw new ArgumentException($"The call to method '{type!.SafeName()}.{MemberName}' is ambigous between {methodInfoArray.Length} different options for the given arguments.", nameof(type));
 		}
 
 		if (methodInfo is null || !methodInfo.IsStatic)

--- a/src/xunit.v3.core/Sdk/MemberDataDiscoverer.cs
+++ b/src/xunit.v3.core/Sdk/MemberDataDiscoverer.cs
@@ -30,7 +30,7 @@ public class MemberDataDiscoverer : DataDiscoverer
 				memberDataAttribute.MemberType is null &&
 				reflectionTestMethod.Type is _IReflectionTypeInfo reflectionTestMethodType)
 			{
-				var newMemberDataAttribute = new MemberDataAttribute(memberDataAttribute.MemberName, memberDataAttribute.Parameters)
+				var newMemberDataAttribute = new MemberDataAttribute(memberDataAttribute.MemberName, memberDataAttribute.Arguments)
 				{
 					DisableDiscoveryEnumeration = memberDataAttribute.DisableDiscoveryEnumeration,
 					Explicit = memberDataAttribute.Explicit,


### PR DESCRIPTION
Proposed fix for https://github.com/xunit/xunit/issues/1985
@bradwilson 

Before you submit a PR...

* Did you ensure this is an accepted ['help wanted' issue](
  https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
* Did you read the project governance @ https://xunit.net/governance ?
* Does the code follow existing coding styles? (tabs, comments, no regions, etc.)
* Did you write unit tests?
