### PR TITLE
Feature/override environmental values per test

### DIFF
--- a/src/xunit.v3.assert.tests/Asserts/CollectionAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/CollectionAssertsTests.cs
@@ -2392,6 +2392,48 @@ public static class CollectionAssertsTests
 		}
 	}
 
+	public static class Overrides
+	{
+		[Fact]
+		public static void OverrideMaxEnumerableLength_Default()
+		{
+			var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			var actual = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 11 };
+
+			var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex);
+			Assert.Equal(
+				"Assert.Equal() Failure: Collections differ" + Environment.NewLine +
+				"                            ↓ (pos 9)" + Environment.NewLine +
+				$"Expected: [{ArgumentFormatter.Ellipsis}, 6, 7, 8, 9, 10]" + Environment.NewLine +
+				$"Actual:   [{ArgumentFormatter.Ellipsis}, 6, 7, 8, 9, 11]" + Environment.NewLine +
+				"                            ↑ (pos 9)",
+				ex.Message
+			);
+		}
+
+		[Fact]
+		public static void OverrideMaxEnumerableLength_Override()
+		{
+			var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			var actual = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 11 };
+			Assert.OverrideMaxEnumerableLength(3);
+
+			var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex);
+			Assert.Equal(
+				"Assert.Equal() Failure: Collections differ" + Environment.NewLine +
+				"                      ↓ (pos 9)" + Environment.NewLine +
+				$"Expected: [{ArgumentFormatter.Ellipsis}, 8, 9, 10]" + Environment.NewLine +
+				$"Actual:   [{ArgumentFormatter.Ellipsis}, 8, 9, 11]" + Environment.NewLine +
+				"                      ↑ (pos 9)",
+				ex.Message
+			);
+		}
+	}
+
 	public static class Single_NonGeneric
 	{
 		[Fact]

--- a/src/xunit.v3.assert.tests/Asserts/EqualityAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/EqualityAssertsTests.cs
@@ -4589,6 +4589,83 @@ public static class EqualityAssertsTests
 		}
 	}
 
+#if !XUNIT_AOT  // Object contents aren't printed in Native AOT
+
+	public static class Overrides
+	{
+		[Fact]
+		public static void OverrideMaxObjectDepth_Default()
+		{
+			var expected = new RecursiveObject();
+			var actual = new object();
+
+			var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex);
+			Assert.Equal(
+				"Assert.Equal() Failure: Values differ" + Environment.NewLine +
+				$"Expected: RecursiveObject {{ Self = RecursiveObject {{ Self = RecursiveObject {{ {ArgumentFormatter.Ellipsis} }} }} }}" + Environment.NewLine +
+				"Actual:   Object { }",
+				ex.Message
+			);
+		}
+
+		[Fact]
+		public static void OverrideMaxObjectDepth_Override()
+		{
+			var expected = new RecursiveObject();
+			var actual = new object();
+			Assert.OverrideMaxObjectDepth(1);
+
+			var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex);
+			Assert.Equal(
+				"Assert.Equal() Failure: Values differ" + Environment.NewLine +
+				$"Expected: RecursiveObject {{ Self = RecursiveObject {{ {ArgumentFormatter.Ellipsis} }} }}" + Environment.NewLine +
+				"Actual:   Object { }",
+				ex.Message
+			);
+		}
+
+		[Fact]
+		public static void OverrideMaxObjectMemberCount_Default()
+		{
+			var expected = new MultiPropertyObject();
+			var actual = new object();
+
+			var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex);
+			Assert.Equal(
+				"Assert.Equal() Failure: Values differ" + Environment.NewLine +
+				"Expected: MultiPropertyObject { DecimalValue = 21.12, IntValue = 42, StringValue = \"Hello, world\" }" + Environment.NewLine +
+				"Actual:   Object { }",
+				ex.Message
+			);
+		}
+
+		[Fact]
+		public static void OverrideMaxObjectMemberCount_Override()
+		{
+			var expected = new MultiPropertyObject();
+			var actual = new object();
+			Assert.OverrideMaxObjectMemberCount(1);
+
+			var ex = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex);
+			Assert.Equal(
+				"Assert.Equal() Failure: Values differ" + Environment.NewLine +
+				$"Expected: MultiPropertyObject {{ DecimalValue = 21.12, {ArgumentFormatter.Ellipsis} }}" + Environment.NewLine +
+				"Actual:   Object { }",
+				ex.Message
+			);
+		}
+	}
+
+#endif  // !XUNIT_AOT
+
 	public static class StrictEqual
 	{
 		[Fact]
@@ -4887,4 +4964,20 @@ public static class EqualityAssertsTests
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
+
+#pragma warning disable CA1822
+
+	class MultiPropertyObject
+	{
+		public decimal DecimalValue => 21.12m;
+		public int IntValue => 42;
+		public string StringValue => "Hello, world";
+	}
+
+	class RecursiveObject
+	{
+		public RecursiveObject Self => this;
+	}
+
+#pragma warning restore CA1822
 }

--- a/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
@@ -942,13 +942,13 @@ public static class StringAssertsTests
 			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan(), ignoreWhiteSpaceDifferences: true));
 			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan(), ignoreWhiteSpaceDifferences: true));
 		}
-		
+
 		[Fact]
 		public static void SetPrintMaxStringLength()
 		{
 			var expected = "01234567890123456789_01234567890123456789";
-			var actual   = "01234567890123456789012345678901234567890123456789";
-			
+			var actual = "01234567890123456789012345678901234567890123456789";
+
 			static void verify(Action action)
 			{
 				Assert.SetPrintMaxStringLength(20);
@@ -977,12 +977,12 @@ public static class StringAssertsTests
 			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
 			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
 		}
-		
+
 		[Fact]
 		public static void SetPrintMaxStringLength_Zero_DisablesTruncation()
 		{
 			var expected = "01234567890123456789012345678901234567890123456789_1234";
-			var actual   = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+			var actual = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
@@ -1012,12 +1012,12 @@ public static class StringAssertsTests
 			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
 			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
 		}
-		
+
 		[Fact]
 		public static void SetPrintMaxStringLength_MismatchedAtFirst()
 		{
 			var expected = "01234_56789012345678901234567890123456789";
-			var actual   = "01234567890123456789012345678901234567890123456789";
+			var actual = "01234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
@@ -1047,12 +1047,12 @@ public static class StringAssertsTests
 			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
 			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
 		}
-		
+
 		[Fact]
 		public static void SetPrintMaxStringLength_MismatchedAtEnd()
 		{
 			var expected = "01234567890123456789012345678901234567890123456789_1234";
-			var actual   = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+			var actual = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
@@ -1082,16 +1082,16 @@ public static class StringAssertsTests
 			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
 			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
 		}
-		
+
 		[Fact]
 		public static void SetPrintMaxStringLength_DoesNotAffectOtherTests()
 		{
 			var expected = "01234567890123456789012345678901234567890123456789_1234";
-			var actual   = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
-			
+			var actual = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+
 			Assert.SetPrintMaxStringLength(0);
 			var ex1 = Record.Exception(() => Assert.Equal(expected, actual));
-			
+
 			Assert.SetPrintMaxStringLength(null);
 			var ex2 = Record.Exception(() => Assert.Equal(expected, actual));
 

--- a/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
@@ -942,6 +942,180 @@ public static class StringAssertsTests
 			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan(), ignoreWhiteSpaceDifferences: true));
 			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan(), ignoreWhiteSpaceDifferences: true));
 		}
+		
+		[Fact]
+		public static void SetPrintMaxStringLength()
+		{
+			var expected = "01234567890123456789_01234567890123456789";
+			var actual   = "01234567890123456789012345678901234567890123456789";
+			
+			static void verify(Action action)
+			{
+				Assert.SetPrintMaxStringLength(20);
+
+				var ex = Record.Exception(action);
+
+				Assert.IsType<EqualException>(ex);
+
+				Assert.Equal(
+					"Assert.Equal() Failure: Strings differ" + Environment.NewLine +
+					"                        ↓ (pos 20)" + Environment.NewLine +
+					$"Expected: {ArgumentFormatter.Ellipsis}\"0123456789_012345678\"{ArgumentFormatter.Ellipsis}" + Environment.NewLine +
+					$"Actual:   {ArgumentFormatter.Ellipsis}\"01234567890123456789\"{ArgumentFormatter.Ellipsis}" + Environment.NewLine +
+					"                        ↑ (pos 20)",
+					ex.Message
+				);
+			}
+
+			verify(() => Assert.Equal(expected, actual));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
+		}
+		
+		[Fact]
+		public static void SetPrintMaxStringLength_Zero_DisablesTruncation()
+		{
+			var expected = "01234567890123456789012345678901234567890123456789_1234";
+			var actual   = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+
+			static void verify(Action action)
+			{
+				Assert.SetPrintMaxStringLength(0);
+
+				var ex = Record.Exception(action);
+
+				Assert.IsType<EqualException>(ex);
+
+				Assert.Equal(
+					"Assert.Equal() Failure: Strings differ" + Environment.NewLine +
+					"                                                             ↓ (pos 50)" + Environment.NewLine +
+					"Expected: \"01234567890123456789012345678901234567890123456789_1234\"" + Environment.NewLine +
+					"Actual:   \"01234567890123456789012345678901234567890123456789012345678901234567890123456789\"" + Environment.NewLine +
+					"                                                             ↑ (pos 50)",
+					ex.Message
+				);
+			}
+
+			verify(() => Assert.Equal(expected, actual));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
+		}
+		
+		[Fact]
+		public static void SetPrintMaxStringLength_MismatchedAtFirst()
+		{
+			var expected = "01234_56789012345678901234567890123456789";
+			var actual   = "01234567890123456789012345678901234567890123456789";
+
+			static void verify(Action action)
+			{
+				Assert.SetPrintMaxStringLength(20);
+
+				var ex = Record.Exception(action);
+
+				Assert.IsType<EqualException>(ex);
+
+				Assert.Equal(
+					"Assert.Equal() Failure: Strings differ" + Environment.NewLine +
+					"                ↓ (pos 5)" + Environment.NewLine +
+					$"Expected: \"01234_56789012345678\"{ArgumentFormatter.Ellipsis}" + Environment.NewLine +
+					$"Actual:   \"01234567890123456789\"{ArgumentFormatter.Ellipsis}" + Environment.NewLine +
+					"                ↑ (pos 5)",
+					ex.Message
+				);
+			}
+
+			verify(() => Assert.Equal(expected, actual));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
+		}
+		
+		[Fact]
+		public static void SetPrintMaxStringLength_MismatchedAtEnd()
+		{
+			var expected = "01234567890123456789012345678901234567890123456789_1234";
+			var actual   = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+
+			static void verify(Action action)
+			{
+				Assert.SetPrintMaxStringLength(10);
+
+				var ex = Record.Exception(action);
+
+				Assert.IsType<EqualException>(ex);
+
+				Assert.Equal(
+					"Assert.Equal() Failure: Strings differ" + Environment.NewLine +
+					"                   ↓ (pos 50)" + Environment.NewLine +
+					$"Expected: {ArgumentFormatter.Ellipsis}\"56789_1234\"" + Environment.NewLine +
+					$"Actual:   {ArgumentFormatter.Ellipsis}\"5678901234\"{ArgumentFormatter.Ellipsis}" + Environment.NewLine +
+					"                   ↑ (pos 50)",
+					ex.Message
+				);
+			}
+
+			verify(() => Assert.Equal(expected, actual));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.Memoryify()));
+			verify(() => Assert.Equal(expected.Memoryify(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.AsMemory(), actual.AsMemory()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.Spanify()));
+			verify(() => Assert.Equal(expected.Spanify(), actual.AsSpan()));
+			verify(() => Assert.Equal(expected.AsSpan(), actual.AsSpan()));
+		}
+		
+		[Fact]
+		public static void SetPrintMaxStringLength_DoesNotAffectOtherTests()
+		{
+			var expected = "01234567890123456789012345678901234567890123456789_1234";
+			var actual   = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+			
+			Assert.SetPrintMaxStringLength(0);
+			var ex1 = Record.Exception(() => Assert.Equal(expected, actual));
+			
+			Assert.SetPrintMaxStringLength(null);
+			var ex2 = Record.Exception(() => Assert.Equal(expected, actual));
+
+			Assert.IsType<EqualException>(ex1);
+			Assert.IsType<EqualException>(ex2);
+
+			Assert.Equal(
+				"Assert.Equal() Failure: Strings differ" + Environment.NewLine +
+				"                                                             ↓ (pos 50)" + Environment.NewLine +
+				$"Expected: \"01234567890123456789012345678901234567890123456789_1234\"" + Environment.NewLine +
+				$"Actual:   \"01234567890123456789012345678901234567890123456789012345678901234567890123456789\"" + Environment.NewLine +
+				"                                                             ↑ (pos 50)",
+				ex1.Message
+			);
+
+			Assert.Equal(
+				"Assert.Equal() Failure: Strings differ" + Environment.NewLine +
+				"                                       ↓ (pos 50)" + Environment.NewLine +
+				$"Expected: {ArgumentFormatter.Ellipsis}\"5678901234567890123456789_1234\"" + Environment.NewLine +
+				$"Actual:   {ArgumentFormatter.Ellipsis}\"56789012345678901234567890123456789012345678901234\"{ArgumentFormatter.Ellipsis}" + Environment.NewLine +
+				"                                       ↑ (pos 50)",
+				ex2.Message
+			);
+		}
 	}
 
 	public static class Matches_Pattern

--- a/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
+++ b/src/xunit.v3.assert.tests/Asserts/StringAssertsTests.cs
@@ -944,14 +944,14 @@ public static class StringAssertsTests
 		}
 
 		[Fact]
-		public static void SetPrintMaxStringLength()
+		public static void OverrideMaxStringLength_NonZero()
 		{
 			var expected = "01234567890123456789_01234567890123456789";
 			var actual = "01234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
-				Assert.SetPrintMaxStringLength(20);
+				Assert.OverrideMaxStringLength(20);
 
 				var ex = Record.Exception(action);
 
@@ -979,14 +979,14 @@ public static class StringAssertsTests
 		}
 
 		[Fact]
-		public static void SetPrintMaxStringLength_Zero_DisablesTruncation()
+		public static void OverrideMaxStringLength_Zero_DisablesTruncation()
 		{
 			var expected = "01234567890123456789012345678901234567890123456789_1234";
 			var actual = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
-				Assert.SetPrintMaxStringLength(0);
+				Assert.OverrideMaxStringLength(0);
 
 				var ex = Record.Exception(action);
 
@@ -1014,14 +1014,14 @@ public static class StringAssertsTests
 		}
 
 		[Fact]
-		public static void SetPrintMaxStringLength_MismatchedAtFirst()
+		public static void OverrideMaxStringLength_MismatchedAtFirst()
 		{
 			var expected = "01234_56789012345678901234567890123456789";
 			var actual = "01234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
-				Assert.SetPrintMaxStringLength(20);
+				Assert.OverrideMaxStringLength(20);
 
 				var ex = Record.Exception(action);
 
@@ -1049,14 +1049,14 @@ public static class StringAssertsTests
 		}
 
 		[Fact]
-		public static void SetPrintMaxStringLength_MismatchedAtEnd()
+		public static void OverrideMaxStringLength_MismatchedAtEnd()
 		{
 			var expected = "01234567890123456789012345678901234567890123456789_1234";
 			var actual = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 
 			static void verify(Action action)
 			{
-				Assert.SetPrintMaxStringLength(10);
+				Assert.OverrideMaxStringLength(10);
 
 				var ex = Record.Exception(action);
 
@@ -1084,15 +1084,15 @@ public static class StringAssertsTests
 		}
 
 		[Fact]
-		public static void SetPrintMaxStringLength_DoesNotAffectOtherTests()
+		public static void OverrideMaxStringLength_DoesNotAffectOtherTests()
 		{
 			var expected = "01234567890123456789012345678901234567890123456789_1234";
 			var actual = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 
-			Assert.SetPrintMaxStringLength(0);
+			Assert.OverrideMaxStringLength(0);
 			var ex1 = Record.Exception(() => Assert.Equal(expected, actual));
 
-			Assert.SetPrintMaxStringLength(null);
+			Assert.OverrideMaxStringLength(null);
 			var ex2 = Record.Exception(() => Assert.Equal(expected, actual));
 
 			Assert.IsType<EqualException>(ex1);


### PR DESCRIPTION
This PR implements #3526 - the ability to override environmental values on a per-test basis.

Specifically, it adds:

```csharp
Assert.SetPrintMaxStringLength(int? maxLength);
```

`0` disables truncation completely for the current test.

`null` (or not calling the method) removes the override.