### PR TITLE
Pin System.Security.AccessControl to 6.0.1 to avoid deprecated 5.0.0 transitive dep

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -160,6 +160,7 @@ $([System.IO.File]::ReadAllText($(MSBuildThisFileDirectory)..\README.md))
         SignedPath=$(SignedPath);
         System_Collections_Immutable_Version=$(System_Collections_Immutable_Version);
         System_Memory_Version=$(System_Memory_Version);
+        System_Security_AccessControl_Version=$(System_Security_AccessControl_Version);
         xunit_abstractions_Version=$(xunit_abstractions_Version);
         xunit_analyzers_Version=$(xunit_analyzers_Version);
       </NuspecProperties>

--- a/src/Versions.props
+++ b/src/Versions.props
@@ -34,6 +34,7 @@
 
     <!-- Used by xunit.v3.runner.common to keep a cache of media type => extension mappings -->
     <Microsoft_Win32_Registry_Version>5.0.0</Microsoft_Win32_Registry_Version>
+    <System_Security_AccessControl_Version>6.0.1</System_Security_AccessControl_Version>
 
     <!-- Used by xunit.v3.runner.msbuild to reference MSBuild types -->
     <Microsoft_Build_Tasks_Core_Version>16.11.6</Microsoft_Build_Tasks_Core_Version>

--- a/src/xunit.v3.runner.common/xunit.v3.runner.common.csproj
+++ b/src/xunit.v3.runner.common/xunit.v3.runner.common.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(Microsoft_Win32_Registry_Version)" />
+    <PackageReference Include="System.Security.AccessControl" Version="$(System_Security_AccessControl_Version)" />
     <PackageReference Include="Mono.Cecil" Version="$(Mono_Cecil_Version)" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/xunit.v3.runner.common/xunit.v3.runner.common.nuspec
+++ b/src/xunit.v3.runner.common/xunit.v3.runner.common.nuspec
@@ -16,6 +16,7 @@
 		<dependencies>
 			<group targetFramework="netstandard2.0">
 				<dependency id="Microsoft.Win32.Registry" version="[$Microsoft_Win32_Registry_Version$]" />
+				<dependency id="System.Security.AccessControl" version="[$System_Security_AccessControl_Version$]" />
 				<dependency id="xunit.v3.common" version="[$PackageVersion$]" />
 			</group>
 		</dependencies>


### PR DESCRIPTION
Fixes #3516

## Problem

`xunit.v3.runner.common` depends on `Microsoft.Win32.Registry 5.0.0` (the latest supporting netstandard2.0). This package transitively brings `System.Security.AccessControl 5.0.0`, which is [deprecated](https://github.com/dotnet/announcements/issues/217) as part of the .NET package deprecation effort.

This causes Component Governance alerts in all downstream consumers of any xunit v3 package that references runner.common.

## Fix

Add `System.Security.AccessControl 6.0.1` as a direct dependency in `xunit.v3.runner.common.csproj`. This overrides the deprecated 5.0.0 from `Microsoft.Win32.Registry` while remaining compatible with `netstandard2.0`.

## Changes

- `src/Versions.props`: Add `System_Security_AccessControl_Version` = `6.0.1`
- `src/xunit.v3.runner.common/xunit.v3.runner.common.csproj`: Add PackageReference to `System.Security.AccessControl`
