### PR TITLE
Reference .NET built-in packages conditionally

### DIFF
--- a/src/xunit.v3.assert.tests/xunit.v3.assert.tests.csproj
+++ b/src/xunit.v3.assert.tests/xunit.v3.assert.tests.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' ">
     <PackageReference Include="System.Collections.Immutable" Version="[$(SystemCollectionsImmutableVersion)]" />
     <PackageReference Include="System.Memory" Version="[$(SystemMemoryVersion)]" />
   </ItemGroup>

--- a/src/xunit.v3.assert.x86.tests/xunit.v3.assert.x86.tests.csproj
+++ b/src/xunit.v3.assert.x86.tests/xunit.v3.assert.x86.tests.csproj
@@ -11,7 +11,7 @@
     <Compile Include="..\xunit.v3.assert.tests\**\*.cs" Exclude="**\obj\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' ">
     <PackageReference Include="System.Collections.Immutable" Version="[$(SystemCollectionsImmutableVersion)]" />
     <PackageReference Include="System.Memory" Version="[$(SystemMemoryVersion)]" />
   </ItemGroup>

--- a/src/xunit.v3.assert/xunit.v3.assert.csproj
+++ b/src/xunit.v3.assert/xunit.v3.assert.csproj
@@ -7,7 +7,7 @@
     <Title>xUnit.net v3 [Assertion Library]</Title>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' ">
     <PackageReference Include="System.Collections.Immutable" Version="[$(SystemCollectionsImmutableVersion)]" />
     <PackageReference Include="System.Memory" Version="[$(SystemMemoryVersion)]" />
   </ItemGroup>

--- a/src/xunit.v3.assert/xunit.v3.assert.nuspec
+++ b/src/xunit.v3.assert/xunit.v3.assert.nuspec
@@ -19,10 +19,7 @@
 				<dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutableVersion$" />
 				<dependency id="System.Memory" version="$SystemMemoryVersion$" />
 			</group>
-			<group targetFramework="net8.0">
-				<dependency id="System.Collections.Immutable" version="$SystemCollectionsImmutableVersion$" />
-				<dependency id="System.Memory" version="$SystemMemoryVersion$" />
-			</group>
+			<group targetFramework="net8.0" />
 		</dependencies>
 	</metadata>
 	<!-- Remember to update tools\builder\targets\SignAssemblies.cs when assemblies are added or removed -->


### PR DESCRIPTION
The "System.Collections.Immutable" and "System.Memory" packages are built-in to .NET 8, so referencing them when targeting .NET 8 just gives users unnecessary transitive package references.