### PR TITLE
Bump MTP to 1.8.5

### DIFF
--- a/src/Versions.props
+++ b/src/Versions.props
@@ -12,7 +12,7 @@
     <TunnelVisionLabs_ReferenceAssemblyAnnotator_Version>1.0.0-alpha.160</TunnelVisionLabs_ReferenceAssemblyAnnotator_Version>
 
     <!-- Used for Microsoft.Testing.* (xunit.v3.core NuGet package and xunit.v3.runner.inproc.console) -->
-    <Microsoft_Testing_Version>1.8.4</Microsoft_Testing_Version>
+    <Microsoft_Testing_Version>1.8.5</Microsoft_Testing_Version>
 
     <!-- Used by NuGet packages (xunit.v3 and xunit.v3.templates) -->
     <Microsoft_NET_Test_Sdk_Version>17.13.0</Microsoft_NET_Test_Sdk_Version>


### PR DESCRIPTION
This patch release fixes #3397, and also fixes a bug with MTP's HotReload extension.