### PR TITLE
fix: restore missing ? in PR template help-wanted link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Before you submit a PR...
 
 * Did you ensure this is an accepted ['help wanted' issue](
-  https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
+  https://github.com/xunit/xunit/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)?
 * Did you read the project governance @ https://xunit.net/governance ?
 * Does the code follow existing coding styles? (tabs, comments, no regions, etc.)
 * Did you write unit tests?


### PR DESCRIPTION
## Problem
`.github/PULL_REQUEST_TEMPLATE.md` links to

`https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22`

The `?` before `q=` is missing, so GitHub resolves the path as a literal page:

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  "https://github.com/xunit/xunit/issuesq=is%3Aopen+is%3Aissue+label%3A%22help%20wanted%22"
# 404
```

Contributors clicking it get a 404 instead of the filtered help-wanted issue list.

## Solution
Restore the query separator: `issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22`

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  "https://github.com/xunit/xunit/issues?q=is%3Aopen+is%3Aissue+label%3A%22help%20wanted%22"
# 200
```

## Verification
Markdown-only change to the PR template.
