### PR TITLE
Default CollectSourceInformation to false

### DIFF
--- a/src/xunit.v3.runner.common/Utility/RunSettingsUtility.cs
+++ b/src/xunit.v3.runner.common/Utility/RunSettingsUtility.cs
@@ -29,7 +29,7 @@ internal static class RunSettingsUtility
 				}
 				catch { }
 
-				collectSourceInformation ??= true;
+				collectSourceInformation ??= false;
 			}
 
 			return collectSourceInformation.Value;


### PR DESCRIPTION
In DevKit, it will be forced as true.

```xml
<RunSettings>
  <RunConfiguration>
    <CollectSourceInformation>true</CollectSourceInformation>
  </RunConfiguration>
  <DataCollectionRunSettings>
    <DataCollectors />
  </DataCollectionRunSettings>
</RunSettings>
```

In VS F#, it will be forced as true as well:

```xml
<RunSettings>
  <BoostTestInternalSettings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <VSProcessId>32540</VSProcessId>
  </BoostTestInternalSettings>
  <RunConfiguration>
    <ResultsDirectory>C:\Users\ygerges\source\repos\TestProject83\TestResults</ResultsDirectory>
    <SolutionDirectory>C:\Users\ygerges\source\repos\TestProject83\</SolutionDirectory>
    <CollectSourceInformation>True</CollectSourceInformation>
  </RunConfiguration>
  <GoogleTestAdapterSettings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <SolutionSettings>
      <Settings />
    </SolutionSettings>
    <ProjectSettings />
  </GoogleTestAdapterSettings>
</RunSettings>
```

The above scenarios are the only scenarios where it's important to produce source information. Defaulting to false is good for at least command-line where it's an extra cost without any benefits to produce source info.