### PR TITLE
Emit warning messages to the runner for config files when relevant

### DIFF
--- a/src/xunit.v3.runner.common/Parsers/CommandLineParserBase.cs
+++ b/src/xunit.v3.runner.common/Parsers/CommandLineParserBase.cs
@@ -149,6 +149,9 @@ public abstract class CommandLineParserBase
 		Args.Length > 0 && (Args[0] == "-?" || Args[0] == "/?" || Args[0] == "-h" || Args[0] == "--help");
 
 	/// <summary/>
+	public List<string> ParseWarnings { get; } = new();
+
+	/// <summary/>
 	protected XunitProject Project { get; } = new();
 
 	/// <summary/>

--- a/src/xunit.v3.runner.console/CommandLine.cs
+++ b/src/xunit.v3.runner.console/CommandLine.cs
@@ -30,6 +30,8 @@ public class CommandLine : CommandLineParserBase
 		AddParsers();
 	}
 
+	public List<string> parseWarnings { get; } = new();
+	
 	private void AddParsers()
 	{
 		// General options
@@ -74,7 +76,8 @@ public class CommandLine : CommandLineParserBase
 			TargetFramework = targetFramework
 		};
 
-		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName);
+		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, out List<string> warnings);
+		parseWarnings.AddRange(warnings);
 		projectAssembly.Configuration.Seed = seed ?? projectAssembly.Configuration.Seed;
 
 		Project.Add(projectAssembly);

--- a/src/xunit.v3.runner.console/CommandLine.cs
+++ b/src/xunit.v3.runner.console/CommandLine.cs
@@ -30,8 +30,6 @@ public class CommandLine : CommandLineParserBase
 		AddParsers();
 	}
 
-	public List<string> parseWarnings { get; } = new();
-	
 	private void AddParsers()
 	{
 		// General options
@@ -76,8 +74,7 @@ public class CommandLine : CommandLineParserBase
 			TargetFramework = targetFramework
 		};
 
-		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, out List<string> warnings);
-		parseWarnings.AddRange(warnings);
+		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, ParseWarnings);
 		projectAssembly.Configuration.Seed = seed ?? projectAssembly.Configuration.Seed;
 
 		Project.Add(projectAssembly);

--- a/src/xunit.v3.runner.console/ConsoleRunner.cs
+++ b/src/xunit.v3.runner.console/ConsoleRunner.cs
@@ -102,7 +102,7 @@ sealed class ConsoleRunner
 			if (!reporter.ForceNoLogo && !project.Configuration.NoLogoOrDefault)
 				PrintHeader();
 
-			foreach (string warning in commandLine.parseWarnings)
+			foreach (string warning in commandLine.ParseWarnings)
 				logger.LogWarning(warning);
 
 			var failCount = 0;

--- a/src/xunit.v3.runner.console/ConsoleRunner.cs
+++ b/src/xunit.v3.runner.console/ConsoleRunner.cs
@@ -102,6 +102,9 @@ sealed class ConsoleRunner
 			if (!reporter.ForceNoLogo && !project.Configuration.NoLogoOrDefault)
 				PrintHeader();
 
+			foreach (string warning in commandLine.parseWarnings)
+				logger.LogWarning(warning);
+
 			var failCount = 0;
 
 			if (project.Configuration.List is not null)

--- a/src/xunit.v3.runner.inproc.console/CommandLine.cs
+++ b/src/xunit.v3.runner.inproc.console/CommandLine.cs
@@ -33,9 +33,6 @@ public class CommandLine : CommandLineParserBase
 			"  collections - parallelize by collections [default]"
 		);
 	}
-	
-	/// <summary/>
-	public List<string> parseWarnings { get; } = new();
 
 	void AddAssembly(
 		Assembly assembly,
@@ -57,8 +54,7 @@ public class CommandLine : CommandLineParserBase
 			TargetFramework = targetFramework
 		};
 
-		ConfigReader_Json.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, out List<string> warnings);
-		parseWarnings.AddRange(warnings);
+		ConfigReader_Json.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, ParseWarnings);
 		projectAssembly.Configuration.Seed = seed ?? projectAssembly.Configuration.Seed;
 
 		Project.Add(projectAssembly);

--- a/src/xunit.v3.runner.inproc.console/CommandLine.cs
+++ b/src/xunit.v3.runner.inproc.console/CommandLine.cs
@@ -33,6 +33,9 @@ public class CommandLine : CommandLineParserBase
 			"  collections - parallelize by collections [default]"
 		);
 	}
+	
+	/// <summary/>
+	public List<string> parseWarnings { get; } = new();
 
 	void AddAssembly(
 		Assembly assembly,
@@ -54,7 +57,8 @@ public class CommandLine : CommandLineParserBase
 			TargetFramework = targetFramework
 		};
 
-		ConfigReader_Json.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName);
+		ConfigReader_Json.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, out List<string> warnings);
+		parseWarnings.AddRange(warnings);
 		projectAssembly.Configuration.Seed = seed ?? projectAssembly.Configuration.Seed;
 
 		Project.Add(projectAssembly);

--- a/src/xunit.v3.runner.inproc.console/ConsoleRunner.cs
+++ b/src/xunit.v3.runner.inproc.console/ConsoleRunner.cs
@@ -116,8 +116,8 @@ public class ConsoleRunner
 
 			if (!reporter.ForceNoLogo && !project.Configuration.NoLogoOrDefault)
 				PrintHeader();
-			
-			foreach (string warning in commandLine.parseWarnings)
+
+			foreach (string warning in commandLine.ParseWarnings)
 				logger.LogWarning(warning);
 
 			var failCount = 0;

--- a/src/xunit.v3.runner.inproc.console/ConsoleRunner.cs
+++ b/src/xunit.v3.runner.inproc.console/ConsoleRunner.cs
@@ -116,6 +116,9 @@ public class ConsoleRunner
 
 			if (!reporter.ForceNoLogo && !project.Configuration.NoLogoOrDefault)
 				PrintHeader();
+			
+			foreach (string warning in commandLine.parseWarnings)
+				logger.LogWarning(warning);
 
 			var failCount = 0;
 

--- a/src/xunit.v3.runner.msbuild/xunit.cs
+++ b/src/xunit.v3.runner.msbuild/xunit.cs
@@ -228,7 +228,12 @@ public class xunit : MSBuildTask, ICancelableTask
 					TargetFramework = targetFramework
 				};
 
-				ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, configFileName);
+				bool loaded = ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, configFileName, out List<string> warnings);
+				if (!loaded && warnings.Count > 0)
+				{
+					foreach (string warning in warnings)
+						logger.LogWarning(warning);
+				}
 
 				if (Culture is not null)
 					projectAssembly.Configuration.Culture = Culture switch

--- a/src/xunit.v3.runner.msbuild/xunit.cs
+++ b/src/xunit.v3.runner.msbuild/xunit.cs
@@ -228,12 +228,11 @@ public class xunit : MSBuildTask, ICancelableTask
 					TargetFramework = targetFramework
 				};
 
-				bool loaded = ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, configFileName, out List<string> warnings);
-				if (!loaded && warnings.Count > 0)
-				{
-					foreach (string warning in warnings)
-						logger.LogWarning(warning);
-				}
+				var warnings = new List<string>();
+				ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, configFileName, warnings);
+
+				foreach (string warning in warnings)
+					logger.LogWarning(warning);
 
 				if (Culture is not null)
 					projectAssembly.Configuration.Culture = Culture switch

--- a/src/xunit.v3.runner.tdnet/TdNetRunnerHelper.cs
+++ b/src/xunit.v3.runner.tdnet/TdNetRunnerHelper.cs
@@ -36,7 +36,7 @@ public class TdNetRunnerHelper : IAsyncDisposable
 		Assembly assembly,
 		ITestListener testListener)
 	{
-		this.testListener = testListener;
+		this.testListener = Guard.ArgumentNotNull(testListener);
 
 		var assemblyFileName = assembly.GetLocalCodeBase();
 		var project = new XunitProject();
@@ -47,7 +47,12 @@ public class TdNetRunnerHelper : IAsyncDisposable
 			TargetFramework = AssemblyUtility.GetTargetFramework(assemblyFileName)
 		};
 		projectAssembly.Configuration.ShadowCopy = false;
-		ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, null, out _);
+
+		var warnings = new List<string>();
+		ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, warnings: warnings);
+
+		foreach (var warning in warnings)
+			testListener.WriteLine(warning, Category.Warning);
 
 		var diagnosticMessages = projectAssembly.Configuration.DiagnosticMessagesOrDefault;
 		var internalDiagnosticMessages = projectAssembly.Configuration.InternalDiagnosticMessagesOrDefault;

--- a/src/xunit.v3.runner.tdnet/TdNetRunnerHelper.cs
+++ b/src/xunit.v3.runner.tdnet/TdNetRunnerHelper.cs
@@ -47,7 +47,7 @@ public class TdNetRunnerHelper : IAsyncDisposable
 			TargetFramework = AssemblyUtility.GetTargetFramework(assemblyFileName)
 		};
 		projectAssembly.Configuration.ShadowCopy = false;
-		ConfigReader.Load(projectAssembly.Configuration, assemblyFileName);
+		ConfigReader.Load(projectAssembly.Configuration, assemblyFileName, null, out _);
 
 		var diagnosticMessages = projectAssembly.Configuration.DiagnosticMessagesOrDefault;
 		var internalDiagnosticMessages = projectAssembly.Configuration.InternalDiagnosticMessagesOrDefault;

--- a/src/xunit.v3.runner.utility.tests/Configuration/ConfigReaderTests.cs
+++ b/src/xunit.v3.runner.utility.tests/Configuration/ConfigReaderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit;
@@ -18,13 +19,25 @@ public class ConfigReaderTests
 	}
 
 	[Fact]
-	public static void ConfigurationFileNotFound_ReturnsFalse()
+	public static void ConfigurationFileNotJson_ReturnsFalseWithWarning()
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "UnknownFile.txt"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "UnknownFile.txt"), out List<string> warnings);
 
 		Assert.False(result);
+		Assert.NotEmpty(warnings);
+	}
+
+	[Fact]
+	public static void ConfigurationFileNotFound_ReturnsFalseWithWarning()
+	{
+		var configuration = new TestAssemblyConfiguration();
+
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "UnknownFile.json"), out List<string> warnings);
+
+		Assert.False(result);
+		Assert.NotEmpty(warnings);
 	}
 
 	[Theory]
@@ -36,9 +49,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Null(configuration.Culture);
 		Assert.False(configuration.DiagnosticMessagesOrDefault);
 		Assert.False(configuration.InternalDiagnosticMessagesOrDefault);
@@ -62,9 +76,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.True(configuration.DiagnosticMessagesOrDefault);
 		Assert.True(configuration.InternalDiagnosticMessagesOrDefault);
 		Assert.Equal(2112, configuration.MaxParallelThreadsOrDefault);
@@ -91,9 +106,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.False(configuration.DiagnosticMessagesOrDefault);
 		Assert.False(configuration.InternalDiagnosticMessagesOrDefault);
 		Assert.Equal(Environment.ProcessorCount, configuration.MaxParallelThreadsOrDefault);
@@ -113,9 +129,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration { Culture = "override-me" };
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_CultureDefault.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_CultureDefault.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Null(configuration.Culture);
 	}
 
@@ -124,9 +141,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_CultureInvariant.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_CultureInvariant.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(string.Empty, configuration.Culture);
 	}
 
@@ -139,9 +157,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(-1, configuration.MaxParallelThreadsOrDefault);
 	}
 
@@ -154,9 +173,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, configFileName), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(Environment.ProcessorCount, configuration.MaxParallelThreadsOrDefault);
 	}
 
@@ -165,9 +185,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsMultiplier.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsMultiplier.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(Environment.ProcessorCount * 2, configuration.MaxParallelThreadsOrDefault);
 	}
 
@@ -176,9 +197,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsMultiplierComma.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsMultiplierComma.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(Environment.ProcessorCount * 2, configuration.MaxParallelThreadsOrDefault);
 	}
 
@@ -187,9 +209,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsMultiplierDecimal.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsMultiplierDecimal.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(Environment.ProcessorCount * 2, configuration.MaxParallelThreadsOrDefault);
 	}
 
@@ -198,9 +221,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration { MaxParallelThreads = 2112 };
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsDefault.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsDefault.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(Environment.ProcessorCount, configuration.MaxParallelThreadsOrDefault);
 	}
 
@@ -209,9 +233,10 @@ public class ConfigReaderTests
 	{
 		var configuration = new TestAssemblyConfiguration();
 
-		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsUnlimited.json"));
+		var result = ConfigReader.Load(configuration, AssemblyFileName, Path.Combine(AssemblyPath, "ConfigReader_MaxThreadsUnlimited.json"), out List<string> warnings);
 
 		Assert.True(result);
+		Assert.Empty(warnings);
 		Assert.Equal(-1, configuration.MaxParallelThreadsOrDefault);
 	}
 }

--- a/src/xunit.v3.runner.utility/Configuration/ConfigReader.cs
+++ b/src/xunit.v3.runner.utility/Configuration/ConfigReader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Xunit.Runner.Common;
 
@@ -13,24 +14,26 @@ public static class ConfigReader
 	/// <param name="configuration">The configuration object to write the values to.</param>
 	/// <param name="assemblyFileName">The test assembly.</param>
 	/// <param name="configFileName">The test assembly configuration file.</param>
-	/// <param name="warnings">The list of warnings that occured when loading</param>
+	/// <param name="warnings">A container to receive loading warnings, if desired.</param>
 	/// <returns>A flag which indicates whether configuration values were read.</returns>
 	public static bool Load(
 		TestAssemblyConfiguration configuration,
 		string? assemblyFileName,
-		string? configFileName,
-		out List<string> warnings)
+		string? configFileName = null,
+		List<string>? warnings = null)
 	{
-		warnings = new List<string>();
-		
 		// JSON configuration takes priority over XML configuration
-		if (ConfigReader_Json.Load(configuration, assemblyFileName, configFileName, out warnings))
+		if (ConfigReader_Json.Load(configuration, assemblyFileName, configFileName, warnings))
 			return true;
 
 #if NETFRAMEWORK
-		if (ConfigReader_Configuration.Load(configuration, assemblyFileName, configFileName, out warnings))
+		if (ConfigReader_Configuration.Load(configuration, assemblyFileName, configFileName, warnings))
 			return true;
 #endif
+
+		// If we end up here with a config file and no warnings, we have an unsupported file type
+		if (configFileName is not null && warnings is not null && warnings.Count == 0)
+			warnings.Add(string.Format(CultureInfo.CurrentCulture, "Couldn't load config file '{0}': unknown file type", configFileName));
 
 		return false;
 	}

--- a/src/xunit.v3.runner.utility/Configuration/ConfigReader.cs
+++ b/src/xunit.v3.runner.utility/Configuration/ConfigReader.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Xunit.Runner.Common;
 
 /// <summary>
@@ -11,18 +13,22 @@ public static class ConfigReader
 	/// <param name="configuration">The configuration object to write the values to.</param>
 	/// <param name="assemblyFileName">The test assembly.</param>
 	/// <param name="configFileName">The test assembly configuration file.</param>
+	/// <param name="warnings">The list of warnings that occured when loading</param>
 	/// <returns>A flag which indicates whether configuration values were read.</returns>
 	public static bool Load(
 		TestAssemblyConfiguration configuration,
 		string? assemblyFileName,
-		string? configFileName = null)
+		string? configFileName,
+		out List<string> warnings)
 	{
+		warnings = new List<string>();
+		
 		// JSON configuration takes priority over XML configuration
-		if (ConfigReader_Json.Load(configuration, assemblyFileName, configFileName))
+		if (ConfigReader_Json.Load(configuration, assemblyFileName, configFileName, out warnings))
 			return true;
 
 #if NETFRAMEWORK
-		if (ConfigReader_Configuration.Load(configuration, assemblyFileName, configFileName))
+		if (ConfigReader_Configuration.Load(configuration, assemblyFileName, configFileName, out warnings))
 			return true;
 #endif
 

--- a/src/xunit.v3.runner.utility/Runners/AssemblyRunner.cs
+++ b/src/xunit.v3.runner.utility/Runners/AssemblyRunner.cs
@@ -68,7 +68,7 @@ public class AssemblyRunner : IAsyncDisposable, _IMessageSink
 			ConfigFileName = configFileName,
 		};
 
-		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName);
+		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, out _);
 		projectAssembly.Configuration.AppDomain = appDomainSupport;
 		projectAssembly.Configuration.ShadowCopy = shadowCopy;
 		projectAssembly.Configuration.ShadowCopyFolder = shadowCopyFolder;
@@ -78,7 +78,7 @@ public class AssemblyRunner : IAsyncDisposable, _IMessageSink
 		controller = XunitFrontController.ForDiscoveryAndExecution(projectAssembly, diagnosticMessageSink: this);
 		disposalTracker.Add(controller);
 
-		ConfigReader.Load(configuration, assemblyFileName, configFileName);
+		ConfigReader.Load(configuration, assemblyFileName, configFileName, out _);
 	}
 
 	/// <summary>

--- a/src/xunit.v3.runner.utility/Runners/AssemblyRunner.cs
+++ b/src/xunit.v3.runner.utility/Runners/AssemblyRunner.cs
@@ -68,7 +68,7 @@ public class AssemblyRunner : IAsyncDisposable, _IMessageSink
 			ConfigFileName = configFileName,
 		};
 
-		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName, out _);
+		ConfigReader.Load(projectAssembly.Configuration, projectAssembly.AssemblyFileName, projectAssembly.ConfigFileName);
 		projectAssembly.Configuration.AppDomain = appDomainSupport;
 		projectAssembly.Configuration.ShadowCopy = shadowCopy;
 		projectAssembly.Configuration.ShadowCopyFolder = shadowCopyFolder;
@@ -78,7 +78,7 @@ public class AssemblyRunner : IAsyncDisposable, _IMessageSink
 		controller = XunitFrontController.ForDiscoveryAndExecution(projectAssembly, diagnosticMessageSink: this);
 		disposalTracker.Add(controller);
 
-		ConfigReader.Load(configuration, assemblyFileName, configFileName, out _);
+		ConfigReader.Load(configuration, assemblyFileName, configFileName);
 	}
 
 	/// <summary>


### PR DESCRIPTION
v3 support #1655 (and supercedes #2434)

As discussed in the issue, I did the changes for the v3 api and then implemented them to the IRunnerLogger whenever the runner supported it. This also includes amending the existing unit tests. I had to change the 2 CommandLine class due to the need of having to parse, store the warnings and then later log them, not sure if this is a problem, but we can discuss if it is.

The warnings I put are the following:
- The file was sent explicitly, but it wasn't a .json / .config file or doesn't exist (no warning if no filename was sent)
- The file exists, but the root object isn't a json one
- The file exists, but it failed to read
- The file exists, was read, but the deserialisation failed

Let me know if this is exhaustive, I tried to cover all the runners that had to be refactored from this. I tested in inproc runner and it seemed to work.