### PR TITLE
Fix broken template source link in xunit.v3.templates.nuspec

### DIFF
--- a/src/xunit.v3.templates/xunit.v3.templates.nuspec
+++ b/src/xunit.v3.templates/xunit.v3.templates.nuspec
@@ -13,7 +13,7 @@
 		<releaseNotes>https://xunit.net/releases/v3/$PackageVersion$</releaseNotes>
 		<description>Includes templates for use with 'dotnet new' for creating xUnit.net v3 projects</description>
 		<copyright>Copyright (C) .NET Foundation</copyright>
-		<repository type="git" url="https://github.com/xunit/templates.xunit" commit="$GitCommitId$" />
+		<repository type="git" url="https://github.com/xunit/xunit/tree/main/src/xunit.v3.templates" commit="$GitCommitId$" />
 		<tags>dotnet-new templates xunit</tags>
 		<packageTypes>
 			<packageType name="Template" />


### PR DESCRIPTION
The repo link on https://www.nuget.org/packages/xunit.v3.templates/0.2.0-pre.69 is broken (404), this patch changes the link to the current source location

I'm not going to be signing any CLA, so you may have to recreate this patch without this PR.
