### PR TITLE
Disable colors for the TeamCity reporter

### DIFF
--- a/src/xunit.v3.runner.common/Parsers/CommandLineParserBase.cs
+++ b/src/xunit.v3.runner.common/Parsers/CommandLineParserBase.cs
@@ -938,6 +938,9 @@ public abstract class CommandLineParserBase
 				RunnerReporters.FirstOrDefault(r => "default".Equals(r.RunnerSwitch, StringComparison.OrdinalIgnoreCase))
 					?? new DefaultRunnerReporter();
 
+		if (Project.Configuration.NoColor is null && Project.RunnerReporter is TeamCityReporter)
+			Project.Configuration.NoColor = true;
+
 		return Project;
 	}
 

--- a/src/xunit.v3.runner.console.tests/CommandLineTests.cs
+++ b/src/xunit.v3.runner.console.tests/CommandLineTests.cs
@@ -1050,6 +1050,20 @@ public static class CommandLineTests
 
 			Assert.Same(implicitReporter1, project.RunnerReporter);
 		}
+
+		[Fact]
+		public void EnvironmentallyEnabledTeamCityReporter_DisablesColor()
+		{
+			using var _ = EnvironmentHelper.RestoreEnvironment(TestProjectConfiguration.EnvNameNoColor);
+			Environment.SetEnvironmentVariable(TestProjectConfiguration.EnvNameNoColor, null);
+			Environment.SetEnvironmentVariable("TEAMCITY_PROJECT_NAME", "project");
+			var commandLine = new TestableCommandLine([new TeamCityReporter()], CommandLineTestsLocation, "no-config.json");
+
+			var project = commandLine.Parse();
+
+			Assert.IsType<TeamCityReporter>(project.RunnerReporter);
+			Assert.True(project.Configuration.NoColorOrDefault);
+		}
 	}
 
 	class TestableCommandLine : CommandLine

--- a/src/xunit.v3.runner.inproc.console.tests/CommandLineTests.cs
+++ b/src/xunit.v3.runner.inproc.console.tests/CommandLineTests.cs
@@ -901,6 +901,20 @@ public static class CommandLineTests
 
 			Assert.Same(implicitReporter1, assembly.Project.RunnerReporter);
 		}
+
+		[Fact]
+		public void EnvironmentallyEnabledTeamCityReporter_DisablesColor()
+		{
+			using var _ = EnvironmentHelper.RestoreEnvironment(TestProjectConfiguration.EnvNameNoColor);
+			Environment.SetEnvironmentVariable(TestProjectConfiguration.EnvNameNoColor, null);
+			Environment.SetEnvironmentVariable("TEAMCITY_PROJECT_NAME", "project");
+			var commandLine = new TestableCommandLine([new TeamCityReporter()], "no-config.json");
+
+			var assembly = commandLine.Parse();
+
+			Assert.IsType<TeamCityReporter>(assembly.Project.RunnerReporter);
+			Assert.True(assembly.Project.Configuration.NoColorOrDefault);
+		}
 	}
 
 	class TestableCommandLine : CommandLine


### PR DESCRIPTION
Fixes #1438.

TeamCity reads stdout as service messages, so ANSI color and reset sequences just turn into noise in the build log. We already know when the TeamCity reporter has been selected; this makes no-color the default at that point for the current v3 runners.

This only fills the value when it hasn't been configured, so an explicit `NoColor = false` still wins.

I added the same regression case to both command-line implementations and ran their complete test assemblies locally:

- in-process console: 248 passed
- standalone console: 278 passed

`dotnet format whitespace --verify-no-changes` and `git diff --check` are also clean.
