### PR TITLE
Update the VstsClient.cs to use newer Azure DevOps APIs

### DIFF
--- a/src/xunit.v3.runner.common/Utility/VstsClient.cs
+++ b/src/xunit.v3.runner.common/Utility/VstsClient.cs
@@ -255,7 +255,7 @@ sealed class VstsClient : IDisposable
 		var method = isAdd ? HttpMethod.Post : PatchHttpMethod;
 		var bodyString = ToJson(body);
 
-		var url = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/results?api-version=3.0-preview", baseUri, runId);
+		var url = string.Format(CultureInfo.InvariantCulture, "{0}/{1}/results?api-version=7.2-preview", baseUri, runId);
 
 		try
 		{


### PR DESCRIPTION
## Summary

- Just update the `VstsClient.cs` to use the newer Azure DevOps APIs.

This attempts to address #3364