### PR TITLE
Added Disabled Parallelization section to xUnit1031 warning documentation

### DIFF
--- a/xunit.analyzers/_rules/xUnit1031.md
+++ b/xunit.analyzers/_rules/xUnit1031.md
@@ -58,16 +58,22 @@ public class xUnit1031
 }
 ```
 
-
-
 ## Disabled parallelization
 
-When parallelization is intentionally disabled, this warning is unwarranted.
+If you have disabled parallelization for the entire test assembly, you can disable this warning as it no longer
+applies to your project.
 
-In that case it can be explicitly suppressed in the project.
+You can disable it via a global attribute:
 
-```C#
+```csharp
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("xUnit", "xUnit1031", Justification = "Parallelization is disabled")]
+```
+
+Or you can disable it by adding the following to a project-level `.editorconfig` file:
+
+```ini
+[*.cs]
+dotnet_diagnostic.xUnit1031.severity = none
 ```

--- a/xunit.analyzers/_rules/xUnit1031.md
+++ b/xunit.analyzers/_rules/xUnit1031.md
@@ -57,3 +57,17 @@ public class xUnit1031
     }
 }
 ```
+
+
+
+## Disabled parallelization
+
+When parallelization is intentionally disabled, this warning is unwarranted.
+
+In that case it can be explicitly suppressed in the project.
+
+```C#
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("xUnit", "xUnit1031", Justification = "Parallelization is disabled")]
+```


### PR DESCRIPTION
Added disabled parallelization section to give users a guide on how to disable this warning when parallelization is disabled

Before you submit a PR...

* Did you ensure this is an accepted ['help wanted' issue](
  https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
* Did you read the project governance @ https://xunit.net/governance ?
* Does the code follow existing coding styles? (tabs, comments, no regions, etc.)
* Did you write unit tests?
