### PR TITLE
Update/fix FSharp SupportedOSAttribute project template

### DIFF
--- a/src/xunit.v3.templates/templates/project/xunit3-extension/fs/SupportedOSAttribute.fs
+++ b/src/xunit.v3.templates/templates/project/xunit3-extension/fs/SupportedOSAttribute.fs
@@ -37,11 +37,14 @@ type SupportedOSAttribute([<ParamArray>]supportedOSes: SupportedOS[]) =
 
         for supportedOS in supportedOSes do
             let osPlatform =
-                match osMappings.TryGetValue supportedOS with
-                | true, value -> value
-                | _ -> raise (new ArgumentException($"Supported OS value '{supportedOS}' is not a known OS", nameof(supportedOSes)))
+                match Map.tryFind supportedOS osMappings with
+                | Some value -> value
+                | None -> raise (new ArgumentException($"Supported OS value '{supportedOS}' is not a known OS", nameof(supportedOSes)))
 
-            if RuntimeInformation.IsOSPlatform osPlatform then matched = true |> ignore else () 
+            if RuntimeInformation.IsOSPlatform osPlatform then
+                matched <- true
+            else
+                () 
 
             if not matched then
                 // We use the dynamic skip exception message pattern to turn this into a skipped test

--- a/src/xunit.v3.templates/templates/project/xunit3-extension/fs/SupportedOSAttribute.fs
+++ b/src/xunit.v3.templates/templates/project/xunit3-extension/fs/SupportedOSAttribute.fs
@@ -39,7 +39,7 @@ type SupportedOSAttribute([<ParamArray>]supportedOSes: SupportedOS[]) =
             let osPlatform =
                 match Map.tryFind supportedOS osMappings with
                 | Some value -> value
-                | None -> raise (new ArgumentException($"Supported OS value '{supportedOS}' is not a known OS", nameof(supportedOSes)))
+                | None -> invalidArg (nameof supportedOSes) $"Supported OS value '{supportedOS}' is not a known OS"
 
             if RuntimeInformation.IsOSPlatform osPlatform then
                 matched <- true
@@ -49,7 +49,7 @@ type SupportedOSAttribute([<ParamArray>]supportedOSes: SupportedOS[]) =
             if not matched then
                 // We use the dynamic skip exception message pattern to turn this into a skipped test
                 // when it's not running on one of the targeted OSes
-                raise (new Exception($"$XunitDynamicSkip$This test is not supported on {RuntimeInformation.OSDescription}"))
+                failwith $"$XunitDynamicSkip$This test is not supported on {RuntimeInformation.OSDescription}"
             else ()
 
         Unchecked.defaultof<ValueTask>


### PR DESCRIPTION
In response to https://elk.zone/mastodon.social/@bradwilson/112865921926948375:

- Use Map.tryFind rather than IDictionary method
- Fix setting mutable value
- Avoid constructing Exception objects by using `invalidArg` and `failwith`

For lightly more idiomatic FSharp I might have replaced the `for` loop with a tail recursive function, but exceptions are being used in control flow I don't think it makes much difference.
