### PR TITLE
TeamCity Reporter. Remove flow id from name of test suites.

### DIFF
--- a/src/xunit.runner.reporters/TeamCityReporterMessageHandler.cs
+++ b/src/xunit.runner.reporters/TeamCityReporterMessageHandler.cs
@@ -274,7 +274,7 @@ namespace Xunit.Runner.Reporters
             message.TestCollection.UniqueID.ToString("N");
 
         string ToTestCollectionName(ITestCollectionMessage message) =>
-            string.Format(CultureInfo.InvariantCulture, "{0} ({1})", message.TestCollection.DisplayName, ToCollectionFlowId(message));
+            string.Format(CultureInfo.InvariantCulture, "{0}", message.TestCollection.DisplayName);
 
         string ToTestMethodName(ITestMethodMessage message) =>
             string.Format(CultureInfo.InvariantCulture, "{0}.{1}", message.TestMethod.Method.Type.Name, message.TestMethod.Method.Name);

--- a/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
+++ b/test/test.xunit.runner.reporters/TeamCityReporterMessageHandlerTests.cs
@@ -37,7 +37,7 @@ public class TeamCityReporterMessageHandlerTests
                 var collectionCleanupFailure = MakeFailureInformationSubstitute<ITestCollectionCleanupFailure>();
                 var testCollection = Mocks.TestCollection(displayName: "FooBar\t\r\n", uniqueID: Guid.Empty);
                 collectionCleanupFailure.TestCollection.Returns(testCollection);
-                yield return new object[] { collectionCleanupFailure, "Test Collection Cleanup Failure (FooBar\t|r|n (00000000000000000000000000000000))", "00000000000000000000000000000000" };
+                yield return new object[] { collectionCleanupFailure, "Test Collection Cleanup Failure (FooBar\t|r|n)", "00000000000000000000000000000000" };
 
                 // ITestClassCleanupFailure
                 var classCleanupFailure = MakeFailureInformationSubstitute<ITestClassCleanupFailure>();
@@ -148,8 +148,8 @@ public class TeamCityReporterMessageHandlerTests
             Assert.Collection(
                 handler.Messages.Where(msg => msg.Contains("##teamcity")),
                 msg => Assert.Equal("[Raw] => ##teamcity[flowStarted timestamp='2023-05-03T21:12:00.000+0000' flowId='00000000000000000000000000000000' parent='test|[assembly|].dll']", msg),
-                msg => Assert.Equal("[Raw] => ##teamcity[testSuiteStarted timestamp='2023-05-03T21:12:00.000+0000' flowId='00000000000000000000000000000000' name='my-test-collection\t|r|n (00000000000000000000000000000000)']", msg),
-                msg => Assert.Equal("[Raw] => ##teamcity[testSuiteFinished timestamp='2023-05-03T21:12:00.000+0000' flowId='00000000000000000000000000000000' name='my-test-collection\t|r|n (00000000000000000000000000000000)']", msg),
+                msg => Assert.Equal("[Raw] => ##teamcity[testSuiteStarted timestamp='2023-05-03T21:12:00.000+0000' flowId='00000000000000000000000000000000' name='my-test-collection\t|r|n']", msg),
+                msg => Assert.Equal("[Raw] => ##teamcity[testSuiteFinished timestamp='2023-05-03T21:12:00.000+0000' flowId='00000000000000000000000000000000' name='my-test-collection\t|r|n']", msg),
                 msg => Assert.Equal("[Raw] => ##teamcity[flowFinished timestamp='2023-05-03T21:12:00.000+0000' flowId='00000000000000000000000000000000']", msg)
             );
         }


### PR DESCRIPTION
Request fixes this issue https://github.com/xunit/visualstudio.xunit/issues/394

The output name of the test suites does not need a flow id.
I can assume that during the development of xunit.runner.visualstudio 2.5 version, flow id generation for test suites was fixed, which caused test suites to stop being constant, which breaks the history of test execution on Teamcity. 