### PR TITLE
Avoid duplicating file extensions in attachment file names

### DIFF
--- a/src/xunit.v3.runner.inproc.console/TestingPlatform/TestPlatformExecutionMessageSink.cs
+++ b/src/xunit.v3.runner.inproc.console/TestingPlatform/TestPlatformExecutionMessageSink.cs
@@ -151,13 +151,20 @@ public class TestPlatformExecutionMessageSink(
 
 						if (attachmentType == TestAttachmentType.String)
 						{
-							localFilePath += ".txt";
+							if (Path.GetExtension(localFilePath) != ".txt")
+							{
+								localFilePath += ".txt";
+							}
 							File.WriteAllText(localFilePath, kvp.Value.AsString());
 						}
 						else if (attachmentType == TestAttachmentType.ByteArray)
 						{
 							var (byteArray, mediaType) = kvp.Value.AsByteArray();
-							localFilePath += MediaTypeUtility.GetFileExtension(mediaType);
+							var fileExtension = MediaTypeUtility.GetFileExtension(mediaType);
+							if (Path.GetExtension(localFilePath) != fileExtension)
+							{
+								localFilePath += fileExtension;
+							}
 							File.WriteAllBytes(localFilePath, byteArray);
 						}
 						else

--- a/src/xunit.v3.runner.inproc.console/TestingPlatform/TestPlatformExecutionMessageSink.cs
+++ b/src/xunit.v3.runner.inproc.console/TestingPlatform/TestPlatformExecutionMessageSink.cs
@@ -152,9 +152,8 @@ public class TestPlatformExecutionMessageSink(
 						if (attachmentType == TestAttachmentType.String)
 						{
 							if (Path.GetExtension(localFilePath) != ".txt")
-							{
 								localFilePath += ".txt";
-							}
+
 							File.WriteAllText(localFilePath, kvp.Value.AsString());
 						}
 						else if (attachmentType == TestAttachmentType.ByteArray)
@@ -162,9 +161,8 @@ public class TestPlatformExecutionMessageSink(
 							var (byteArray, mediaType) = kvp.Value.AsByteArray();
 							var fileExtension = MediaTypeUtility.GetFileExtension(mediaType);
 							if (Path.GetExtension(localFilePath) != fileExtension)
-							{
 								localFilePath += fileExtension;
-							}
+
 							File.WriteAllBytes(localFilePath, byteArray);
 						}
 						else


### PR DESCRIPTION
This prevents file names with double extensions (e.g. screenshot.png.png) if the attachment name already contains a file extension.