### PR TITLE
#3593 Expose MTP SessionUid via TestContext.KeyValueStorage

### DIFF
--- a/src/common/MicrosoftTestingPlatform/TestPlatformTestFramework.cs
+++ b/src/common/MicrosoftTestingPlatform/TestPlatformTestFramework.cs
@@ -164,7 +164,7 @@ public class TestPlatformTestFramework :
 				throw new ArgumentException($"Unsupported discovery filter type '{filter.GetType().SafeName()}'", nameof(filter));
 
 			var messageHandler = new TestPlatformDiscoveryMessageSink(session.MessageHandler, projectAssembly.Assembly!.FullName!, sessionUid, discoveryFilter, messageBus, cancellationToken);
-			await projectRunner.Discover(projectAssembly, pipelineStartup, messageHandler);
+			await projectRunner.Discover(projectAssembly, pipelineStartup, messageHandler, testPlatformSessionUid: sessionUid.Value);
 		}, cancellationToken);
 	}
 
@@ -208,7 +208,7 @@ public class TestPlatformTestFramework :
 			projectAssembly.Configuration.ShowLiveOutput = false;
 
 			var messageHandler = new TestPlatformExecutionMessageSink(session.MessageHandler, sessionUid, messageBus, trxCapability, outputDevice, showLiveOutput, serverMode, cancellationToken);
-			await projectRunner.Run(projectAssembly, messageHandler, diagnosticMessageSink, runnerLogger, pipelineStartup, testCaseIDsToRun);
+			await projectRunner.Run(projectAssembly, messageHandler, diagnosticMessageSink, runnerLogger, pipelineStartup, testCaseIDsToRun, sessionUid.Value);
 
 			foreach (var output in projectAssembly.Project.Configuration.Output)
 				await messageBus.PublishAsync(this, new SessionFileArtifact(sessionUid, new FileInfo(output.Value), Path.GetFileNameWithoutExtension(output.Value)));

--- a/src/xunit.v3.core.tests/TestContextTests.cs
+++ b/src/xunit.v3.core.tests/TestContextTests.cs
@@ -48,6 +48,26 @@ public sealed class TestContextTests : IClassFixture<TestContextTests.MyClassFix
 		TestContext.Current.KeyValueStorage["testValue"] = 2600;
 	}
 
+	// Run on a separate execution context so the replaced ambient context doesn't leak into
+	// the cleanup of the test that's currently running.
+	[Fact]
+	public static Task TestPlatformSessionUidIsStoredInKeyValueStorageWhenProvided() =>
+		Task.Run(() =>
+		{
+			TestContext.SetForInitialization(diagnosticMessageSink: null, diagnosticMessages: false, internalDiagnosticMessages: false, testPlatformSessionUid: "session-1234");
+
+			Assert.Equal("session-1234", TestContext.Current.KeyValueStorage[TestContext.KeyValueStorageMicrosoftTestingPlatformSessionUid]);
+		}, TestContext.Current.CancellationToken);
+
+	[Fact]
+	public static Task TestPlatformSessionUidIsAbsentFromKeyValueStorageWhenNotProvided() =>
+		Task.Run(() =>
+		{
+			TestContext.SetForInitialization(diagnosticMessageSink: null, diagnosticMessages: false, internalDiagnosticMessages: false);
+
+			Assert.False(TestContext.Current.KeyValueStorage.ContainsKey(TestContext.KeyValueStorageMicrosoftTestingPlatformSessionUid));
+		}, TestContext.Current.CancellationToken);
+
 	[Fact]
 	public static void CannotAccessCancellationTokenOfDisposedContext()
 	{

--- a/src/xunit.v3.core/TestContext.cs
+++ b/src/xunit.v3.core/TestContext.cs
@@ -11,6 +11,15 @@ namespace Xunit;
 /// </summary>
 public sealed class TestContext : ITestContext, IDisposable
 {
+	/// <summary>
+	/// Gets the key used to store the Microsoft.Testing.Platform session ID into <see cref="KeyValueStorage"/>.
+	/// The associated value is a <see cref="string"/> that uniquely identifies the current test run session, and
+	/// can be used (for example) to synchronize data across several test projects that are run together as part of
+	/// a single session. This value is only present when the tests are run via Microsoft.Testing.Platform; it will
+	/// not be present when running through any other runner.
+	/// </summary>
+	public const string KeyValueStorageMicrosoftTestingPlatformSessionUid = "Microsoft.Testing.Platform.SessionUid";
+
 	static readonly TestContext idleTestContext = new(null, null, null, TestPipelineStage.Unknown, default, disposable: false);
 	static readonly AsyncLocal<TestContext?> local = new();
 	static readonly HashSet<TestEngineStatus> validExecutionStatuses = [TestEngineStatus.Initializing, TestEngineStatus.Running, TestEngineStatus.CleaningUp];
@@ -313,11 +322,20 @@ public sealed class TestContext : ITestContext, IDisposable
 	/// and <see cref="IInternalDiagnosticMessage"/> instances.</param>
 	/// <param name="diagnosticMessages">A flag to indicate whether the user wants to receive diagnostic messages</param>
 	/// <param name="internalDiagnosticMessages">A flag to indicate whether the user wants to receive internal diagnostic messages</param>
+	/// <param name="testPlatformSessionUid">The optional Microsoft.Testing.Platform session ID, which (when present)
+	/// is made available via <see cref="KeyValueStorage"/> using the <see cref="KeyValueStorageMicrosoftTestingPlatformSessionUid"/> key.</param>
 	public static void SetForInitialization(
 		IMessageSink? diagnosticMessageSink,
 		bool diagnosticMessages,
-		bool internalDiagnosticMessages) =>
-			local.Value = new TestContext(diagnosticMessages ? diagnosticMessageSink : null, internalDiagnosticMessages ? diagnosticMessageSink : null, [], TestPipelineStage.Initialization, default);
+		bool internalDiagnosticMessages,
+		string? testPlatformSessionUid = null)
+	{
+		var keyValueStorage = new ConcurrentDictionary<string, object?>();
+		if (testPlatformSessionUid is not null)
+			keyValueStorage[KeyValueStorageMicrosoftTestingPlatformSessionUid] = testPlatformSessionUid;
+
+		local.Value = new TestContext(diagnosticMessages ? diagnosticMessageSink : null, internalDiagnosticMessages ? diagnosticMessageSink : null, keyValueStorage, TestPipelineStage.Initialization, default);
+	}
 
 	/// <summary>
 	/// Sets the test context for execution of a test. This assumes an existing test context already exists from which

--- a/src/xunit.v3.runner.inproc.console/Utility/ProjectAssemblyRunner.cs
+++ b/src/xunit.v3.runner.inproc.console/Utility/ProjectAssemblyRunner.cs
@@ -67,12 +67,14 @@ public sealed class ProjectAssemblyRunner(
 	/// <param name="messageSink">The optional message sink to send messages to</param>
 	/// <param name="diagnosticMessageSink">The optional message sink to send diagnostic messages to</param>
 	/// <param name="testCases">A collection to contain the test cases to run, if desired</param>
+	/// <param name="testPlatformSessionUid">The optional Microsoft.Testing.Platform session ID</param>
 	public async ValueTask Discover(
 		XunitProjectAssembly assembly,
 		ITestPipelineStartup? pipelineStartup,
 		IMessageSink? messageSink = null,
 		IMessageSink? diagnosticMessageSink = null,
-		IList<(ITestCase TestCase, bool PassedFilter)>? testCases = null)
+		IList<(ITestCase TestCase, bool PassedFilter)>? testCases = null,
+		string? testPlatformSessionUid = null)
 	{
 		Guard.ArgumentNotNull(assembly);
 
@@ -81,7 +83,7 @@ public sealed class ProjectAssemblyRunner(
 		var diagnosticMessages = assembly.Configuration.DiagnosticMessagesOrDefault;
 		var internalDiagnosticMessages = assembly.Configuration.InternalDiagnosticMessagesOrDefault;
 
-		TestContext.SetForInitialization(diagnosticMessageSink, diagnosticMessages, internalDiagnosticMessages);
+		TestContext.SetForInitialization(diagnosticMessageSink, diagnosticMessages, internalDiagnosticMessages, testPlatformSessionUid);
 
 		await using var disposalTracker = new DisposalTracker();
 		var testFramework = ExtensibilityPointFactory.GetTestFramework(testAssembly);
@@ -185,6 +187,7 @@ public sealed class ProjectAssemblyRunner(
 	/// <param name="runnerLogger">The runner logger, to log console output to</param>
 	/// <param name="pipelineStartup">The pipeline startup object</param>
 	/// <param name="testCaseIDsToRun">An optional list of test case unique IDs to run</param>
+	/// <param name="testPlatformSessionUid">The optional Microsoft.Testing.Platform session ID</param>
 	/// <returns>Returns <c>0</c> if there were no failures; non-<c>zero</c> failure count, otherwise</returns>
 	public async ValueTask<int> Run(
 		XunitProjectAssembly assembly,
@@ -192,7 +195,8 @@ public sealed class ProjectAssemblyRunner(
 		IMessageSink? diagnosticMessageSink,
 		IRunnerLogger runnerLogger,
 		ITestPipelineStartup? pipelineStartup,
-		HashSet<string>? testCaseIDsToRun = null)
+		HashSet<string>? testCaseIDsToRun = null,
+		string? testPlatformSessionUid = null)
 	{
 		Guard.ArgumentNotNull(assembly);
 		Guard.ArgumentNotNull(messageSink);
@@ -218,7 +222,7 @@ public sealed class ProjectAssemblyRunner(
 			var internalDiagnosticMessages = assembly.Configuration.InternalDiagnosticMessagesOrDefault;
 			var longRunningSeconds = assembly.Configuration.LongRunningTestSecondsOrDefault;
 
-			TestContext.SetForInitialization(diagnosticMessageSink, diagnosticMessages, internalDiagnosticMessages);
+			TestContext.SetForInitialization(diagnosticMessageSink, diagnosticMessages, internalDiagnosticMessages, testPlatformSessionUid);
 
 			try
 			{


### PR DESCRIPTION
Adds a well-known key (TestContext.KeyValueStorageMicrosoftTestingPlatformSessionUid) under which the Microsoft.Testing.Platform session ID is stored in TestContext.Current.KeyValueStorage when tests are run via MTP. This lets multiple test projects in a single run session correlate/share data. The value is absent when not running under MTP.

Before you submit a PR...

* Did you ensure this is an accepted ['help wanted' issue](
  https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
* Did you read the project governance @ https://xunit.net/governance ?
* Does the code follow existing coding styles? (tabs, comments, no regions, etc.)
* Did you write unit tests?
