### PR TITLE
Provide source information via CallerFilePath and CallerLineNumber

### DIFF
--- a/src/xunit.v3.core/Abstractions/Attributes/IFactAttribute.cs
+++ b/src/xunit.v3.core/Abstractions/Attributes/IFactAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Xunit.Sdk;
 
 namespace Xunit.v3;
@@ -84,4 +85,14 @@ public interface IFactAttribute
 	/// completely).
 	/// </remarks>
 	int Timeout { get; }
+
+	/// <summary>
+	/// Gets the source file path declaring the attribute. Usually provided via <see cref="CallerFilePathAttribute"/>.
+	/// </summary>
+	string? SourceFilePath { get; }
+
+	/// <summary>
+	/// Gets the source file line number declaring the attribute. Usually provided via <see cref="CallerLineNumberAttribute"/>.
+	/// </summary>
+	int SourceLineNumber { get; }
 }

--- a/src/xunit.v3.core/FactAttribute.cs
+++ b/src/xunit.v3.core/FactAttribute.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CA1813 // This attribute is unsealed because it's an extensibility point
 
 using System;
+using System.Runtime.CompilerServices;
 using Xunit.v3;
 
 namespace Xunit;
@@ -13,6 +14,15 @@ namespace Xunit;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class FactAttribute : Attribute, IFactAttribute
 {
+	/// <summary>
+	/// Createa a new instance of <see cref="FactAttribute"/> which provides source information.
+	/// </summary>
+	public FactAttribute([CallerFilePath] string? sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+	{
+		SourceFilePath = sourceFilePath;
+		SourceLineNumber = sourceLineNumber;
+	}
+
 	/// <inheritdoc/>
 	public string? DisplayName { get; set; }
 
@@ -36,4 +46,10 @@ public class FactAttribute : Attribute, IFactAttribute
 
 	/// <inheritdoc/>
 	public int Timeout { get; set; }
+
+	/// <inheritdoc/>
+	public string? SourceFilePath { get; }
+
+	/// <inheritdoc/>
+	public int SourceLineNumber { get; }
 }

--- a/src/xunit.v3.core/Framework/FactDiscoverer.cs
+++ b/src/xunit.v3.core/Framework/FactDiscoverer.cs
@@ -40,6 +40,8 @@ public class FactDiscoverer : IXunitTestCaseDiscoverer
 			details.SkipUnless,
 			details.SkipWhen,
 			testMethod.Traits.ToReadWrite(StringComparer.OrdinalIgnoreCase),
+			sourceFilePath: factAttribute.SourceFilePath,
+			sourceLineNumber: factAttribute.SourceLineNumber,
 			timeout: details.Timeout
 		);
 	}
@@ -84,11 +86,15 @@ public class FactDiscoverer : IXunitTestCaseDiscoverer
 
 		var details = TestIntrospectionHelper.GetTestCaseDetails(discoveryOptions, testMethod, factAttribute);
 
-		return new(
+		var errorTestCase = new ExecutionErrorTestCase(
 			details.ResolvedTestMethod,
 			details.TestCaseDisplayName,
 			details.UniqueID,
 			message
 		);
+
+		errorTestCase.SourceFilePath = factAttribute.SourceFilePath;
+		errorTestCase.SourceLineNumber = factAttribute.SourceLineNumber;
+		return errorTestCase;
 	}
 }

--- a/src/xunit.v3.core/Framework/TheoryDiscoverer.cs
+++ b/src/xunit.v3.core/Framework/TheoryDiscoverer.cs
@@ -94,6 +94,8 @@ public class TheoryDiscoverer : IXunitTestCaseDiscoverer
 					details.SkipUnless,
 					details.SkipWhen,
 					testMethod.Traits.ToReadWrite(StringComparer.OrdinalIgnoreCase),
+					sourceFilePath: theoryAttribute.SourceFilePath,
+					sourceLineNumber: theoryAttribute.SourceLineNumber,
 					timeout: details.Timeout
 				)
 				: (IXunitTestCase)new XunitDelayEnumeratedTheoryTestCase(
@@ -108,6 +110,8 @@ public class TheoryDiscoverer : IXunitTestCaseDiscoverer
 					details.SkipUnless,
 					details.SkipWhen,
 					testMethod.Traits.ToReadWrite(StringComparer.OrdinalIgnoreCase),
+					sourceFilePath: theoryAttribute.SourceFilePath,
+					sourceLineNumber: theoryAttribute.SourceLineNumber,
 					timeout: details.Timeout
 				);
 
@@ -183,6 +187,10 @@ public class TheoryDiscoverer : IXunitTestCaseDiscoverer
 									testMethod.MethodName
 								)
 							)
+							{
+								SourceFilePath = theoryAttribute.SourceFilePath,
+								SourceLineNumber = theoryAttribute.SourceLineNumber,
+							}
 						);
 
 						continue;
@@ -243,9 +251,13 @@ public class TheoryDiscoverer : IXunitTestCaseDiscoverer
 					var message = string.Format(CultureInfo.CurrentCulture, "No data found for {0}.{1}", testMethod.TestClass.TestClassName, testMethod.MethodName);
 
 					if (theoryAttribute.SkipTestWithoutData)
-						results.Add(new XunitTestCase(details.ResolvedTestMethod, details.TestCaseDisplayName, details.UniqueID, details.Explicit, skipReason: message));
+						results.Add(new XunitTestCase(details.ResolvedTestMethod, details.TestCaseDisplayName, details.UniqueID, details.Explicit, skipReason: message, sourceFilePath: theoryAttribute.SourceFilePath, sourceLineNumber: theoryAttribute.SourceLineNumber));
 					else
-						results.Add(new ExecutionErrorTestCase(details.ResolvedTestMethod, details.TestCaseDisplayName, details.UniqueID, errorMessage: message));
+						results.Add(new ExecutionErrorTestCase(details.ResolvedTestMethod, details.TestCaseDisplayName, details.UniqueID, errorMessage: message)
+						{
+							SourceFilePath = theoryAttribute.SourceFilePath,
+							SourceLineNumber = theoryAttribute.SourceLineNumber,
+						});
 				}
 
 				return results;

--- a/src/xunit.v3.core/Framework/XunitTestFrameworkDiscoverer.cs
+++ b/src/xunit.v3.core/Framework/XunitTestFrameworkDiscoverer.cs
@@ -101,6 +101,13 @@ public class XunitTestFrameworkDiscoverer : TestFrameworkDiscoverer<IXunitTestCl
 #pragma warning disable CA2000  // Ownership of this object is handed off to the callback
 			var testCase = new ExecutionErrorTestCase(details.ResolvedTestMethod, details.TestCaseDisplayName, details.UniqueID, message);
 #pragma warning restore CA2000
+
+			if (factAttribute is FactAttribute { SourceFilePath: { } sourceFilePath, SourceLineNumber: { } sourceLineNumber })
+			{
+				testCase.SourceFilePath = sourceFilePath;
+				testCase.SourceLineNumber = sourceLineNumber;
+			}
+
 			return await discoveryCallback(testCase);
 		}
 

--- a/src/xunit.v3.core/TheoryAttribute.cs
+++ b/src/xunit.v3.core/TheoryAttribute.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CA1813 // This attribute is unsealed because it's an extensibility point
 
 using System;
+using System.Runtime.CompilerServices;
 using Xunit.v3;
 
 namespace Xunit;
@@ -17,6 +18,14 @@ namespace Xunit;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class TheoryAttribute : FactAttribute, ITheoryAttribute
 {
+	/// <summary>
+	/// Createa a new instance of <see cref="TheoryAttribute"/> which provides source information.
+	/// </summary>
+	public TheoryAttribute([CallerFilePath] string? sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+		: base(sourceFilePath, sourceLineNumber)
+	{
+	}
+
 	/// <inheritdoc/>
 	public bool DisableDiscoveryEnumeration { get; set; }
 


### PR DESCRIPTION
- This is a quick PoC that has breaking changes.
- It doesn't fully build (there are tests that need to be updated to account for the breaking changes).
- Not yet tested.

@bradwilson This PR is my *personal* view on how source information should be collected. What do you think? Is it something you can consider for xunit.v3 3.x?