### PR TITLE
Introducing xUnit.net Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ For project documentation, please visit the [xUnit.net project home](https://xun
 * _Need some help building the source? See [BUILDING.md](https://github.com/xunit/xunit/tree/main/BUILDING.md)._
 * _Want to contribute to the project? See [CONTRIBUTING.md](https://github.com/xunit/.github/tree/main/CONTRIBUTING.md)._
 * _Want to contribute to the assertion library? See the [suggested contribution workflow](https://github.com/xunit/assert.xunit/tree/main/README.md#suggested-contribution-workflow) in the assertion library project, as it is slightly more complex due to code being spread across two GitHub repositories._
+* You can also [Ask xUnit Guru](https://gurubase.io/g/xunit-net), it is a xUnit-focused AI to answer your questions.
 
-[![Powered by NDepend](https://raw.github.com/xunit/media/main/powered-by-ndepend-transparent.png)](http://www.ndepend.com/) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20xUnit.net%20Guru-006BFF)](https://gurubase.io/g/xunit-net)
+[![Powered by NDepend](https://raw.github.com/xunit/media/main/powered-by-ndepend-transparent.png)](http://www.ndepend.com/)
 
 ## Latest Builds
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For project documentation, please visit the [xUnit.net project home](https://xun
 * _Want to contribute to the project? See [CONTRIBUTING.md](https://github.com/xunit/.github/tree/main/CONTRIBUTING.md)._
 * _Want to contribute to the assertion library? See the [suggested contribution workflow](https://github.com/xunit/assert.xunit/tree/main/README.md#suggested-contribution-workflow) in the assertion library project, as it is slightly more complex due to code being spread across two GitHub repositories._
 
-[![Powered by NDepend](https://raw.github.com/xunit/media/main/powered-by-ndepend-transparent.png)](http://www.ndepend.com/)
+[![Powered by NDepend](https://raw.github.com/xunit/media/main/powered-by-ndepend-transparent.png)](http://www.ndepend.com/) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20xUnit.net%20Guru-006BFF)](https://gurubase.io/g/xunit-net)
 
 ## Latest Builds
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For project documentation, please visit the [xUnit.net project home](https://xun
 * _Need some help building the source? See [BUILDING.md](https://github.com/xunit/xunit/tree/main/BUILDING.md)._
 * _Want to contribute to the project? See [CONTRIBUTING.md](https://github.com/xunit/.github/tree/main/CONTRIBUTING.md)._
 * _Want to contribute to the assertion library? See the [suggested contribution workflow](https://github.com/xunit/assert.xunit/tree/main/README.md#suggested-contribution-workflow) in the assertion library project, as it is slightly more complex due to code being spread across two GitHub repositories._
-* You can also [Ask xUnit.net Guru](https://gurubase.io/g/xunit-net), it is a xUnit.net-focused AI to answer your questions.
+* _You can also [Ask xUnit.net Guru](https://gurubase.io/g/xunit-net), it is a xUnit.net-focused AI to answer your questions._
 
 [![Powered by NDepend](https://raw.github.com/xunit/media/main/powered-by-ndepend-transparent.png)](http://www.ndepend.com/)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For project documentation, please visit the [xUnit.net project home](https://xun
 * _Need some help building the source? See [BUILDING.md](https://github.com/xunit/xunit/tree/main/BUILDING.md)._
 * _Want to contribute to the project? See [CONTRIBUTING.md](https://github.com/xunit/.github/tree/main/CONTRIBUTING.md)._
 * _Want to contribute to the assertion library? See the [suggested contribution workflow](https://github.com/xunit/assert.xunit/tree/main/README.md#suggested-contribution-workflow) in the assertion library project, as it is slightly more complex due to code being spread across two GitHub repositories._
-* You can also [Ask xUnit Guru](https://gurubase.io/g/xunit-net), it is a xUnit-focused AI to answer your questions.
+* You can also [Ask xUnit.net Guru](https://gurubase.io/g/xunit-net), it is a xUnit.net-focused AI to answer your questions.
 
 [![Powered by NDepend](https://raw.github.com/xunit/media/main/powered-by-ndepend-transparent.png)](http://www.ndepend.com/)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [xUnit.net Guru](https://gurubase.io/g/xunit-net) to Gurubase. xUnit.net Guru uses the data from this repo and data from the [docs](https://xunit.net/) to answer questions by leveraging the LLM.

In this PR, I showcased the "xUnit.net Guru", which highlights that xUnit.net now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable xUnit.net Guru in Gurubase, just let me know that's totally fine.
