### PR TITLE
Sanitize attachment filenames against cross-platform invalid chars

### DIFF
--- a/src/xunit.v3.runner.common.tests/Utility/MediaTypeUtilityTests.cs
+++ b/src/xunit.v3.runner.common.tests/Utility/MediaTypeUtilityTests.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+public class MediaTypeUtilityTests
+{
+	[Fact]
+	public void ReplacesCrossPlatformInvalidChars()
+	{
+		// Chars invalid on Windows must be scrubbed regardless of the runtime OS, since
+		// attachments written on one OS are frequently consumed on another (e.g. uploaded
+		// as GitHub Actions artifacts, which rejects ':', '"', '<', '>', '|', '*', '?').
+		var result = MediaTypeUtility.GetSanitizedFileNameWithExtension("name:with<>|\"*?/\\bad", "text/plain");
+
+		Assert.Equal("name_with________bad.txt", result);
+	}
+
+	[Fact]
+	public void ReplacesControlChars()
+	{
+		var result = MediaTypeUtility.GetSanitizedFileNameWithExtension("a\0b\tc\nd", "text/plain");
+
+		Assert.Equal("a_b_c_d.txt", result);
+	}
+
+	[Fact]
+	public void AppendsExtensionWhenMissing()
+	{
+		var result = MediaTypeUtility.GetSanitizedFileNameWithExtension("attachment", "application/json");
+
+		Assert.Equal("attachment.json", result);
+	}
+
+	[Fact]
+	public void DoesNotAppendExtensionWhenAlreadyPresent()
+	{
+		var result = MediaTypeUtility.GetSanitizedFileNameWithExtension("attachment.json", "application/json");
+
+		Assert.Equal("attachment.json", result);
+	}
+
+	[Fact]
+	public void UnknownMediaTypeUsesBinExtension()
+	{
+		var result = MediaTypeUtility.GetSanitizedFileNameWithExtension("attachment", "application/x-not-a-real-type");
+
+		Assert.Equal("attachment.bin", result);
+	}
+}

--- a/src/xunit.v3.runner.common/Utility/MediaTypeUtility.cs
+++ b/src/xunit.v3.runner.common/Utility/MediaTypeUtility.cs
@@ -11,7 +11,19 @@ namespace Xunit;
 public static class MediaTypeUtility
 {
 	const string DefaultExtension = ".bin";
-	static readonly HashSet<char> InvalidFileNameChars = [.. Path.GetInvalidFileNameChars()];
+
+	// Use the union of invalid filename chars across Windows/Linux/macOS rather than Path.GetInvalidFileNameChars(),
+	// which is OS-dependent. Attachments written on one OS are frequently consumed on another (e.g. attachments
+	// produced by a Linux CI run uploaded as GitHub Actions artifacts, which rejects Windows-invalid chars like ':').
+	static readonly HashSet<char> InvalidFileNameChars = BuildInvalidFileNameChars();
+
+	static HashSet<char> BuildInvalidFileNameChars()
+	{
+		var chars = new HashSet<char> { '"', '<', '>', '|', ':', '*', '?', '\\', '/' };
+		for (var c = (char)0; c < 32; c++)
+			chars.Add(c);
+		return chars;
+	}
 
 	static readonly Dictionary<string, string> mediaTypeMappings = new(StringComparer.OrdinalIgnoreCase)
 	{


### PR DESCRIPTION
  MediaTypeUtility.GetSanitizedFileNameWithExtension used
  Path.GetInvalidFileNameChars(), which is OS-dependent. On Linux it only
  returns '/' and '\0', so chars that are invalid on Windows (':', '"',
  '<', '>', '|', '*', '?', '\') passed through unchanged. Attachment
  files are frequently consumed on a different OS than they were written
  on — e.g. produced on a Linux CI runner and then uploaded as GitHub
  Actions artifacts, which rejects those same Windows-invalid chars and
  fails the upload.

  Replace the OS-dependent set with the union of invalid filename chars
  across Windows/Linux/macOS plus control chars 0-31, so sanitized
  filenames are portable regardless of the producing OS.

fixes https://github.com/VerifyTests/Verify/issues/1721