### PR TITLE
Changing DelegatingSummarySink and DelegatingXmlCreationSink to invok…

### DIFF
--- a/src/xunit.v3.runner.common.tests/Sinks/DelegatingSinks/DelegatingXmlCreationSinkTests.cs
+++ b/src/xunit.v3.runner.common.tests/Sinks/DelegatingSinks/DelegatingXmlCreationSinkTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using NSubstitute;
@@ -88,60 +87,6 @@ public class DelegatingXmlCreationSinkTests
 		);
 		var assemblyElement = new XElement("assembly");
 		var sink = new DelegatingXmlCreationSink(innerSink, assemblyElement);
-		var errorMessage = TestData.ErrorMessage(
-			exceptionParentIndices: new[] { -1 },
-			exceptionTypes: new[] { "ExceptionType" },
-			messages: new[] { "Message" },
-			stackTraces: new[] { "Stack" }
-		);
-
-		sink.OnMessage(errorMessage);
-		sink.OnMessage(assemblyFinished);
-
-		Assert.Equal("2112", assemblyElement.Attribute("total")!.Value);
-		Assert.Equal("2061", assemblyElement.Attribute("passed")!.Value);
-		Assert.Equal("42", assemblyElement.Attribute("failed")!.Value);
-		Assert.Equal("6", assemblyElement.Attribute("skipped")!.Value);
-		Assert.Equal("3", assemblyElement.Attribute("not-run")!.Value);
-		Assert.Equal(123.457M.ToString(CultureInfo.InvariantCulture), assemblyElement.Attribute("time")!.Value);
-		Assert.Equal("1", assemblyElement.Attribute("errors")!.Value);
-	}
-
-	private sealed class ExecutionSinkThatFillsExecutionSummaryWhenOnMessageInvoked : IExecutionSink
-	{
-		private readonly ExecutionSummary _executionSummary = new();
-		public ExecutionSummary ExecutionSummary => _executionSummary;
-
-		private readonly ManualResetEvent _finishedMre = new(false);
-		public ManualResetEvent Finished => _finishedMre;
-
-
-		public void Dispose()
-		{
-			//Intentionally empty
-		}
-
-		public bool OnMessage(_MessageSinkMessage message)
-		{
-			_executionSummary.Total = 2112;
-			_executionSummary.Failed = 42;
-			_executionSummary.Skipped = 6;
-			_executionSummary.NotRun = 3;
-			_executionSummary.Time = 123.4567M;
-			_executionSummary.Errors = 1;
-			return true;
-		}
-	}
-
-
-	[CulturedFact]
-	public void AddsAssemblyFinishedInformationToXmlWhenSummaryIsFilledByOnMessage()
-	{
-		IExecutionSink localSink = new ExecutionSinkThatFillsExecutionSummaryWhenOnMessageInvoked();
-
-		var assemblyFinished = TestData.TestAssemblyFinished();
-		var assemblyElement = new XElement("assembly");
-		var sink = new DelegatingXmlCreationSink(localSink, assemblyElement);
 		var errorMessage = TestData.ErrorMessage(
 			exceptionParentIndices: new[] { -1 },
 			exceptionTypes: new[] { "ExceptionType" },

--- a/src/xunit.v3.runner.common.tests/Sinks/DelegatingSinks/DelegatingXmlCreationSinkTests.cs
+++ b/src/xunit.v3.runner.common.tests/Sinks/DelegatingSinks/DelegatingXmlCreationSinkTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using NSubstitute;
@@ -83,6 +84,60 @@ public class DelegatingXmlCreationSinkTests
 		var assemblyFinished = TestData.TestAssemblyFinished();
 		var assemblyElement = new XElement("assembly");
 		var sink = new DelegatingXmlCreationSink(innerSink, assemblyElement);
+		var errorMessage = TestData.ErrorMessage(
+			exceptionParentIndices: new[] { -1 },
+			exceptionTypes: new[] { "ExceptionType" },
+			messages: new[] { "Message" },
+			stackTraces: new[] { "Stack" }
+		);
+
+		sink.OnMessage(errorMessage);
+		sink.OnMessage(assemblyFinished);
+
+		Assert.Equal("2112", assemblyElement.Attribute("total")!.Value);
+		Assert.Equal("2061", assemblyElement.Attribute("passed")!.Value);
+		Assert.Equal("42", assemblyElement.Attribute("failed")!.Value);
+		Assert.Equal("6", assemblyElement.Attribute("skipped")!.Value);
+		Assert.Equal("3", assemblyElement.Attribute("not-run")!.Value);
+		Assert.Equal(123.457M.ToString(CultureInfo.InvariantCulture), assemblyElement.Attribute("time")!.Value);
+		Assert.Equal("1", assemblyElement.Attribute("errors")!.Value);
+	}
+
+	private sealed class ExecutionSinkThatFillsExecutionSummaryWhenOnMessageInvoked : IExecutionSink
+	{
+		private readonly ExecutionSummary _executionSummary = new();
+		public ExecutionSummary ExecutionSummary => _executionSummary;
+
+		private readonly ManualResetEvent _finishedMre = new(false);
+		public ManualResetEvent Finished => _finishedMre;
+
+
+		public void Dispose()
+		{
+			//Intentionally empty
+		}
+
+		public bool OnMessage(_MessageSinkMessage message)
+		{
+			_executionSummary.Total = 2112;
+			_executionSummary.Failed = 42;
+			_executionSummary.Skipped = 6;
+			_executionSummary.NotRun = 3;
+			_executionSummary.Time = 123.4567M;
+			_executionSummary.Errors = 1;
+			return true;
+		}
+	}
+
+
+	[CulturedFact]
+	public void AddsAssemblyFinishedInformationToXmlWhenSummaryIsFilledByOnMessage()
+	{
+		IExecutionSink localSink = new ExecutionSinkThatFillsExecutionSummaryWhenOnMessageInvoked();
+
+		var assemblyFinished = TestData.TestAssemblyFinished();
+		var assemblyElement = new XElement("assembly");
+		var sink = new DelegatingXmlCreationSink(localSink, assemblyElement);
 		var errorMessage = TestData.ErrorMessage(
 			exceptionParentIndices: new[] { -1 },
 			exceptionTypes: new[] { "ExceptionType" },

--- a/src/xunit.v3.runner.common/Sinks/DelegatingSinks/DelegatingSummarySink.cs
+++ b/src/xunit.v3.runner.common/Sinks/DelegatingSinks/DelegatingSummarySink.cs
@@ -157,10 +157,7 @@ public class DelegatingSummarySink : IExecutionSink
 	{
 		Guard.ArgumentNotNull(message);
 
-		var result = innerSink.OnMessage(message);
-
-		return
-			message.DispatchWhen<_DiscoveryComplete>(HandleDiscoveryComplete)
+		var dispatchSuccessful = message.DispatchWhen<_DiscoveryComplete>(HandleDiscoveryComplete)
 			&& message.DispatchWhen<_DiscoveryStarting>(HandleDiscoveryStarting)
 			&& message.DispatchWhen<_ErrorMessage>(args => Interlocked.Increment(ref errors))
 			&& message.DispatchWhen<_TestAssemblyCleanupFailure>(args => Interlocked.Increment(ref errors))
@@ -171,7 +168,9 @@ public class DelegatingSummarySink : IExecutionSink
 			&& message.DispatchWhen<_TestCleanupFailure>(args => Interlocked.Increment(ref errors))
 			&& message.DispatchWhen<_TestCollectionCleanupFailure>(args => Interlocked.Increment(ref errors))
 			&& message.DispatchWhen<_TestMethodCleanupFailure>(args => Interlocked.Increment(ref errors))
-			&& result
 			&& !cancelThunk();
+
+		return innerSink.OnMessage(message)
+			&& dispatchSuccessful;
 	}
 }

--- a/src/xunit.v3.runner.common/Sinks/DelegatingSinks/DelegatingXmlCreationSink.cs
+++ b/src/xunit.v3.runner.common/Sinks/DelegatingSinks/DelegatingXmlCreationSink.cs
@@ -348,12 +348,7 @@ public class DelegatingXmlCreationSink : IExecutionSink
 	{
 		Guard.ArgumentNotNull(message);
 
-		// Call the inner sink first, because we want to be able to depend on ExecutionSummary
-		// being correctly filled out.
-		var result = innerSink.OnMessage(message);
-
-		return message.DispatchWhen<_ErrorMessage>(HandleErrorMessage)
-
+		var dispatchSuccessful = message.DispatchWhen<_ErrorMessage>(HandleErrorMessage)
 			&& message.DispatchWhen<_TestAssemblyCleanupFailure>(HandleTestAssemblyCleanupFailure)
 			&& message.DispatchWhen<_TestAssemblyFinished>(HandleTestAssemblyFinished)
 			&& message.DispatchWhen<_TestAssemblyStarting>(HandleTestAssemblyStarting)
@@ -380,9 +375,10 @@ public class DelegatingXmlCreationSink : IExecutionSink
 			&& message.DispatchWhen<_TestPassed>(HandleTestPassed)
 			&& message.DispatchWhen<_TestNotRun>(HandleTestNotRun)
 			&& message.DispatchWhen<_TestSkipped>(HandleTestSkipped)
-			&& message.DispatchWhen<_TestStarting>(HandleTestStarting)
+			&& message.DispatchWhen<_TestStarting>(HandleTestStarting);
 
-			&& result;
+		return innerSink.OnMessage(message)
+			&& dispatchSuccessful;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Changing `DelegatingSummarySink` and `DelegatingXmlCreationSink` to invoke` innerSink.OnMessage` after local handling of messages.

fixing #2090 and maybe #1534

Note I tried to only invoke the local `HandleTestAssemblyFinished` after `innerSink.OnMessage` per the comment in #2090 
> We could move the inner sink invocation down as you suggest, with the caveat that we call HandleTestAssemblyFinished after the inner sink has had a chance to run.

However, this did not pass unit tests nor fix the issue.

The current changes I have made do pass all unit tests and also pass the test from https://github.com/sobkowicz/xunit-sink-xml-app.

I don't love the new unit test I added, and I am uncertain if you will like the location of the new class made to facilitate the test. Honestly I am not sure this test adds value, but it does demonstrate that the innerSink.OnMessage is invoked successfully as part of the process.

If this is accepted I will make a similar PR for V2.