### PR TITLE
added recommendation to use nameof

### DIFF
--- a/src/xunit.v3.core/Abstractions/Attributes/IFactAttribute.cs
+++ b/src/xunit.v3.core/Abstractions/Attributes/IFactAttribute.cs
@@ -48,6 +48,8 @@ public interface IFactAttribute
 	/// <remarks>
 	/// This property cannot be set if <see cref="SkipWhen"/> is set. Setting both will
 	/// result in a failed test.
+	/// To ensure compile-time safety and easier refactoring, use the <c>nameof</c> operator,
+	/// e.g., <c>SkipUnless = nameof(IsConditionMet)</c>.
 	/// </remarks>
 	string? SkipUnless { get; }
 
@@ -58,6 +60,8 @@ public interface IFactAttribute
 	/// <remarks>
 	/// This property cannot be set if <see cref="SkipUnless"/> is set. Setting both will
 	/// result in a failed test.
+	/// To avoid issues during refactoring, it is recommended to use the <c>nameof</c> operator
+	/// to reference the property, e.g., <c>SkipWhen = nameof(IsTestSkipped)</c>.
 	/// </remarks>
 	string? SkipWhen { get; }
 

--- a/src/xunit.v3.core/Attributes/MemberDataAttributeBase.cs
+++ b/src/xunit.v3.core/Attributes/MemberDataAttributeBase.cs
@@ -13,7 +13,10 @@ namespace Xunit.v3;
 /// <summary>
 /// Provides a base class for attributes that will provide member data.
 /// </summary>
-/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
+/// <param name="memberName">
+/// The name of the public static member on the test class that will provide the test data
+/// It is recommended to use the <c>nameof</c> operator to ensure compile-time safety, e.g., <c>nameof(SomeMemberName)</c>.
+/// </param>
 /// <param name="arguments">The arguments to be passed to the member (only supported for methods; ignored for everything else)</param>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 public abstract class MemberDataAttributeBase(

--- a/src/xunit.v3.core/MemberDataAttribute.cs
+++ b/src/xunit.v3.core/MemberDataAttribute.cs
@@ -17,7 +17,10 @@ namespace Xunit;
 /// <see cref="IAsyncEnumerable{T}"/>, and those collections may optionally be wrapped in either
 /// <see cref="Task{TResult}"/> or <see cref="ValueTask{TResult}"/>.
 /// </remarks>
-/// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
+/// <param name="memberName">
+/// The name of the public static member on the test class that will provide the test data
+/// It is recommended to use the <c>nameof</c> operator to ensure compile-time safety, e.g., <c>nameof(SomeMemberName)</c>.
+/// </param>
 /// <param name="arguments">The arguments to be passed to the member (only supported for methods; ignored for everything else)</param>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 public sealed class MemberDataAttribute(


### PR DESCRIPTION
This fixes #2991 

### Change History
- **MemberDataAttribute**: Updated XML documentation for the `memberName` parameter to recommend using the `nameof` operator for compile-time safety.
- **SkipWhen**: Updated XML documentation to suggest the use of `nameof` for referencing public static properties to ensure safer and more maintainable code.
- **SkipUnless**: Added a recommendation in the XML documentation to use the `nameof` operator when referencing public static properties, promoting best practices.