### PR TITLE
#1742 Improved the error reporting when the DefaultTestCaseDescriptorProvider fails.

### DIFF
--- a/src/xunit.runner.utility/Frameworks/XunitFrontController.cs
+++ b/src/xunit.runner.utility/Frameworks/XunitFrontController.cs
@@ -151,7 +151,7 @@ namespace Xunit
             if (innerController == null)
             {
                 innerController = CreateInnerController();
-                descriptorProvider = (innerController as ITestCaseDescriptorProvider) ?? new DefaultTestCaseDescriptorProvider(innerController);
+                descriptorProvider = (innerController as ITestCaseDescriptorProvider) ?? new DefaultTestCaseDescriptorProvider(innerController, diagnosticMessageSink);
                 bulkDeserializer = (innerController as ITestCaseBulkDeserializer) ?? new DefaultTestCaseBulkDeserializer(innerController);
                 toDispose.Push(innerController);
             }

--- a/src/xunit.runner.utility/Frameworks/v2/Xunit2Discoverer.cs
+++ b/src/xunit.runner.utility/Frameworks/v2/Xunit2Discoverer.cs
@@ -206,7 +206,7 @@ namespace Xunit
                     catch (TypeLoadException) { }    // Only be willing to eat "Xunit.Sdk.TestCaseDescriptorFactory" doesn't exist
                 }
 
-                defaultTestCaseDescriptorProvider = new DefaultTestCaseDescriptorProvider(RemoteDiscoverer);
+                defaultTestCaseDescriptorProvider = new DefaultTestCaseDescriptorProvider(RemoteDiscoverer, DiagnosticMessageSink);
             }
 
             return defaultTestCaseDescriptorProvider.GetTestCaseDescriptors(testCases, includeSerialization);


### PR DESCRIPTION
Calling `UniqueID` in the `DefaultTestCaseDescriptorProvider` caused an exception when there were test method arguments that could not be serialized. The exception was silently dropped. This PR tries to improve error reporting in this case.

This PR targets `v2` because the same bug does not happen in v3 (the exception happens earlier and the fallback is theory enumeration during execution).