### PR TITLE
Fix tests failing depending on OS culture

### DIFF
--- a/test/test.xunit.assert/Asserts/RangeAssertsTests.cs
+++ b/test/test.xunit.assert/Asserts/RangeAssertsTests.cs
@@ -113,7 +113,7 @@ public class RangeAssertsTests
 			Assert.NotInRange(1.50, .75, 1.25);
 		}
 
-		[Fact]
+		[CulturedFact]
 		public void DoubleWithinRange()
 		{
 			var ex = Record.Exception(() => Assert.NotInRange(1.0, .75, 1.25));
@@ -121,8 +121,8 @@ public class RangeAssertsTests
 			Assert.IsType<NotInRangeException>(ex);
 			Assert.Equal(
 				"Assert.NotInRange() Failure: Value in range" + Environment.NewLine +
-				"Range:  (0.75 - 1.25)" + Environment.NewLine +
-				"Actual: 1",
+				$"Range:  ({0.75:G17} - {1.25:G17})" + Environment.NewLine +
+				$"Actual: {1:G17}",
 				ex.Message
 			);
 		}
@@ -170,7 +170,7 @@ public class RangeAssertsTests
 
 	public class NotInRange_WithComparer
 	{
-		[Fact]
+		[CulturedFact]
 		public void DoubleValueWithinRange()
 		{
 			var ex = Record.Exception(() => Assert.NotInRange(400.0, .75, 1.25, new DoubleComparer(-1)));
@@ -178,8 +178,8 @@ public class RangeAssertsTests
 			Assert.IsType<NotInRangeException>(ex);
 			Assert.Equal(
 				"Assert.NotInRange() Failure: Value in range" + Environment.NewLine +
-				"Range:  (0.75 - 1.25)" + Environment.NewLine +
-				"Actual: 400",
+				$"Range:  ({0.75:G17} - {1.25:G17})" + Environment.NewLine +
+				$"Actual: {400:G17}",
 				ex.Message
 			);
 		}

--- a/test/test.xunit.console/CommandLineTests.cs
+++ b/test/test.xunit.console/CommandLineTests.cs
@@ -206,14 +206,14 @@ public class CommandLineTests
             Assert.Equal("missing argument for -maxthreads", ex.Message);
         }
 
-        [Theory]
+        [CulturedTheory]
         [InlineData("0")]
         [InlineData("abc")]
         public static void InvalidValues(string value)
         {
             var ex = Assert.Throws<ArgumentException>(() => TestableCommandLine.Parse("assemblyName.dll", "-maxthreads", value));
 
-            Assert.Equal("incorrect argument value for -maxthreads (must be 'default', 'unlimited', a positive number, or a multiplier in the form of '0.0x')", ex.Message);
+            Assert.Equal($"incorrect argument value for -maxthreads (must be 'default', 'unlimited', a positive number, or a multiplier in the form of '{0.0m}x')", ex.Message);
         }
 
         [Theory]
@@ -227,10 +227,12 @@ public class CommandLineTests
             Assert.Equal(expected, commandLine.MaxParallelThreads);
         }
 
-        [Theory]
-        public static void MultiplierValue()
+        [CulturedTheory]
+        [InlineData("2.0x")]
+        [InlineData("2,0x")]
+        public static void MultiplierValue(string value)
         {
-            var commandLine = TestableCommandLine.Parse("assemblyName.dll", "-maxthreads", "2.0x");
+            var commandLine = TestableCommandLine.Parse("assemblyName.dll", "-maxthreads", value);
 
             Assert.Equal(Environment.ProcessorCount * 2, commandLine.MaxParallelThreads);
         }


### PR DESCRIPTION
`Assert.NotInRange` tests verifying error messages were updated to match `Assert.InRange` tests. `CommandLine.MultiplierValue` test was updated because `-maxthreads` parsing is intended to be culture-independent, now test should ensure it is.