### PR TITLE
In .NET 7+, call `IParsable<T>.Parse` via a wrapper method

### DIFF
--- a/src/xunit.v3.common/Serialization/Serializers/FormattableAndParsableSerializer.cs
+++ b/src/xunit.v3.common/Serialization/Serializers/FormattableAndParsableSerializer.cs
@@ -1,39 +1,52 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+
+#if NET7_0_OR_GREATER
 using System.Reflection;
+#endif
 
 namespace Xunit.Sdk;
 
 internal sealed class FormattableAndParsableSerializer : IXunitSerializer
 {
-	static Type? typeParsable = Type.GetType("System.IParsable`1");
-
-	public static bool IsSupported =>
-		typeParsable is not null;
-
+#if NET7_0_OR_GREATER
+	public static bool IsSupported => true;
+	static Type typeParsable = typeof(IParsable<>);
+	static T Parse<T>(string s) where T : IParsable<T>
+		=> T.Parse(s, CultureInfo.InvariantCulture);
 	public object Deserialize(Type type, string serializedValue)
 	{
 		// We need to look for the Parse method, and while it's definitely static, it might be public
 		// or private, depending on whether the type wanted to hide the implementation of IParseable
-		var parse =
-			type.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public, null, [typeof(string), typeof(IFormatProvider)], null) ??
-			type.GetMethod($"System.IParsable<{type.FullName}>.Parse", BindingFlags.Static | BindingFlags.NonPublic, null, [typeof(string), typeof(IFormatProvider)], null) ??
+		var rawParse =
+			typeof(FormattableAndParsableSerializer)
+			.GetMethod(nameof(Parse), BindingFlags.Static | BindingFlags.NonPublic, null, [typeof(string)], null) ??
 			throw new InvalidOperationException($"Could not find Parse method for IParsable<{type.FullName}>");
 
+		MethodInfo parse;
+		try
+		{
+			parse = rawParse.MakeGenericMethod(type);
+		}
+		catch (ArgumentException)
+		{
+			throw new InvalidOperationException($"Type '{type.FullName}' must implement IParsable<> to be deserialized");
+		}
+
 		return
-			parse.Invoke(null, [serializedValue, CultureInfo.InvariantCulture])
+			parse.Invoke(null, [serializedValue])
 			?? throw new InvalidOperationException($"Call to IParsable<{type.FullName}>.Parse(\"{serializedValue}\") returned null");
 	}
+#else
+	public static bool IsSupported => false;
+	public object Deserialize(Type type, string serializedValue)
+		=> throw new InvalidOperationException($"Could not find Parse method for IParsable<{type.FullName}>");
+#endif
 
 	public bool IsSerializable(Type type, object? value, [NotNullWhen(false)] out string? failureReason)
 	{
-		if (typeParsable is null)
-		{
-			failureReason = "Type IParsable<> is not supported on the current platform";
-			return false;
-		}
-
+#if NET7_0_OR_GREATER
 		var isParsable = false;
 
 		// We wrap this in a try/catch because instantiating the generic may throw because
@@ -52,6 +65,10 @@ internal sealed class FormattableAndParsableSerializer : IXunitSerializer
 
 		failureReason = null;
 		return true;
+#else
+		failureReason = "Type IParsable<> is not supported on the current platform";
+		return false;
+#endif
 	}
 
 	public string Serialize(object value) =>

--- a/src/xunit.v3.common/xunit.v3.common.csproj
+++ b/src/xunit.v3.common/xunit.v3.common.csproj
@@ -5,8 +5,9 @@
     <Description>Includes common code shared between xunit.v3.core and xunit.v3.runner.common (xunit.v3.common.dll). Supports .NET Standard 2.0.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Xunit.Sdk</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <Title>xUnit.net v3 [Common Library]</Title>
+    <NoWarn>$(NoWarn);CA1307;CA1513;CA1845;CA1846;CA1865;SYSLIB0012</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #3141 

Added .net7.0 to TargetFrameworks in xunit.v3.common and created a wrapper method to call `IParsable<T>.Parse`, which seems to resolve the issue.